### PR TITLE
feat(oscript): добавлены команды для работы с задачами oscript

### DIFF
--- a/package.json
+++ b/package.json
@@ -313,6 +313,16 @@
         "category": "1C"
       },
       {
+        "command": "1c-platform-tools.oscript.run",
+        "title": "Запустить задачу oscript (opm run)",
+        "category": "1C"
+      },
+      {
+        "command": "1c-platform-tools.oscript.addTask",
+        "title": "Добавить задачу oscript",
+        "category": "1C"
+      },
+      {
         "command": "1c-platform-tools.launch.edit",
         "title": "Редактировать задачи",
         "category": "1C"

--- a/src/commands/oscriptTasksCommands.ts
+++ b/src/commands/oscriptTasksCommands.ts
@@ -1,0 +1,158 @@
+import * as vscode from 'vscode';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import { BaseCommand } from './baseCommand';
+
+/**
+ * Результат получения списка задач oscript из каталога tasks
+ */
+export interface OscriptTask {
+	/** Имя задачи (имя файла без расширения .os) */
+	name: string;
+}
+
+/** Содержимое по умолчанию для нового файла задачи oscript */
+const DEFAULT_TASK_CONTENT = '//Вставить содержимое скрипта ';
+
+/**
+ * Команды для работы с задачами oscript из каталога tasks в корне проекта
+ */
+export class OscriptTasksCommands extends BaseCommand {
+	private static readonly TASKS_DIR = 'tasks';
+	private static readonly OS_EXTENSION = '.os';
+
+	/**
+	 * Получает список задач oscript из каталога tasks
+	 *
+	 * Читает каталог tasks в корне workspace и возвращает имена файлов *.os
+	 * без расширения (для выполнения через opm run &lt;имя&gt;).
+	 *
+	 * @returns Промис, который разрешается массивом задач.
+	 *          Возвращает пустой массив, если workspace не открыт, каталог tasks
+	 *          не существует или не содержит файлов *.os
+	 */
+	async getOscriptTasks(): Promise<OscriptTask[]> {
+		const workspaceRoot = this.vrunner.getWorkspaceRoot();
+		if (!workspaceRoot) {
+			return [];
+		}
+
+		const tasksPath = path.join(workspaceRoot, OscriptTasksCommands.TASKS_DIR);
+		try {
+			const entries = await fs.readdir(tasksPath, { withFileTypes: true });
+			const files = entries
+				.filter(
+					entry =>
+						entry.isFile() &&
+						entry.name.toLowerCase().endsWith(OscriptTasksCommands.OS_EXTENSION)
+				)
+				.map(entry => path.basename(entry.name, OscriptTasksCommands.OS_EXTENSION))
+				.map(name => ({ name }));
+			return files;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+				return [];
+			}
+			throw error;
+		}
+	}
+
+	/**
+	 * Запускает задачу oscript через opm run
+	 *
+	 * Выполняет команду opm run &lt;имя&gt; в терминале VS Code.
+	 * Если taskName не передан (вызов из палитры команд), показывает выбор задачи из списка.
+	 *
+	 * @param taskName - Имя задачи (имя файла без .os). Опционально при вызове из палитры
+	 * @returns Промис, который разрешается после запуска команды в терминале или отмены выбора
+	 */
+	async runOscriptTask(taskName?: string): Promise<void> {
+		if (!this.ensureWorkspace()) {
+			return;
+		}
+
+		let nameToRun = taskName;
+		if (nameToRun === undefined) {
+			const tasks = await this.getOscriptTasks();
+			if (tasks.length === 0) {
+				vscode.window.showWarningMessage('Нет задач oscript в каталоге tasks');
+				return;
+			}
+			const chosen = await vscode.window.showQuickPick(
+				tasks.map(t => ({ label: t.name, description: `opm run ${t.name}` })),
+				{ placeHolder: 'Выберите задачу oscript для запуска' }
+			);
+			if (!chosen) {
+				return;
+			}
+			nameToRun = chosen.label;
+		}
+
+		this.vrunner.executeOpmInTerminal(['run', nameToRun], {
+			name: `opm run ${nameToRun}`,
+		});
+	}
+
+	/**
+	 * Добавляет новую задачу oscript
+	 *
+	 * Показывает диалог ввода имени файла, создаёт каталог tasks в корне проекта
+	 * (если его нет), создаёт в нём файл с введённым именем в формате *.os
+	 * и содержимым по умолчанию.
+	 *
+	 * @returns Промис, который разрешается после создания файла или отмены ввода
+	 */
+	async addOscriptTask(): Promise<void> {
+		if (!this.ensureWorkspace()) {
+			return;
+		}
+
+		const workspaceRoot = this.vrunner.getWorkspaceRoot();
+		if (!workspaceRoot) {
+			return;
+		}
+
+		const fileName = await vscode.window.showInputBox({
+			prompt: 'Имя файла задачи (будет создан в каталоге tasks с расширением .os)',
+			placeHolder: 'имя_задачи',
+			validateInput: (value: string) => {
+				const trimmed = value.trim();
+				if (!trimmed) {
+					return 'Введите имя файла';
+				}
+				const invalidChars = /[\\/:*?"<>|]/;
+				if (invalidChars.test(trimmed)) {
+					return String.raw`Имя файла не должно содержать символы \ / : * ? " < > |`;
+				}
+				return null;
+			},
+		});
+
+		if (fileName === undefined) {
+			return;
+		}
+
+		const baseName = fileName.trim();
+		const nameWithExt = baseName.toLowerCase().endsWith(OscriptTasksCommands.OS_EXTENSION)
+			? baseName
+			: `${baseName}${OscriptTasksCommands.OS_EXTENSION}`;
+
+		const tasksPath = path.join(workspaceRoot, OscriptTasksCommands.TASKS_DIR);
+		const filePath = path.join(tasksPath, nameWithExt);
+
+		try {
+			await fs.mkdir(tasksPath, { recursive: true });
+			await fs.writeFile(filePath, DEFAULT_TASK_CONTENT, 'utf8');
+
+			const uri = vscode.Uri.file(filePath);
+			const doc = await vscode.workspace.openTextDocument(uri);
+			await vscode.window.showTextDocument(doc);
+
+			vscode.window.showInformationMessage(`Создана задача oscript: ${nameWithExt}`);
+		} catch (error) {
+			vscode.window.showErrorMessage(
+				`Ошибка при создании задачи: ${(error as Error).message}`
+			);
+		}
+	}
+}

--- a/src/commands/workspaceTasksCommands.ts
+++ b/src/commands/workspaceTasksCommands.ts
@@ -34,10 +34,10 @@ export class WorkspaceTasksCommands extends BaseCommand {
 
 	/**
 	 * Получает задачи из tasks.json
-	 * 
+	 *
 	 * Загружает все задачи workspace из VS Code API и фильтрует их,
 	 * оставляя только задачи workspace (исключая глобальные задачи).
-	 * 
+	 *
 	 * @returns Промис, который разрешается массивом задач workspace.
 	 *          Возвращает пустой массив, если workspace не открыт или произошла ошибка
 	 */
@@ -51,7 +51,7 @@ export class WorkspaceTasksCommands extends BaseCommand {
 			const tasks: Task[] = [];
 			for (const vscodeTask of vscodeTasks) {
 				const isWorkspaceTask = vscodeTask.scope !== vscode.TaskScope.Global;
-				
+
 				if (isWorkspaceTask) {
 					const definition = vscodeTask.definition;
 					tasks.push({
@@ -60,7 +60,7 @@ export class WorkspaceTasksCommands extends BaseCommand {
 					});
 				}
 			}
-			
+
 			return tasks;
 		} catch {
 			return [];


### PR DESCRIPTION
Реализованы задачи oscript в панели 1C Platform Tools

Закрывает #26

Что добавлено:

Группа «Задачи (oscript)» в панели

- Располагается выше группы «Задачи (workspace)», с той же иконкой (ракета)
- Список задач формируется по файлам *.os в каталоге tasks в корне проекта
- Двойной щелчок по задаче запускает в терминале opm run <имя_файла_без_расширения>
- При отсутствии каталога tasks или файлов *.os показывается информационное сообщение в дереве

Команда «Добавить задачу»

- Статичная команда в начале списка (как в «Задачи (workspace)»)
- Диалог ввода имени файла с проверкой недопустимых символов
- Создание каталога tasks при его отсутствии
- Создание файла имя.os с содержимым по умолчанию и открытие в редакторе
- После добавления задачи дерево панели обновляется

Обновление дерева

- После добавления задачи oscript дерево обновляется автоматически
- Для «Задачи (workspace)» дерево обновляется при сохранении .vscode/tasks.json или .vscode/launch.json
