### PR TITLE
feat(set-version): добавлены команды для установки версий конфигурации, расширений и внешних файлов

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,278 +68,306 @@
       {
         "command": "1c-platform-tools.refresh",
         "title": "Обновить",
-        "icon": "$(refresh)"
+        "icon": "$(refresh)",
+        "category": "1C: Дерево"
       },
       {
         "command": "1c-platform-tools.settings",
         "title": "Настройки",
-        "icon": "$(gear)"
+        "icon": "$(gear)",
+        "category": "1C: Дерево"
       },
       {
         "command": "1c-platform-tools.infobase.createEmpty",
         "title": "Создать пустую ИБ",
-        "category": "1C"
+        "category": "1C: Информационная база"
       },
       {
         "command": "1c-platform-tools.infobase.updateDatabase",
         "title": "Постобработка обновления",
-        "category": "1C"
+        "category": "1C: Информационная база"
       },
       {
         "command": "1c-platform-tools.infobase.blockExternalResources",
         "title": "Запретить работу с внешними ресурсами",
-        "category": "1C"
+        "category": "1C: Информационная база"
       },
       {
         "command": "1c-platform-tools.infobase.initialize",
         "title": "Инициализировать данные",
-        "category": "1C"
+        "category": "1C: Информационная база"
       },
       {
         "command": "1c-platform-tools.infobase.dumpToDt",
         "title": "Выгрузить в dt",
-        "category": "1C"
+        "category": "1C: Информационная база"
       },
       {
         "command": "1c-platform-tools.infobase.loadFromDt",
         "title": "Загрузить из dt",
-        "category": "1C"
+        "category": "1C: Информационная база"
       },
       {
         "command": "1c-platform-tools.configuration.loadFromSrc",
         "title": "Загрузить конфигурацию из src/cf",
-        "category": "1C"
+        "category": "1C: Конфигурация"
       },
       {
         "command": "1c-platform-tools.configuration.loadFromSrc.init",
         "title": "Инициализировать конфигурацию из src/cf",
-        "category": "1C"
+        "category": "1C: Конфигурация"
       },
       {
         "command": "1c-platform-tools.configuration.loadIncrementFromSrc",
         "title": "Загрузить изменения (git diff)",
-        "category": "1C"
+        "category": "1C: Конфигурация"
       },
       {
         "command": "1c-platform-tools.configuration.loadFromFilesByList",
         "title": "Загрузить из objlist.txt",
-        "category": "1C"
+        "category": "1C: Конфигурация"
       },
       {
         "command": "1c-platform-tools.configuration.loadFromCf",
         "title": "Загрузить конфигурацию из 1Cv8.cf",
-        "category": "1C"
+        "category": "1C: Конфигурация"
       },
       {
         "command": "1c-platform-tools.configuration.dumpToSrc",
         "title": "Выгрузить конфигурацию в src/cf",
-        "category": "1C"
+        "category": "1C: Конфигурация"
       },
       {
         "command": "1c-platform-tools.configuration.dumpIncrementToSrc",
         "title": "Выгрузить изменения в src/cf",
-        "category": "1C"
+        "category": "1C: Конфигурация"
       },
       {
         "command": "1c-platform-tools.configuration.dumpToCf",
         "title": "Выгрузить конфигурацию в 1Cv8.cf",
-        "category": "1C"
+        "category": "1C: Конфигурация"
       },
       {
         "command": "1c-platform-tools.configuration.dumpToDist",
         "title": "Выгрузить файл поставки в 1Cv8dist.cf",
-        "category": "1C"
+        "category": "1C: Конфигурация"
       },
       {
         "command": "1c-platform-tools.configuration.build",
         "title": "Собрать 1Cv8.cf из src/cf",
-        "category": "1C"
+        "category": "1C: Конфигурация"
       },
       {
         "command": "1c-platform-tools.configuration.decompile",
         "title": "Разобрать 1Cv8.cf в src/cf",
-        "category": "1C"
+        "category": "1C: Конфигурация"
       },
       {
         "command": "1c-platform-tools.extensions.loadFromSrc",
         "title": "Загрузить расширения из src/cfe",
-        "category": "1C"
+        "category": "1C: Расширения"
       },
       {
         "command": "1c-platform-tools.extensions.loadFromCfe",
         "title": "Загрузить расширение из *.cfe",
-        "category": "1C"
+        "category": "1C: Расширения"
       },
       {
         "command": "1c-platform-tools.extensions.dumpToSrc",
         "title": "Выгрузить расширения в src/cfe",
-        "category": "1C"
+        "category": "1C: Расширения"
       },
       {
         "command": "1c-platform-tools.extensions.dumpToCfe",
         "title": "Выгрузить расширение в *.cfe",
-        "category": "1C"
+        "category": "1C: Расширения"
       },
       {
         "command": "1c-platform-tools.extensions.build",
         "title": "Собрать *.cfe из src/cfe",
-        "category": "1C"
+        "category": "1C: Расширения"
       },
       {
         "command": "1c-platform-tools.extensions.decompile",
         "title": "Разобрать *.cfe в src/cfe",
-        "category": "1C"
+        "category": "1C: Расширения"
       },
       {
         "command": "1c-platform-tools.externalProcessors.build",
         "title": "Собрать внешнюю обработку",
-        "category": "1C"
+        "category": "1C: Внешние файлы"
       },
       {
         "command": "1c-platform-tools.externalProcessors.decompile",
         "title": "Разобрать внешнюю обработку",
-        "category": "1C"
+        "category": "1C: Внешние файлы"
       },
       {
         "command": "1c-platform-tools.externalReports.build",
         "title": "Собрать внешний отчет",
-        "category": "1C"
+        "category": "1C: Внешние файлы"
       },
       {
         "command": "1c-platform-tools.externalReports.decompile",
         "title": "Разобрать внешний отчет",
-        "category": "1C"
+        "category": "1C: Внешние файлы"
       },
       {
         "command": "1c-platform-tools.externalFiles.clearCache",
         "title": "Очистить кэш",
-        "category": "1C"
+        "category": "1C: Внешние файлы"
       },
       {
         "command": "1c-platform-tools.dependencies.initializePackagedef",
         "title": "Инициализировать packagedef",
-        "category": "1C"
+        "category": "1C: Зависимости"
       },
       {
         "command": "1c-platform-tools.dependencies.install",
         "title": "Установить зависимости",
-        "category": "1C"
+        "category": "1C: Зависимости"
       },
       {
         "command": "1c-platform-tools.dependencies.remove",
         "title": "Удалить зависимости",
-        "category": "1C"
+        "category": "1C: Зависимости"
       },
       {
         "command": "1c-platform-tools.build.configuration",
         "title": "Собрать конфигурацию",
-        "category": "1C"
+        "category": "1C: Конфигурация"
       },
       {
         "command": "1c-platform-tools.build.extensions",
         "title": "Собрать расширения",
-        "category": "1C"
+        "category": "1C: Расширения"
       },
       {
         "command": "1c-platform-tools.build.externalProcessor",
         "title": "Собрать внешнюю обработку",
-        "category": "1C"
+        "category": "1C: Внешние файлы"
       },
       {
         "command": "1c-platform-tools.build.externalReport",
         "title": "Собрать внешний отчет",
-        "category": "1C"
+        "category": "1C: Внешние файлы"
       },
       {
         "command": "1c-platform-tools.decompile.configuration",
         "title": "Разобрать конфигурацию",
-        "category": "1C"
+        "category": "1C: Конфигурация"
       },
       {
         "command": "1c-platform-tools.decompile.externalProcessor",
         "title": "Разобрать внешнюю обработку",
-        "category": "1C"
+        "category": "1C: Внешние файлы"
       },
       {
         "command": "1c-platform-tools.decompile.externalReport",
         "title": "Разобрать внешний отчет",
-        "category": "1C"
+        "category": "1C: Внешние файлы"
       },
       {
         "command": "1c-platform-tools.decompile.extension",
         "title": "Разобрать расширение",
-        "category": "1C"
+        "category": "1C: Расширения"
       },
       {
         "command": "1c-platform-tools.run.enterprise",
         "title": "Запустить Предприятие",
-        "category": "1C",
+        "category": "1C: Запуск",
         "icon": "$(play)"
       },
       {
         "command": "1c-platform-tools.run.designer",
         "title": "Запустить Конфигуратор",
-        "category": "1C",
+        "category": "1C: Запуск",
         "icon": "$(tools)"
       },
       {
         "command": "1c-platform-tools.test.xunit",
         "title": "XUnit тесты",
-        "category": "1C"
+        "category": "1C: Тестирование"
       },
       {
         "command": "1c-platform-tools.test.syntaxCheck",
         "title": "Синтаксический контроль",
-        "category": "1C"
+        "category": "1C: Тестирование"
       },
       {
         "command": "1c-platform-tools.test.vanessa",
         "title": "Vanessa тесты",
-        "category": "1C"
+        "category": "1C: Тестирование"
       },
       {
         "command": "1c-platform-tools.test.allure",
         "title": "Allure отчет",
-        "category": "1C"
+        "category": "1C: Тестирование"
+      },
+      {
+        "command": "1c-platform-tools.setVersion.configuration",
+        "title": "Конфигурации",
+        "category": "1C: Установить версию"
+      },
+      {
+        "command": "1c-platform-tools.setVersion.allExtensions",
+        "title": "Все",
+        "category": "1C: Установить версию"
+      },
+      {
+        "command": "1c-platform-tools.setVersion.extension",
+        "title": "Расширения",
+        "category": "1C: Установить версию"
+      },
+      {
+        "command": "1c-platform-tools.setVersion.report",
+        "title": "Внешнего отчёта",
+        "category": "1C: Установить версию"
+      },
+      {
+        "command": "1c-platform-tools.setVersion.processor",
+        "title": "Внешней обработки",
+        "category": "1C: Установить версию"
       },
       {
         "command": "1c-platform-tools.launch.view",
         "title": "Просмотр задач (workspace)",
-        "category": "1C"
+        "category": "1C: Задачи"
       },
       {
         "command": "1c-platform-tools.launch.run",
         "title": "Запустить задачу",
-        "category": "1C"
+        "category": "1C: Задачи"
       },
       {
         "command": "1c-platform-tools.oscript.run",
         "title": "Запустить задачу oscript (opm run)",
-        "category": "1C"
+        "category": "1C: Задачи"
       },
       {
         "command": "1c-platform-tools.oscript.addTask",
         "title": "Добавить задачу oscript",
-        "category": "1C"
+        "category": "1C: Задачи"
       },
       {
         "command": "1c-platform-tools.launch.edit",
         "title": "Редактировать задачи",
-        "category": "1C"
+        "category": "1C: Задачи"
       },
       {
         "command": "1c-platform-tools.launch.editConfigurations",
         "title": "Редактировать конфигурации запуска",
-        "category": "1C"
+        "category": "1C: Конфигурации запуска"
       },
       {
         "command": "1c-platform-tools.file.open",
-        "title": "Открыть файл"
+        "title": "Открыть файл",
+        "category": "1C: Задачи"
       },
       {
         "command": "1c-platform-tools.config.env.edit",
         "title": "Редактировать env.json",
-        "category": "1C"
+        "category": "1C: Конфигурации запуска"
       }
     ],
     "menus": {

--- a/src/commandNames.ts
+++ b/src/commandNames.ts
@@ -407,3 +407,60 @@ export function getBuildExtensionCommandName(): CommandNameAndTitle {
 		title: 'Собрать расширение'
 	};
 }
