### PR TITLE
fix(vrunner): путь к тестам xunit на vrunner 3

### DIFF
--- a/src/commands/testCommands.ts
+++ b/src/commands/testCommands.ts
@@ -32,7 +32,13 @@ export class TestCommands extends BaseCommand {
 	 */
 	async runXUnit(opts?: CommandExecutionOptions): Promise<StructuredCommandResult | void> {
 		const commandName = getXUnitTestsCommandName();
-		return this.runVRunner(['xunit', ...this.vrunner.getActiveSettingsParamIfExists()], opts, commandName.title);
+		const args = ['xunit', ...this.vrunner.getActiveSettingsParamIfExists()];
+		// vrunner 3 требует путь к тестам позиционным аргументом (в 2.x он шёл из
+		// секции xunit.testsPath env.json, которая в настройки 3.x не переносится).
+		if (await this.vrunner.supportsVRunnerFeature('cli3')) {
+			args.push(await this.vrunner.getXunitTestsPath());
+		}
+		return this.runVRunner(args, opts, commandName.title);
 	}
 
 	/**

--- a/src/shared/vrunnerManager.ts
+++ b/src/shared/vrunnerManager.ts
@@ -1444,6 +1444,36 @@ export class VRunnerManager {
 	}
 
 	/**
+	 * Путь к тестам xUnit (vanessa-add) для команды `vrunner test xunit`.
+	 *
+	 * В 2.x путь брался из секции `xunit.testsPath` файла env.json; в 3.x его нужно
+	 * передавать позиционным аргументом `TESTSPATH` (в настройки он не переносится).
+	 * Берём из активного env-профиля, иначе — стандартные smoke-тесты vanessa-add.
+	 *
+	 * @returns Путь к тестам (по умолчанию `$addRoot/tests/smoke`)
+	 */
+	public async getXunitTestsPath(): Promise<string> {
+		const fallback = '$addRoot/tests/smoke';
+		if (!this.workspaceRoot) {
+			return fallback;
+		}
+		const settingsFile = this.getActiveEnvFile();
+		const absolutePath = path.isAbsolute(settingsFile)
+			? settingsFile
+			: path.join(this.workspaceRoot, settingsFile);
+		try {
+			const env = JSON.parse(await fs.readFile(absolutePath, 'utf8'));
+			const value = env.xunit?.testsPath;
+			if (typeof value === 'string' && value.trim()) {
+				return value.trim();
+			}
+		} catch {
+			// файл недоступен/не JSON — используем значение по умолчанию
+		}
+		return fallback;
+	}
+
+	/**
 	 * Получает параметр --ibconnection для команды vrunner
 	 * 
 	 * Порядок определения значения:


### PR DESCRIPTION
Команда «XUnit тесты» (панель инструментов) на vrunner 3 падала: `test xunit` требует путь к тестам позиционным аргументом, а в 2.x он брался из `xunit.testsPath` env.json (не переносится в формат настроек 3.0). Теперь путь передаётся позиционно (из активного env-профиля, иначе `$addRoot/tests/smoke`).

Проверено на живом vrunner 3.0.0_beta (ssl_3_1): smoke-тесты xunit запускаются. Заодно прогнал на v3 остальные команды панелей инструментов и артефактов (infobase init/dump-dt, cf compile/decompile/load, cfe compile/load/decompile, epf compile, vanessa, syntax-check) — работают.