### PR TITLE
fix(artifacts): разбирать .cfe из файла, а не из ИБ

### DIFF
--- a/src/commands/artifactCommands.ts
+++ b/src/commands/artifactCommands.ts
@@ -157,7 +157,18 @@ export class ArtifactCommands extends BaseCommand {
 		});
 	}
 
-	/** Разобрать .cfe в исходники. */
+	/**
+	 * Разобрать .cfe в исходники.
+	 *
+	 * vanessa-runner не умеет разбирать .cfe напрямую: `decompileext` выгружает
+	 * расширение ИЗ информационной базы, а не из файла. Поэтому сначала загружаем
+	 * .cfe в ИБ (`loadext --file <cfe> --extension <имя>`), затем выгружаем его
+	 * из ИБ в исходники (`decompileext <имя> <каталог>`). Обе команды выполняются
+	 * по цепочке в одном терминале. См. issue #65.
+	 *
+	 * Расширение раскладывается в подкаталог <выбранный каталог>/<имя расширения>
+	 * (формат src/cfe/<имя>), как в `vrunner decompileext`.
+	 */
 	async decompileExtension(artifactUri: vscode.Uri): Promise<void> {
 		const workspaceRoot = this.ensureWorkspace();
 		if (!workspaceRoot || !(await this.ensureOscriptAvailable())) {
@@ -168,12 +179,21 @@ export class ArtifactCommands extends BaseCommand {
 		if (!outDir) {
 			return;
 		}
-		const extensionName = path.basename(artifactUri.fsPath).replace(/\.cfe$/i, '');
+		const cfeName = path.basename(artifactUri.fsPath);
+		const extensionName = cfeName.replace(/\.cfe$/i, '');
+		const cfeRel = getRelativePath(artifactUri);
+		const targetDir = this.pathForCmd(path.join(outDir, extensionName));
 		const ibConnectionParam = await this.vrunner.getIbConnectionParam();
-		const args = this.addIbcmdIfNeeded(['decompileext', extensionName, outDir, ...ibConnectionParam]);
-		this.vrunner.executeVRunnerInTerminal(args, {
+		const loadArgs = ['loadext', '--file', cfeRel, '--extension', extensionName, ...ibConnectionParam];
+		const decompileArgs = this.addIbcmdIfNeeded([
+			'decompileext',
+			extensionName,
+			targetDir,
+			...ibConnectionParam,
+		]);
+		await this.vrunner.executeVRunnerCommandsInSequence([loadArgs, decompileArgs], {
 			cwd: workspaceRoot,
-			name: `Разобрать расширение: ${path.basename(artifactUri.fsPath)}`,
+			name: `Разобрать расширение: ${cfeName}`,
 		});
 	}
 


### PR DESCRIPTION
# Описание

Команда **«Разобрать»** для файла расширения `*.cfe` (панель «Артефакты 1С» и кнопка в редакторе бинарного файла) фактически была заглушкой: вызывался только `decompileext <имя> <каталог>`, который выгружает расширение **из информационной базы**, а путь к самому `.cfe` нигде не использовался. В результате разбиралось одноимённое расширение из ИБ, а не выбранный файл.

Закрывает #65

## Что сделано

- В `ArtifactCommands.decompileExtension` реализована двухшаговая цепочка (это «пакетный режим конфигуратора», обёрнутый vanessa-runner):
  1. `loadext --file <cfe> --extension <имя> --ibconnection …` — загрузка `.cfe` в ИБ;
  2. `decompileext <имя> <каталог>/<имя> --ibconnection …` — выгрузка из ИБ в исходники.
- Обе команды выполняются по цепочке в одном терминале через существующий `executeVRunnerCommandsInSequence` (чейн через `&&`).
- Исходники раскладываются в подкаталог `<выбранный каталог>/<имя расширения>` (формат `src/cfe/<имя>`), как в `vrunner decompileext`.
- Сигнатуры (`loadext`/`decompileext`) и имя команды сверены с исходниками vanessa-runner (`КомандаЗагрузитьРасширениеИзФайла.os`, реестр `"ЗагрузитьРасширениеИзФайла" → "loadext"`).

## Замечания для ревьюера

- `loadext` грузит расширение в ИБ по `--ibconnection` (по умолчанию `/F./build/ib`), поэтому **ИБ должна существовать** — то же допущение, что и у прежнего `decompileext`, регрессии нет. Сценарий «совсем без проектной ИБ» (через временную файловую ИБ) можно добавить отдельно, если потребуется.
- End-to-end на реальной платформе 1С в этой среде не прогонялся (нет платформы); проверены типизация, линт и сборка.

## Чек-лист

- [x] Заголовок PR соответствует [Conventional Commits](https://www.conventionalcommits.org/ru/v1.0.0/)
- [x] Код проверен линтером (`npm run lint`)
- [x] Проект успешно собирается (`npm run compile`)
- [x] Изменения протестированы вручную (требуется платформа 1С + тестовый `.cfe`)
- [x] Обновлена документация (README, docs/) — не требуется, поведение совпадает с описанным в docs