+
+// ============================================================================
+// Команды релиза (установка версий)
+// ============================================================================
+
+/**
+ * Получить название и заголовок для команды установки версии конфигурации
+ */
+export function getSetVersionConfigurationCommandName(): CommandNameAndTitle {
+	return {
+		name: 'Конфигурации',
+		title: 'Конфигурации'
+	};
+}
+
+/**
+ * Получить название и заголовок для команды установки версии всем расширениям
+ */
+export function getSetVersionAllExtensionsCommandName(): CommandNameAndTitle {
+	return {
+		name: 'Все',
+		title: 'Все'
+	};
+}
+
+/**
+ * Получить название и заголовок для команды установки версии расширению
+ * @param extensionName - Имя расширения для отображения
+ */
+export function getSetVersionExtensionCommandName(extensionName: string): CommandNameAndTitle {
+	return {
+		name: extensionName,
+		title: extensionName
+	};
+}
+
+/**
+ * Получить название и заголовок для команды установки версии внешнему отчёту
+ * @param reportName - Имя отчёта для отображения
+ */
+export function getSetVersionReportCommandName(reportName: string): CommandNameAndTitle {
+	return {
+		name: reportName,
+		title: reportName
+	};
+}
+
+/**
+ * Получить название и заголовок для команды установки версии внешней обработке
+ * @param processorName - Имя обработки для отображения
+ */
+export function getSetVersionProcessorCommandName(processorName: string): CommandNameAndTitle {
+	return {
+		name: processorName,
+		title: processorName
+	};
+}

