### PR TITLE
fix(testing): точечный запуск OneScript-тестов через 1testrunner не показывал результат

### DIFF
--- a/src/features/testing/adapters/onescriptAdapter.ts
+++ b/src/features/testing/adapters/onescriptAdapter.ts
@@ -21,8 +21,12 @@ type OneScriptRunner = '1testrunner' | 'oneunit';
  *
  * Запуск — без платформы 1С, раннер выбирается настройкой
  * testing.onescriptRunner ('auto' — по наличию oneunit в oscript_modules/bin):
- * - 1testrunner: `-run <файл> [ИмяТеста] xddReportPath <каталог>` — jUnit-отчёт;
- * - OneUnit: `execute -f <файл> [-m <метод>] --junit <отчёт>` — jUnit-отчёт.
+ * - 1testrunner: `-run <файл> xddReportPath <каталог>` — jUnit-отчёт. Имя файла
+ *   отчёта раннер выбирает сам по набору тестов, поэтому точечный фильтр не
+ *   передаём (при одном тесте имя расходится с <файл>.os.xml и отчёт не находится)
+ *   — гоняем весь файл, панель раскладывает результаты по кейсам;
+ * - OneUnit: `execute -f <файл> [-m <метод>] --junit <отчёт>` — точечный запуск
+ *   надёжен, отчёт пишется в явный файл.
  *
  * Отчёты складываются в build/out/onescript — их подхватывает команда
  * «Allure отчёт». Для старых версий 1testrunner без поддержки xddReportPath
