### PR TITLE
feat(dependencies): добавлена команда для обновления OPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,6 +223,11 @@
         "category": "1C: Зависимости"
       },
       {
+        "command": "1c-platform-tools.dependencies.updateOpm",
+        "title": "Обновить OPM",
+        "category": "1C: Зависимости"
+      },
+      {
         "command": "1c-platform-tools.dependencies.install",
         "title": "Установить зависимости",
         "category": "1C: Зависимости"

--- a/src/commandNames.ts
+++ b/src/commandNames.ts
@@ -119,6 +119,16 @@ export function getInitializePackagedefCommandName(): CommandNameAndTitle {
 }
 
 /**
+ * Получить название и заголовок для команды обновления OPM
+ */
+export function getUpdateOpmCommandName(): CommandNameAndTitle {
+	return {
+		name: 'Обновить OPM',
+		title: 'Обновить OPM'
+	};
+}
+
+/**
  * Получить название и заголовок для команды сборки конфигурации
  */
 export function getBuildConfigurationCommandName(): CommandNameAndTitle {

--- a/src/commands/commandRegistry.ts
+++ b/src/commands/commandRegistry.ts
@@ -146,6 +146,9 @@ export function registerCommands(context: vscode.ExtensionContext, commands: Com
 		}),
 		vscode.commands.registerCommand('1c-platform-tools.dependencies.initializePackagedef', () => {
 			commands.dependencies.initializePackagedef();
+		}),
+		vscode.commands.registerCommand('1c-platform-tools.dependencies.updateOpm', () => {
+			commands.dependencies.updateOpm();
 		})
 	];
 

--- a/src/commands/dependenciesCommands.ts
+++ b/src/commands/dependenciesCommands.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 import { BaseCommand } from './baseCommand';
-import { getInstallDependenciesCommandName } from '../commandNames';
+import { getInstallDependenciesCommandName, getUpdateOpmCommandName } from '../commandNames';
 
 /**
  * Команды для управления зависимостями проекта
@@ -61,6 +61,27 @@ export class DependenciesCommands extends BaseCommand {
 				vscode.window.showErrorMessage(`Не удалось удалить каталог oscript_modules: ${(error as Error).message}`);
 			}
 		}
+	}
+
+	/**
+	 * Обновляет OPM (OneScript Package Manager)
+	 *
+	 * Выполняет команду opm install opm в терминале для установки или обновления
+	 * менеджера пакетов OPM в проекте.
+	 *
+	 * @returns Промис, который разрешается после запуска команды
+	 */
+	async updateOpm(): Promise<void> {
+		const workspaceRoot = this.ensureWorkspace();
+		if (!workspaceRoot) {
+			return;
+		}
+
+		const commandName = getUpdateOpmCommandName();
+		this.vrunner.executeOpmInTerminal(['install', 'opm'], {
+			cwd: workspaceRoot,
+			name: commandName.title
+		});
 	}
 
 	/**

--- a/src/treeViewProvider.ts
+++ b/src/treeViewProvider.ts
@@ -11,6 +11,7 @@ import {
 	getInstallDependenciesCommandName,
 	getRemoveDependenciesCommandName,
 	getInitializePackagedefCommandName,
+	getUpdateOpmCommandName,
 	getLoadConfigurationFromSrcCommandName,
 	getLoadConfigurationIncrementFromSrcCommandName,
 	getLoadConfigurationFromFilesByListCommandName,
@@ -530,6 +531,15 @@ export class PlatformTreeDataProvider implements vscode.TreeDataProvider<Platfor
 						{
 							command: '1c-platform-tools.dependencies.initializePackagedef',
 							title: getInitializePackagedefCommandName().title,
+						}
+					),
+					this.createTreeItem(
+						'📦 Обновить OPM',
+						TreeItemType.Task,
+						vscode.TreeItemCollapsibleState.None,
+						{
+							command: '1c-platform-tools.dependencies.updateOpm',
+							title: getUpdateOpmCommandName().title,
 						}
 					),
 					this.createTreeItem(


### PR DESCRIPTION
**Реализована команда обновления OPM в панели 1C Platform Tools**

Закрывает #32

**Что добавлено:**

**Группа «Зависимости» в панели**

- В дереве панели 1C Platform Tools в группе «Зависимости» добавлен пункт **«Обновить OPM»** (под «Инициализировать packagedef»).
- По щелчку выполняется команда `opm install opm` в терминале workspace.

**Команда обновления OPM**

- **Обновить OPM** — запуск `opm install opm` в терминале для установки/обновления менеджера пакетов OPM в проекте. Перед запуском проверяется наличие открытой рабочей области (`ensureWorkspace()`). Имя терминала берётся из заголовка команды («Обновить OPM»).

**Регистрация команды**

- Команда зарегистрирована как `1c-platform-tools.dependencies.updateOpm`, категория в палитре команд — «1C: Зависимости».
- Добавлены: метод `updateOpm()` в `DependenciesCommands`, функция `getUpdateOpmCommandName()` в `commandNames.ts`, пункт в дереве в `treeViewProvider.ts`, запись в `package.json` и в `commandRegistry.ts`.