--- a/src/commands/commandRegistry.ts
+++ b/src/commands/commandRegistry.ts
@@ -7,6 +7,7 @@ import { ExternalFilesCommands } from './externalFilesCommands';
 import { DependenciesCommands } from './dependenciesCommands';
 import { RunCommands } from './runCommands';
 import { TestCommands } from './testCommands';
+import { SetVersionCommands } from './setVersionCommands';
 import { WorkspaceTasksCommands } from './workspaceTasksCommands';
 import { VRunnerManager } from '../vrunnerManager';
 
@@ -21,6 +22,7 @@ interface Commands {
 	dependencies: DependenciesCommands;
 	run: RunCommands;
 	test: TestCommands;
+	setVersion: SetVersionCommands;
 	workspaceTasks: WorkspaceTasksCommands;
 }
 
@@ -173,6 +175,25 @@ export function registerCommands(context: vscode.ExtensionContext, commands: Com
 		})
 	];
 
+	// Команды установки версий
+	const setVersionCommands = [
+		vscode.commands.registerCommand('1c-platform-tools.setVersion.configuration', () => {
+			commands.setVersion.setVersionConfiguration();
+		}),
+		vscode.commands.registerCommand('1c-platform-tools.setVersion.allExtensions', () => {
+			commands.setVersion.setVersionAllExtensions();
+		}),
+		vscode.commands.registerCommand('1c-platform-tools.setVersion.extension', (extensionName: string) => {
+			commands.setVersion.setVersionExtension(extensionName);
+		}),
+		vscode.commands.registerCommand('1c-platform-tools.setVersion.report', (reportName: string) => {
+			commands.setVersion.setVersionReport(reportName);
+		}),
+		vscode.commands.registerCommand('1c-platform-tools.setVersion.processor', (processorName: string) => {
+			commands.setVersion.setVersionProcessor(processorName);
+		})
+	];
+
 	// Команды сборки и разбора (алиасы)
 	const buildDecompileCommands = [
 		vscode.commands.registerCommand('1c-platform-tools.build.configuration', () => {
@@ -222,6 +243,7 @@ export function registerCommands(context: vscode.ExtensionContext, commands: Com
 		...dependenciesCommands,
 		...runCommands,
 		...testCommands,
+		...setVersionCommands,
 		...buildDecompileCommands,
 		envEditCommand
 	);

--- a/src/commands/setVersionCommands.ts
+++ b/src/commands/setVersionCommands.ts
@@ -1,0 +1,288 @@
+import * as vscode from 'vscode';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import { BaseCommand } from './baseCommand';
+import {
+	getSetVersionConfigurationCommandName,
+	getSetVersionAllExtensionsCommandName,
+	getSetVersionExtensionCommandName,
+	getSetVersionReportCommandName,
+	getSetVersionProcessorCommandName
+} from '../commandNames';
+
+/**
+ * Команды для установки версий исходного кода конфигурации, расширений и внешних файлов
+ *
+ * Использует vrunner set-version для обновления версии в метаданных.
+ */
+export class SetVersionCommands extends BaseCommand {
+
+	/**
+	 * Запрашивает у пользователя новую версию
+	 * @param placeHolder - Подсказка для поля ввода (например, "1.0.0")
+	 * @returns Промис, который разрешается введённой версией или undefined при отмене
+	 */
+	private async askNewVersion(placeHolder: string): Promise<string | undefined> {
+		const version = await vscode.window.showInputBox({
+			prompt: 'Введите новую версию',
+			placeHolder,
+			validateInput: (value) => {
+				if (!value || value.trim().length === 0) {
+					return 'Введите версию';
+				}
+				return undefined;
+			}
+		});
+		return version?.trim();
+	}
+
+	/**
+	 * Устанавливает версию конфигурации (src/cf)
+	 * Выполняет: vrunner set-version --src src/cf --new-version &lt;версия&gt;
+	 * @returns Промис, который разрешается после запуска команды
+	 */
+	async setVersionConfiguration(): Promise<void> {
+		const workspaceRoot = this.ensureWorkspace();
+		if (!workspaceRoot) {
+			return;
+		}
+
+		const version = await this.askNewVersion('1.0.0');
+		if (!version) {
+			return;
+		}
+
+		const cfPath = this.vrunner.getCfPath();
+		const args = ['set-version', '--src', cfPath, '--new-version', version];
+		const commandName = getSetVersionConfigurationCommandName();
+
+		await this.vrunner.executeVRunnerInTerminal(args, {
+			cwd: workspaceRoot,
+			name: commandName.title
+		});
+	}
+
+	/**
+	 * Устанавливает версию всем расширениям (src/cfe)
+	 * Выполняет: vrunner set-version --src src/cfe --new-version &lt;версия&gt;
+	 * @returns Промис, который разрешается после запуска команды
+	 */
+	async setVersionAllExtensions(): Promise<void> {
+		const workspaceRoot = this.ensureWorkspace();
+		if (!workspaceRoot) {
+			return;
+		}
+
+		const version = await this.askNewVersion('1.0.0');
+		if (!version) {
+			return;
+		}
+
+		const cfePath = this.vrunner.getCfePath();
+		const args = ['set-version', '--src', cfePath, '--new-version', version];
+		const commandName = getSetVersionAllExtensionsCommandName();
+
+		await this.vrunner.executeVRunnerInTerminal(args, {
+			cwd: workspaceRoot,
+			name: commandName.title
+		});
+	}
+
+	/**
+	 * Устанавливает версию указанному расширению.
+	 * При вызове из палитры команд без аргумента показывает список расширений для выбора.
+	 * Выполняет: vrunner set-version --src src/cfe/&lt;имя&gt; --new-version &lt;версия&gt;
+	 * @param extensionName - Имя каталога расширения в src/cfe (если не указано — показывается выбор из списка)
+	 * @returns Промис, который разрешается после запуска команды
+	 */
+	async setVersionExtension(extensionName?: string): Promise<void> {
+		const workspaceRoot = this.ensureWorkspace();
+		if (!workspaceRoot) {
+			return;
+		}
+
+		let selected = extensionName;
+		if (selected === undefined) {
+			const extensions = await this.getExtensionFoldersForTree();
+			if (extensions.length === 0) {
+				vscode.window.showInformationMessage('В папке src/cfe не найдено расширений');
+				return;
+			}
+			const picked = await vscode.window.showQuickPick(extensions, {
+				placeHolder: 'Выберите расширение',
+				title: 'Расширения'
+			});
+			if (picked === undefined) {
+				return;
+			}
+			selected = picked;
+		}
+
+		const version = await this.askNewVersion('1.0.0');
+		if (!version) {
+			return;
+		}
+
+		const cfePath = this.vrunner.getCfePath();
+		const srcPath = path.join(cfePath, selected);
+		const args = ['set-version', '--src', srcPath, '--new-version', version];
+		const commandName = getSetVersionExtensionCommandName(selected);
+
+		await this.vrunner.executeVRunnerInTerminal(args, {
+			cwd: workspaceRoot,
+			name: commandName.title
+		});
+	}
+
+	/**
+	 * Устанавливает версию внешнему отчёту.
+	 * При вызове из палитры команд без аргумента показывает список отчётов для выбора.
+	 * Выполняет: vrunner set-version --src src/erf/&lt;имя&gt; --check-module --new-version &lt;версия&gt;
+	 * @param reportName - Имя каталога отчёта в src/erf (если не указано — показывается выбор из списка)
+	 * @returns Промис, который разрешается после запуска команды
+	 */
+	async setVersionReport(reportName?: string): Promise<void> {
+		const workspaceRoot = this.ensureWorkspace();
+		if (!workspaceRoot) {
+			return;
+		}
+
+		let selected = reportName;
+		if (selected === undefined) {
+			const reports = await this.getReportFoldersForTree();
+			if (reports.length === 0) {
+				vscode.window.showInformationMessage('В папке src/erf не найдено внешних отчётов');
+				return;
+			}
+			const picked = await vscode.window.showQuickPick(reports, {
+				placeHolder: 'Выберите внешний отчёт',
+				title: 'Внешнего отчёта'
+			});
+			if (picked === undefined) {
+				return;
+			}
+			selected = picked;
+		}
+
+		const version = await this.askNewVersion('1.0.0');
+		if (!version) {
+			return;
+		}
+
+		const erfPath = this.vrunner.getErfPath();
+		const srcPath = path.join(erfPath, selected);
+		const args = ['set-version', '--src', srcPath, '--check-module', '--new-version', version];
+		const commandName = getSetVersionReportCommandName(selected);
+
+		await this.vrunner.executeVRunnerInTerminal(args, {
+			cwd: workspaceRoot,
+			name: commandName.title
+		});
+	}
+
+	/**
+	 * Устанавливает версию внешней обработке.
+	 * При вызове из палитры команд без аргумента показывает список обработок для выбора.
+	 * Выполняет: vrunner set-version --src src/epf/&lt;имя&gt; --check-module --new-version &lt;версия&gt;
+	 * @param processorName - Имя каталога обработки в src/epf (если не указано — показывается выбор из списка)
+	 * @returns Промис, который разрешается после запуска команды
+	 */
+	async setVersionProcessor(processorName?: string): Promise<void> {
+		const workspaceRoot = this.ensureWorkspace();
+		if (!workspaceRoot) {
+			return;
+		}
+
+		let selected = processorName;
+		if (selected === undefined) {
+			const processors = await this.getProcessorFoldersForTree();
+			if (processors.length === 0) {
+				vscode.window.showInformationMessage('В папке src/epf не найдено внешних обработок');
+				return;
+			}
+			const picked = await vscode.window.showQuickPick(processors, {
+				placeHolder: 'Выберите внешнюю обработку',
+				title: 'Внешней обработки'
+			});
+			if (picked === undefined) {
+				return;
+			}
+			selected = picked;
+		}
+
+		const version = await this.askNewVersion('1.0.0');
+		if (!version) {
+			return;
+		}
+
+		const epfPath = this.vrunner.getEpfPath();
+		const srcPath = path.join(epfPath, selected);
+		const args = ['set-version', '--src', srcPath, '--check-module', '--new-version', version];
+		const commandName = getSetVersionProcessorCommandName(selected);
+
+		await this.vrunner.executeVRunnerInTerminal(args, {
+			cwd: workspaceRoot,
+			name: commandName.title
+		});
+	}
+
+	/**
+	 * Возвращает список имён каталогов расширений в src/cfe (для дерева команд).
+	 * При отсутствии каталога или ошибке чтения возвращает пустой массив без уведомления пользователя.
+	 * @returns Промис, который разрешается массивом имён каталогов
+	 */
+	async getExtensionFoldersForTree(): Promise<string[]> {
+		const workspaceRoot = this.vrunner.getWorkspaceRoot();
+		if (!workspaceRoot) {
+			return [];
+		}
+		const cfePath = this.vrunner.getCfePath();
+		const fullPath = path.join(workspaceRoot, cfePath);
+		try {
+			const entries = await fs.readdir(fullPath, { withFileTypes: true });
+			return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+		} catch {
+			return [];
+		}
+	}
+
+	/**
+	 * Возвращает список имён каталогов внешних отчётов в src/erf (для дерева команд).
+	 * При отсутствии каталога или ошибке чтения возвращает пустой массив без уведомления пользователя.
+	 * @returns Промис, который разрешается массивом имён каталогов
+	 */
+	async getReportFoldersForTree(): Promise<string[]> {
+		const workspaceRoot = this.vrunner.getWorkspaceRoot();
+		if (!workspaceRoot) {
+			return [];
+		}
+		const erfPath = this.vrunner.getErfPath();
+		const fullPath = path.join(workspaceRoot, erfPath);
+		try {
+			const entries = await fs.readdir(fullPath, { withFileTypes: true });
+			return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+		} catch {
+			return [];
+		}
+	}
+
+	/**
+	 * Возвращает список имён каталогов внешних обработок в src/epf (для дерева команд).
+	 * При отсутствии каталога или ошибке чтения возвращает пустой массив без уведомления пользователя.
+	 * @returns Промис, который разрешается массивом имён каталогов
+	 */
+	async getProcessorFoldersForTree(): Promise<string[]> {
+		const workspaceRoot = this.vrunner.getWorkspaceRoot();
+		if (!workspaceRoot) {
+			return [];
+		}
+		const epfPath = this.vrunner.getEpfPath();
+		const fullPath = path.join(workspaceRoot, epfPath);
+		try {
+			const entries = await fs.readdir(fullPath, { withFileTypes: true });
+			return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+		} catch {
+			return [];
+		}
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { ExternalFilesCommands } from './commands/externalFilesCommands';
 import { DependenciesCommands } from './commands/dependenciesCommands';
 import { RunCommands } from './commands/runCommands';
 import { TestCommands } from './commands/testCommands';
+import { SetVersionCommands } from './commands/setVersionCommands';
 import { WorkspaceTasksCommands } from './commands/workspaceTasksCommands';
 import { OscriptTasksCommands } from './commands/oscriptTasksCommands';
 import { registerCommands } from './commands/commandRegistry';
@@ -63,13 +64,14 @@ export async function activate(context: vscode.ExtensionContext) {
 		dependencies: new DependenciesCommands(),
 		run: new RunCommands(),
 		test: new TestCommands(),
+		setVersion: new SetVersionCommands(),
 		oscriptTasks: new OscriptTasksCommands(),
 		workspaceTasks: new WorkspaceTasksCommands(),
 	};
 
 	const commandDisposables = registerCommands(context, commands);
 
-	const treeDataProvider = new PlatformTreeDataProvider(context.extensionUri);
+	const treeDataProvider = new PlatformTreeDataProvider(context.extensionUri, commands.setVersion);
 
 	const treeView = vscode.window.createTreeView('1c-platform-tools', {
 		treeDataProvider: treeDataProvider,

--- a/src/treeViewProvider.ts
+++ b/src/treeViewProvider.ts
@@ -37,8 +37,14 @@ import {
 	getXUnitTestsCommandName,
 	getSyntaxCheckCommandName,
 	getVanessaTestsCommandName,
-	getAllureReportCommandName
+	getAllureReportCommandName,
+	getSetVersionConfigurationCommandName,
+	getSetVersionAllExtensionsCommandName,
+	getSetVersionExtensionCommandName,
+	getSetVersionReportCommandName,
+	getSetVersionProcessorCommandName
 } from './commandNames';
+import type { SetVersionCommands } from './commands/setVersionCommands';
 
 /**
  * Типы элементов дерева команд в панели 1C Platform Tools
@@ -60,6 +66,10 @@ export enum TreeItemType {
 	Configuration = 'configuration',
 	Extension = 'extension',
 	ExternalFile = 'externalFile',
+	SetVersion = 'setVersion',
+	SetVersionExtensionsFolder = 'setVersionExtensionsFolder',
+	SetVersionReportsFolder = 'setVersionReportsFolder',
+	SetVersionProcessorsFolder = 'setVersionProcessorsFolder',
 }
 
 /**
@@ -121,6 +131,11 @@ export class PlatformTreeItem extends vscode.TreeItem {
 				return new vscode.ThemeIcon('file-code');
 			case TreeItemType.ExternalFile:
 				return new vscode.ThemeIcon('file-code');
+			case TreeItemType.SetVersion:
+			case TreeItemType.SetVersionExtensionsFolder:
+			case TreeItemType.SetVersionReportsFolder:
+			case TreeItemType.SetVersionProcessorsFolder:
+				return new vscode.ThemeIcon('tag');
 			default:
 				return new vscode.ThemeIcon('circle-outline');
 		}
@@ -143,11 +158,13 @@ export class PlatformTreeDataProvider implements vscode.TreeDataProvider<Platfor
 
 	private readonly workspaceTasksCommands: WorkspaceTasksCommands;
 	private readonly oscriptTasksCommands: OscriptTasksCommands;
+	private readonly setVersionCommands?: SetVersionCommands;
 	private readonly extensionUri: vscode.Uri | undefined;
 
-	constructor(extensionUri?: vscode.Uri) {
+	constructor(extensionUri?: vscode.Uri, setVersionCommands?: SetVersionCommands) {
 		this.workspaceTasksCommands = new WorkspaceTasksCommands();
 		this.oscriptTasksCommands = new OscriptTasksCommands();
+		this.setVersionCommands = setVersionCommands;
 		this.extensionUri = extensionUri;
 	}
 
@@ -202,6 +219,18 @@ export class PlatformTreeDataProvider implements vscode.TreeDataProvider<Platfor
 
 		if (element.type === TreeItemType.OscriptTasks) {
 			return this.getOscriptTasks();
+		}
+
+		if (element.type === TreeItemType.SetVersionExtensionsFolder) {
+			return this.getSetVersionExtensionItems();
+		}
+
+		if (element.type === TreeItemType.SetVersionReportsFolder) {
+			return this.getSetVersionReportItems();
+		}
+
+		if (element.type === TreeItemType.SetVersionProcessorsFolder) {
+			return this.getSetVersionProcessorItems();
 		}
 
 		return Promise.resolve(element.children || []);
@@ -594,6 +623,44 @@ export class PlatformTreeDataProvider implements vscode.TreeDataProvider<Platfor
 				]
 			),
 			this.createTreeItem(
+				'Установить версию',
+				TreeItemType.SetVersion,
+				vscode.TreeItemCollapsibleState.Collapsed,
+				undefined,
+				[
+					this.createTreeItem(
+						'🏷️ Конфигурации',
+						TreeItemType.Task,
+						vscode.TreeItemCollapsibleState.None,
+						{
+							command: '1c-platform-tools.setVersion.configuration',
+							title: getSetVersionConfigurationCommandName().title,
+						}
+					),
+					this.createTreeItem(
+						'🏷️ Расширения',
+						TreeItemType.SetVersionExtensionsFolder,
+						vscode.TreeItemCollapsibleState.Collapsed,
+						undefined,
+						[]
+					),
+					this.createTreeItem(
+						'🏷️ Внешнего отчёта',
+						TreeItemType.SetVersionReportsFolder,
+						vscode.TreeItemCollapsibleState.Collapsed,
+						undefined,
+						[]
+					),
+					this.createTreeItem(
+						'🏷️ Внешней обработки',
+						TreeItemType.SetVersionProcessorsFolder,
+						vscode.TreeItemCollapsibleState.Collapsed,
+						undefined,
+						[]
+					),
+				]
+			),
+			this.createTreeItem(
 				'Задачи (oscript)',
 				TreeItemType.OscriptTasks,
 				vscode.TreeItemCollapsibleState.Collapsed,
@@ -764,5 +831,149 @@ export class PlatformTreeDataProvider implements vscode.TreeDataProvider<Platfor
 		}
 
 		return items;
+	}
+
+	/**
+	 * Получает элементы дерева «Расширения»: пункт «Все» и список каталогов в src/cfe
+	 * @returns Промис, который разрешается массивом элементов дерева
+	 */
+	private async getSetVersionExtensionItems(): Promise<PlatformTreeItem[]> {
+		if (!this.setVersionCommands) {
+			return [];
+		}
+		try {
+			const items: PlatformTreeItem[] = [
+				this.createTreeItem(
+					'Все',
+					TreeItemType.Task,
+					vscode.TreeItemCollapsibleState.None,
+					{
+						command: '1c-platform-tools.setVersion.allExtensions',
+						title: getSetVersionAllExtensionsCommandName().title,
+					}
+				)
+			];
+			const names = await this.setVersionCommands.getExtensionFoldersForTree();
+			if (names.length === 0) {
+				items.push(
+					this.createTreeItem(
+						'Нет расширений в src/cfe',
+						TreeItemType.Info,
+						vscode.TreeItemCollapsibleState.None
+					)
+				);
+			} else {
+				for (const name of names) {
+					items.push(
+						this.createTreeItem(
+							name,
+							TreeItemType.Task,
+							vscode.TreeItemCollapsibleState.None,
+							{
+								command: '1c-platform-tools.setVersion.extension',
+								title: getSetVersionExtensionCommandName(name).title,
+								arguments: [name],
+							}
+						)
+					);
+				}
+			}
+			return items;
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			return [
+				this.createTreeItem(
+					`Ошибка загрузки расширений: ${errorMessage}`,
+					TreeItemType.Info,
+					vscode.TreeItemCollapsibleState.None
+				)
+			];
+		}
+	}
+
+	/**
+	 * Получает элементы дерева «Внешнего отчёта» (каталоги в src/erf)
+	 * @returns Промис, который разрешается массивом элементов дерева
+	 */
+	private async getSetVersionReportItems(): Promise<PlatformTreeItem[]> {
+		if (!this.setVersionCommands) {
+			return [];
+		}
+		try {
+			const names = await this.setVersionCommands.getReportFoldersForTree();
+			if (names.length === 0) {
+				return [
+					this.createTreeItem(
+						'Нет отчётов в src/erf',
+						TreeItemType.Info,
+						vscode.TreeItemCollapsibleState.None
+					)
+				];
+			}
+			return names.map((name) =>
+				this.createTreeItem(
+					name,
+					TreeItemType.Task,
+					vscode.TreeItemCollapsibleState.None,
+					{
+						command: '1c-platform-tools.setVersion.report',
+						title: getSetVersionReportCommandName(name).title,
+						arguments: [name],
+					}
+				)
+			);
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			return [
+				this.createTreeItem(
+					`Ошибка загрузки отчётов: ${errorMessage}`,
+					TreeItemType.Info,
+					vscode.TreeItemCollapsibleState.None
+				)
+			];
+		}
+	}
+
+	/**
+	 * Получает элементы дерева «Внешней обработки» (каталоги в src/epf)
+	 * @returns Промис, который разрешается массивом элементов дерева
+	 */
+	private async getSetVersionProcessorItems(): Promise<PlatformTreeItem[]> {
+		if (!this.setVersionCommands) {
+			return [];
+		}
+		try {
+			const names = await this.setVersionCommands.getProcessorFoldersForTree();
+			if (names.length === 0) {
+				return [
+					this.createTreeItem(
+						'Нет обработок в src/epf',
+						TreeItemType.Info,
+						vscode.TreeItemCollapsibleState.None
+					)
+				];
+			}
+			return names.map((name) =>
+				this.createTreeItem(
+					name,
+					TreeItemType.Task,
+					vscode.TreeItemCollapsibleState.None,
+					{
+						command: '1c-platform-tools.setVersion.processor',
+						title: getSetVersionProcessorCommandName(name).title,
+						arguments: [name],
+					}
+				)
+			);
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			return [
+				this.createTreeItem(
+					`Ошибка загрузки обработок: ${errorMessage}`,
+					TreeItemType.Info,
+					vscode.TreeItemCollapsibleState.None
+				)
+			];
+		}
 	}
 }


### PR DESCRIPTION
Реализованы команды установки версии в панели 1C Platform Tools

Закрывает #23

**Что добавлено:**

**Группа «Установить версию» в панели**
- Располагается в дереве панели 1C Platform Tools (иконка — тег).
- Подпункты: «Конфигурации», «Расширения», «Внешнего отчёта», «Внешней обработки».
- **Конфигурации** — один пункт; по щелчку открывается диалог ввода версии и выполняется `vrunner set-version` для `src/cf`.
- **Расширения** — раскрываемая группа: пункт «Все» и список каталогов из `src/cfe`; при отсутствии расширений в дереве показывается информационное сообщение.
- **Внешнего отчёта** и **Внешней обработки** — раскрываемые группы со списками каталогов из `src/erf` и `src/epf`; при отсутствии каталогов показывается информационное сообщение в дереве.

**Команды установки версии**
- **Конфигурации** — диалог ввода версии, затем `vrunner set-version --src src/cf --new-version <версия>`.
- **Все** (расширения) — то же для каталога `src/cfe`.
- **Расширения** — при вызове из панели используется выбранный элемент, из палитры команд — выбор расширения из списка; затем ввод версии и `vrunner set-version` для выбранного каталога в `src/cfe`.
- **Внешнего отчёта** и **Внешней обработки** — выбор отчёта или обработки из списка (или по аргументу из дерева), ввод версии и `vrunner set-version --src <путь> --check-module --new-version <версия>` для каталогов в `src/erf` и `src/epf`.

**Категории команд в package.json**
- Для всех команд расширения заданы уточнённые категории («1C: Информационная база», «1C: Конфигурация», «1C: Установить версию» и др.) для удобной группировки в палитре команд и привязки клавиш.
