### PR TITLE
feat(extensions): добавлена команда для частичной загрузки расширений из objlist.txt

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,6 +195,11 @@
         "category": "1C: Расширения"
       },
       {
+        "command": "1c-platform-tools.extensions.loadFromFilesByList",
+        "title": "Загрузить из objlist.txt",
+        "category": "1C: Расширения"
+      },
+      {
         "command": "1c-platform-tools.extensions.loadFromCfe",
         "title": "Загрузить расширение из *.cfe",
         "category": "1C: Расширения"

--- a/src/commandNames.ts
+++ b/src/commandNames.ts
@@ -419,6 +419,16 @@ export function getLoadExtensionFromSrcCommandName(): CommandNameAndTitle {
 }
 
 /**
+ * Получить название и заголовок для команды частичной загрузки расширения из списка в objlist.txt
+ */
+export function getLoadExtensionFromFilesByListCommandName(): CommandNameAndTitle {
+	return {
+		name: 'Загрузить из objlist.txt',
+		title: 'Загрузить из objlist.txt'
+	};
+}
+
+/**
  * Получить название и заголовок для команды загрузки расширения из *.cfe
  */
 export function getLoadExtensionFromCfeCommandName(): CommandNameAndTitle {

--- a/src/commands/commandRegistry.ts
+++ b/src/commands/commandRegistry.ts
@@ -106,6 +106,9 @@ export function registerCommands(context: vscode.ExtensionContext, commands: Com
 		vscode.commands.registerCommand('1c-platform-tools.extensions.loadFromSrc', () => {
 			commands.extensions.loadFromSrc();
 		}),
+		vscode.commands.registerCommand('1c-platform-tools.extensions.loadFromFilesByList', () => {
+			commands.extensions.loadFromFilesByList();
+		}),
 		vscode.commands.registerCommand('1c-platform-tools.extensions.loadFromCfe', () => {
 			commands.extensions.loadFromCfe();
 		}),

--- a/src/treeStructure.ts
+++ b/src/treeStructure.ts
@@ -29,6 +29,7 @@ import {
 	getBuildConfigurationCommandName,
 	getDecompileConfigurationCommandName,
 	getLoadExtensionFromSrcCommandName,
+	getLoadExtensionFromFilesByListCommandName,
 	getLoadExtensionFromCfeCommandName,
 	getDumpExtensionToSrcCommandName,
 	getDumpExtensionToCfeCommandName,
@@ -115,6 +116,7 @@ export const TREE_GROUPS: TreeGroup[] = [
 		defaultCollapsibleState: 'expanded',
 		commands: [
 			{ command: '1c-platform-tools.extensions.loadFromSrc', title: getLoadExtensionFromSrcCommandName().title, treeLabel: '📥 Загрузить из src/cfe' },
+			{ command: '1c-platform-tools.extensions.loadFromFilesByList', title: getLoadExtensionFromFilesByListCommandName().title, treeLabel: '📥 Загрузить из objlist.txt' },
 			{ command: '1c-platform-tools.extensions.loadFromCfe', title: getLoadExtensionFromCfeCommandName().title, treeLabel: '📥 Загрузить из *.cfe' },
 			{ command: '1c-platform-tools.extensions.dumpToSrc', title: getDumpExtensionToSrcCommandName().title, treeLabel: '📤 Выгрузить в src/cfe' },
 			{ command: '1c-platform-tools.extensions.dumpToCfe', title: getDumpExtensionToCfeCommandName().title, treeLabel: '📤 Выгрузить в *.cfe' },


### PR DESCRIPTION
# Описание

Частичная загрузка расширений из objlist.txt и корректная работа при смешанном списке (конфигурация + расширения). 

Закрывает #39.

## Что сделано

- **Команда «Загрузить из objlist.txt» для расширений** — читает objlist.txt, оставляет только пути из каталогов расширений (src/cfe/&lt;имя&gt;), для каждого расширения формирует список в build/, запускает Конфигуратор с LoadConfigFromFiles -Extension -listFile -Format Hierarchical -partial. Временные файлы extension-partial-load-*.txt создаются в build и удаляются при следующем запуске команды.
- **Фильтрация при загрузке конфигурации** — при загрузке конфигурации из objlist.txt в платформу передаётся только список путей из src/cf; пути из src/cfe/ отфильтровываются. Список записывается в build/objlist-config.txt. Один objlist.txt может содержать и пути конфигурации, и расширений без ошибки «Неизвестный объект метаданных cfe._ДемоРасширение».
- **Поддержка полных путей** — сравнение путей вынесено в BaseCommand.pathUnderBase с нормализацией и без учёта регистра на Windows, чтобы полные пути из objlist.txt корректно определялись как принадлежащие src/cf или src/cfe/&lt;имя&gt;.
- **Рефакторинг** — в BaseCommand добавлены общие хелперы: parseObjlistLines, resolveObjlistLine, relativePathSlash, pathForCmd, writeListFile. Упрощены JSDoc и убраны лишние комментарии в configurationCommands и extensionsCommands.

## Чек-лист

- [x] Заголовок PR соответствует [Conventional Commits](https://www.conventionalcommits.org/ru/v1.0.0/) (например: `feat(scope): описание`)
- [x] Код проверен линтером (`npm run lint`)
- [x] Проект успешно собирается (`npm run compile`)
- [x] Изменения протестированы вручную (при необходимости)
- [x] Обновлена документация (README, docs/), если это необходимо