@@ -66,7 +70,8 @@ export class OneScriptAdapter implements TestFrameworkAdapter {
 	public async buildRunPlan(unit: RunUnit, _reportDir: string): Promise<AdapterRunPlan> {
 		const runner = this.resolveRunner();
 		const quotedFile = `"${unit.fileUri.fsPath}"`;
-		// Точечный запуск возможен только для одного теста
+		// Точечный запуск надёжен только у OneUnit (явный --junit <файл>).
+		// У 1testrunner имя отчёта выбирается раннером — фильтр его ломает (см. ниже).
 		const singleCase = unit.caseNames?.length === 1 ? unit.caseNames[0] : undefined;
 
 		// Отчёты складываем в build/out/onescript (постоянное место):
@@ -89,13 +94,15 @@ export class OneScriptAdapter implements TestFrameworkAdapter {
 			};
 		}
 
-		// 1testrunner: jUnit через xddReportPath <каталог> —
-		// внутри создаётся <имяФайлаТеста>.xml (testcase = метод, статус атрибутом)
-		const args = [runner.command, '-run', quotedFile];
-		if (singleCase) {
-			args.push(`"${singleCase}"`);
-		}
-		args.push('xddReportPath', `"${reportsDir}"`);
+		// 1testrunner: jUnit через xddReportPath <каталог> — внутри создаётся
+		// <имяФайлаТеста>.xml (testcase = метод, статус атрибутом).
+		//
+		// Точечный фильтр (`-run <файл> "ИмяТеста"`) намеренно НЕ передаём: при одном
+		// отобранном тесте 1testrunner формирует имя файла отчёта из схлопнутого набора
+		// тестов, и оно расходится с ожидаемым <файл>.os.xml — отчёт пишется, но панель
+		// его не находит («без jUnit-отчёта»). Поэтому всегда гоняем весь файл, а нужный
+		// кейс панель подсветит при раскладке результатов.
+		const args = [runner.command, '-run', quotedFile, 'xddReportPath', `"${reportsDir}"`];
 		return {
 			tool: 'shell',
 			args: [args.join(' ')],

--- a/src/test/testing/onescriptAdapter.test.ts
+++ b/src/test/testing/onescriptAdapter.test.ts
@@ -25,14 +25,25 @@ suite('onescriptAdapter', () => {
 		);
 	});
 
-	test('buildRunPlan (1testrunner): один кейс добавляет имя теста', async () => {
+	test('buildRunPlan (1testrunner): один кейс гонит весь файл, без фильтра по имени', async () => {
 		const adapter = new OneScriptAdapter(VRunnerManager.getInstance());
 
 		const plan = await adapter.buildRunPlan(
 			{ fileUri, caseNames: ['ТестДолжен_Проверить'] },
 			'C:\\proj\\build\\report'
 		);
-		assert.ok(plan.args[0].includes('"ТестДолжен_Проверить"'));
+		// 1testrunner сам выбирает имя файла отчёта по набору тестов: при точечном
+		// фильтре оно расходится с <файл>.os.xml и отчёт не находится. Поэтому фильтр
+		// по имени не передаём — гоняем весь файл (отчёт остаётся test_example.os.xml).
+		assert.ok(
+			!plan.args[0].includes('"ТестДолжен_Проверить"'),
+			'Имя теста не передаётся в 1testrunner — запускается весь файл'
+		);
+		assert.ok(plan.args[0].includes('xddReportPath'), 'Отчёт пишется через xddReportPath');
+		assert.ok(
+			plan.reportTarget?.path.endsWith('test_example.os.xml'),
+			'Отчёт по имени файла теста'
+		);
 	});
 
 	test('parseFile распознаёт xdd-структуру и аннотации', () => {


### PR DESCRIPTION
## Симптом

При запуске **одного** теста из файла `.os` через 1testrunner (клик по конкретному кейсу в панели «1С: Тесты») прогон падал с «Прогон завершился без jUnit-отчёта (код возврата 0)», хотя в консоли раннера было «Тестов пройдено: 1». Запуск всего файла при этом работал.

## Причина

1testrunner — единственный раннер, которому отдаётся **каталог** для отчёта (`xddReportPath`), а имя файла он выбирает сам по набору тестов. При точечном фильтре (`-run <файл> "ИмяТеста"`) набор схлопывается до одного теста ([testrunner.os](https://github.com/oscript-library/1testrunner/blob/master/src/%D0%9A%D0%BB%D0%B0%D1%81%D1%81%D1%8B/testrunner.os): `НаборТестов.Очистить()` + `Добавить(ОписаниеТеста)`), и имя файла отчёта расходится с ожидаемым `<файл>.os.xml`. Отчёт пишется, но панель ищет ровно `<файл>.os.xml`, не находит его и показывает «без jUnit-отчёта».

Это проявляется **только** у 1testrunner: остальные адаптеры передают явный путь к файлу отчёта (YAxUnit — `reportPath`, 1bdd — явный файл, OneUnit — `--junit <файл>`), поэтому точечный запуск у них не ломается. xUnit (Vanessa-ADD) и Vanessa Automation точечного запуска не делают вовсе.

Баг предсуществующий — введён вместе с панелью тестирования (`01e9983`), не связан с правками Testing API.

## Что сделали

Убрали передачу имени теста в 1testrunner: при точечном запуске гоняем весь файл (отчёт остаётся `<файл>.os.xml` и находится). Нужный кейс панель подсветит при раскладке результатов. Точечный `-m <метод>` у OneUnit оставили без изменений — там отчёт пишется в явный `--junit <файл>` и работает надёжно.

## Как проверить

- `npx tsc --noEmit -p tsconfig.json` — без ошибок типов.
- `npm run compile` — сборка проходит.
- `npm run lint` — без замечаний.
- `npm test` — 249 тестов проходят (тест `buildRunPlan (1testrunner): один кейс гонит весь файл` обновлён под новое поведение).
- Вручную: в проекте с OneScript-тестами (1testrunner) кликнуть по одному кейсу в панели «1С: Тесты» — прогон проходит и показывает результат, без «без jUnit-отчёта».

> Локально 1testrunner у меня нет, поэтому ручную проверку точечного запуска прошу подтвердить на вашем окружении.
