### PR TITLE
feat(base): добавить метод ensureDirectoryExists для проверки и создания директорий

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 1C Platform Tools
 
-[![OpenYellow](https://openyellow.openintegrations.dev/data/badges/1113279075.svg)](https://openyellow.org/grid?filter=top&repo=1113279075)
+<!-- [![OpenYellow](https://openyellow.openintegrations.dev/data/badges/1113279075.svg)](https://openyellow.org/grid?filter=top&repo=1113279075) -->
 
 Расширение для Visual Studio Code с инструментами разработки для экосистемы 1С. Предоставляет удобный интерфейс для работы с проектами 1С через панель команд и дерево задач.
 

--- a/src/commands/baseCommand.ts
+++ b/src/commands/baseCommand.ts
@@ -90,4 +90,21 @@ export abstract class BaseCommand {
 			return [];
 		}
 	}
+
+	/**
+	 * Создает директорию, если она не существует
+	 * @param dirPath - Путь к директории
+	 * @param errorMessage - Сообщение об ошибке при создании
+	 * @returns Промис, который разрешается true, если директория существует или была создана, иначе false
+	 */
+	protected async ensureDirectoryExists(dirPath: string, errorMessage?: string): Promise<boolean> {
+		try {
+			await fs.mkdir(dirPath, { recursive: true });
+			return true;
+		} catch (error) {
+			const message = errorMessage || `Ошибка при создании папки ${dirPath}: ${(error as Error).message}`;
+			vscode.window.showErrorMessage(message);
+			return false;
+		}
+	}
 }

--- a/src/commands/configurationCommands.ts
+++ b/src/commands/configurationCommands.ts
@@ -101,6 +101,11 @@ export class ConfigurationCommands extends BaseCommand {
 		}
 
 		const buildPath = this.vrunner.getBuildPath();
+		const buildFullPath = path.join(workspaceRoot, buildPath);
+		if (!(await this.ensureDirectoryExists(buildFullPath, `Ошибка при создании папки ${buildPath}`))) {
+			return;
+		}
+
 		const outputPath = path.join(buildPath, '1Cv8.cf');
 		const ibConnectionParam = await this.vrunner.getIbConnectionParam();
 		const args = ['unload', outputPath, ...ibConnectionParam];
@@ -126,6 +131,11 @@ export class ConfigurationCommands extends BaseCommand {
 		}
 
 		const buildPath = this.vrunner.getBuildPath();
+		const buildFullPath = path.join(workspaceRoot, buildPath);
+		if (!(await this.ensureDirectoryExists(buildFullPath, `Ошибка при создании папки ${buildPath}`))) {
+			return;
+		}
+
 		const outputPath = path.join(buildPath, '1Cv8dist.cf');
 		const args = ['make-dist', outputPath];
 		const commandName = getDumpConfigurationToDistCommandName();
@@ -148,6 +158,11 @@ export class ConfigurationCommands extends BaseCommand {
 
 		const srcPath = this.vrunner.getSrcPath();
 		const buildPath = this.vrunner.getBuildPath();
+		const buildFullPath = path.join(workspaceRoot, buildPath);
+		if (!(await this.ensureDirectoryExists(buildFullPath, `Ошибка при создании папки ${buildPath}`))) {
+			return;
+		}
+
 		const outputPath = path.join(buildPath, '1Cv8.cf');
 		const args = ['compile', '--src', srcPath, '--out', outputPath];
 		if (this.vrunner.getUseIbcmd()) {

--- a/src/commands/extensionsCommands.ts
+++ b/src/commands/extensionsCommands.ts
@@ -203,6 +203,11 @@ export class ExtensionsCommands extends BaseCommand {
 		}
 
 		const buildPath = this.vrunner.getBuildPath();
+		const cfeBuildPath = path.join(workspaceRoot, buildPath, 'cfe');
+		if (!(await this.ensureDirectoryExists(cfeBuildPath, `Ошибка при создании папки ${buildPath}/cfe`))) {
+			return;
+		}
+
 		const ibConnectionParam = await this.vrunner.getIbConnectionParam();
 		const commandName = getDumpExtensionToCfeCommandName();
 		const vrunnerPath = this.vrunner.getVRunnerPath();
@@ -242,6 +247,11 @@ export class ExtensionsCommands extends BaseCommand {
 		}
 
 		const buildPath = this.vrunner.getBuildPath();
+		const cfeBuildPath = path.join(workspaceRoot, buildPath, 'cfe');
+		if (!(await this.ensureDirectoryExists(cfeBuildPath, `Ошибка при создании папки ${buildPath}/cfe`))) {
+			return;
+		}
+
 		const commandName = getBuildExtensionCommandName();
 		const vrunnerPath = this.vrunner.getVRunnerPath();
 		const shellType = detectShellType();

--- a/src/commands/externalFilesCommands.ts
+++ b/src/commands/externalFilesCommands.ts
@@ -39,12 +39,18 @@ export class ExternalFilesCommands extends BaseCommand {
 
 		const ibConnectionParam = await this.vrunner.getIbConnectionParam();
 		const buildPath = this.vrunner.getBuildPath();
+		const outputFolder = fileType === 'processor' ? 'epf' : 'erf';
+		const outputFullPath = path.join(workspaceRoot, buildPath, outputFolder);
+		if (!(await this.ensureDirectoryExists(outputFullPath, `Ошибка при создании папки ${buildPath}/${outputFolder}`))) {
+			return;
+		}
+
 		const commandName = fileType === 'processor' 
 			? getBuildExternalProcessorCommandName()
 			: getBuildExternalReportCommandName();
 		const vrunnerCommand = 'compileepf';
 		const inputPath = srcFolder;
-		const outputPath = path.join(buildPath, fileType === 'processor' ? 'epf' : 'erf');
+		const outputPath = path.join(buildPath, outputFolder);
 		const args = [vrunnerCommand, inputPath, outputPath, ...ibConnectionParam];
 
 		this.vrunner.executeVRunnerInTerminal(args, {


### PR DESCRIPTION
Closes #16 

- Реализован метод ensureDirectoryExists в классе BaseCommand для создания директории, если она не существует.
- Обновлены команды в configurationCommands, extensionsCommands и externalFilesCommands для использования нового метода при создании необходимых директорий перед выполнением операций.