### PR TITLE
feat(testing): inline-diff для упавших тестов (TestMessage.diff)

### DIFF
--- a/src/features/testing/adapters/onebddAdapter.ts
+++ b/src/features/testing/adapters/onebddAdapter.ts
@@ -156,7 +156,10 @@ export function aggregateBddStepsToScenarios(stepCases: JUnitCase[]): JUnitCase[
 			status: failedStep ? 'failed' : allSkipped ? 'skipped' : 'passed',
 			timeMs,
 			message: failedStep ? `Шаг: ${failedStep.name}` : undefined,
-			details: failedStep?.details ?? failedStep?.message
+			details: failedStep?.details ?? failedStep?.message,
+			// Пара ожидаемое/фактическое упавшего шага едет дальше для diff
+			expected: failedStep?.expected,
+			actual: failedStep?.actual
 		});
 	}
 	return result;

--- a/src/features/testing/parsers/cucumberParser.ts
+++ b/src/features/testing/parsers/cucumberParser.ts
@@ -1,4 +1,5 @@
 import { JUnitCase } from './junitParser';
+import { extractExpectedActual } from './expectedActual';
 
 /**
  * Парсер отчётов Cucumber JSON (Vanessa Automation)
@@ -111,6 +112,7 @@ export function parseCucumberJson(json: string): JUnitCase[] {
 			const steps = element.steps ?? [];
 			const status = elementStatus(steps);
 			const { message, details } = firstError(steps);
+			const diff = extractExpectedActual(details, message);
 
 			// duration шагов — в наносекундах
 			let totalNs = 0;
@@ -129,7 +131,9 @@ export function parseCucumberJson(json: string): JUnitCase[] {
 				status,
 				timeMs: hasDuration ? Math.round(totalNs / 1_000_000) : undefined,
 				message,
-				details
+				details,
+				expected: diff?.expected,
+				actual: diff?.actual
 			});
 		}
 	}

--- a/src/features/testing/parsers/expectedActual.ts
+++ b/src/features/testing/parsers/expectedActual.ts
@@ -1,0 +1,87 @@
+/**
+ * Извлечение пары «ожидаемое/фактическое» из текста падения теста
+ *
+ * jUnit/Cucumber-отчёты 1С (YAxUnit, xUnitFor1C, Vanessa Automation) и xUnit-движки
+ * часто пишут ожидаемое и фактическое значения прямо в текст сообщения об ошибке,
+ * не выделяя их отдельными полями. Распознаём распространённые форматы ассертов,
+ * чтобы показать нативный diff в VS Code (vscode.TestMessage.diff).
+ *
+ * Это эвристика «по возможности»: не распознали — вызывающий код откатывается
+ * на обычное текстовое сообщение.
+ */
+
+/**
+ * Пара значений для diff-представления падения
+ */
+export interface ExpectedActual {
+	/** Ожидаемое значение */
+	expected: string;
+	/** Фактическое значение */
+	actual: string;
+}
+
+/** Метка ожидаемого значения (рус./англ.) */
+const EXPECTED = '(?:ожидаемое(?:\\s+значение)?|ожидаемый(?:\\s+результат)?|ожида(?:ется|ем|ли)|expected)';
+
+/** Сильные метки фактического значения — однозначны даже без знака-разделителя */
+const ACTUAL_STRONG =
+	'(?:фактическое(?:\\s+значение)?|фактический(?:\\s+результат)?|фактически|получено|получили|but\\s+was|but\\s+got|actual(?:\\s+value)?)';
+
+/** Любые метки фактического (включая короткие «was»/«got») — только со знаком-разделителем */
+const ACTUAL_ANY = `(?:${ACTUAL_STRONG}|was|got)`;
+
+/**
+ * Шаблоны распознавания, от строгих к свободным. Группа 1 — ожидаемое, группа 2 — фактическое.
+ */
+const PATTERNS: RegExp[] = [
+	// Классический JUnit assertEquals: expected:<4> but was:<5>
+	new RegExp(`${EXPECTED}\\s*:?\\s*<([\\s\\S]*?)>\\s*${ACTUAL_ANY}\\s*:?\\s*<([\\s\\S]*?)>`, 'i'),
+	// Метка-значение, знак-разделитель (перевод строки/«,»/«.»/«;»), метка-значение:
+	//   «Ожидали: 4, получили: 5», «Expected: 4\nActual: 5», «Ожидаемое значение: 4. Фактическое: 5»
+	new RegExp(`${EXPECTED}\\s*:?\\s*([\\s\\S]+?)\\s*[\\r\\n;,.]+\\s*${ACTUAL_ANY}\\s*:?\\s*([\\s\\S]+)`, 'i'),
+	// Без знака-разделителя, только сильные метки: «Expected: 4 but was: 5»
+	new RegExp(`${EXPECTED}\\s*:?\\s*([\\s\\S]+?)\\s+${ACTUAL_STRONG}\\s*:?\\s*([\\s\\S]+)`, 'i')
+];
+
+/**
+ * Снимает обрамляющие кавычки/угловые скобки и пробелы с захваченного значения
+ */
+function clean(value: string): string {
+	const trimmed = value.trim();
+	const wrapped = /^<([\s\S]*)>$|^"([\s\S]*)"$|^'([\s\S]*)'$|^«([\s\S]*)»$/.exec(trimmed);
+	if (wrapped) {
+		return (wrapped[1] ?? wrapped[2] ?? wrapped[3] ?? wrapped[4]).trim();
+	}
+	return trimmed;
+}
+
+/**
+ * Пытается извлечь пару «ожидаемое/фактическое» из переданных текстов
+ *
+ * Тексты проверяются по порядку (например, сначала message, затем details);
+ * берётся первое распознанное вхождение. Diff бессмыслен, если значения
+ * совпали или оба пусты — в этом случае возвращается undefined.
+ *
+ * @param texts - Куски текста падения в порядке приоритета
+ * @returns Пара значений либо undefined, если ничего не распознано
+ */
+export function extractExpectedActual(...texts: (string | undefined)[]): ExpectedActual | undefined {
+	for (const text of texts) {
+		if (!text) {
+			continue;
+		}
+		for (const pattern of PATTERNS) {
+			const match = pattern.exec(text);
+			if (!match) {
+				continue;
+			}
+			const expected = clean(match[1]);
+			const actual = clean(match[2]);
+			if (expected === actual || (expected === '' && actual === '')) {
+				continue;
+			}
+			return { expected, actual };
+		}
+	}
+	return undefined;
+}

--- a/src/features/testing/parsers/junitParser.ts
+++ b/src/features/testing/parsers/junitParser.ts
@@ -1,4 +1,5 @@
 import { XMLParser } from 'fast-xml-parser';
+import { extractExpectedActual } from './expectedActual';
 
 /**
  * Парсер jUnit XML отчётов
@@ -27,6 +28,10 @@ export interface JUnitCase {
 	message?: string;
 	/** Подробности падения (текст элемента failure/error) */
 	details?: string;
+	/** Ожидаемое значение, если распознано в тексте падения (для diff-представления) */
+	expected?: string;
+	/** Фактическое значение, если распознано в тексте падения (для diff-представления) */
+	actual?: string;
 }
 
 /**
@@ -108,6 +113,7 @@ function parseTestCase(testcase: Record<string, unknown>, suiteName: string): JU
 	}
 
 	const { message, details } = extractFailureInfo(failureNode);
+	const diff = extractExpectedActual(message, details);
 
 	return {
 		suiteName,
@@ -116,7 +122,9 @@ function parseTestCase(testcase: Record<string, unknown>, suiteName: string): JU
 		status,
 		timeMs: parseTimeMs(testcase['@_time']),
 		message,
-		details
+		details,
+		expected: diff?.expected,
+		actual: diff?.actual
 	};
 }
 

--- a/src/features/testing/testController.ts
+++ b/src/features/testing/testController.ts
@@ -652,8 +652,13 @@ export class TestingController implements vscode.Disposable {
 					break;
 				case 'failed':
 				case 'error': {
-					const messages = mapped.messages.map((text) => {
-						const message = new vscode.TestMessage(text);
+					const messages = mapped.messages.map((failure) => {
+						// При наличии пары ожидаемое/фактическое показываем нативный
+						// diff, иначе откатываемся на обычное текстовое сообщение
+						const message =
+							failure.expected !== undefined && failure.actual !== undefined
+								? vscode.TestMessage.diff(failure.text, failure.expected, failure.actual)
+								: new vscode.TestMessage(failure.text);
 						if (item.uri && item.range) {
 							message.location = new vscode.Location(item.uri, item.range.start);
 						}

--- a/src/features/testing/testResultMapper.ts
+++ b/src/features/testing/testResultMapper.ts
@@ -21,6 +21,22 @@ export interface KnownCase {
 }
 
 /**
+ * Сообщение о падении одного testcase
+ *
+ * Когда отчёт содержит ожидаемое/фактическое значения, они едут отдельными
+ * полями — вызывающий код покажет нативный diff (vscode.TestMessage.diff),
+ * иначе откатится на обычный текст.
+ */
+export interface FailureMessage {
+	/** Текст сообщения (message + details) */
+	text: string;
+	/** Ожидаемое значение для diff (только вместе с actual) */
+	expected?: string;
+	/** Фактическое значение для diff (только вместе с expected) */
+	actual?: string;
+}
+
+/**
  * Агрегированный результат одного элемента дерева
  *
  * Один элемент может собрать несколько testcase (Структура сценария → строки Examples).
@@ -31,7 +47,7 @@ export interface MappedResult {
 	/** Суммарная длительность, мс (undefined, если ни один testcase не содержал time) */
 	durationMs?: number;
 	/** Сообщения падений (message + details), в порядке встречаемости */
-	messages: string[];
+	messages: FailureMessage[];
 }
 
 /**
@@ -161,7 +177,7 @@ export function mapResults(junitCases: JUnitCase[], knownCases: KnownCase[]): Ma
 function aggregate(bucket: JUnitCase[]): MappedResult {
 	let status: MappedResult['status'] = 'skipped';
 	let durationMs: number | undefined;
-	const messages: string[] = [];
+	const messages: FailureMessage[] = [];
 
 	const hasError = bucket.some((c) => c.status === 'error');
 	const hasFailed = bucket.some((c) => c.status === 'failed');
@@ -183,7 +199,15 @@ function aggregate(bucket: JUnitCase[]): MappedResult {
 			const parts = [junitCase.message, junitCase.details].filter(
 				(part): part is string => typeof part === 'string' && part.length > 0
 			);
-			messages.push(parts.length > 0 ? parts.join('\n') : 'Тест не пройден (без подробностей в отчёте)');
+			const message: FailureMessage = {
+				text: parts.length > 0 ? parts.join('\n') : 'Тест не пройден (без подробностей в отчёте)'
+			};
+			// expected/actual едут парой: diff бессмыслен без обоих значений
+			if (junitCase.expected !== undefined && junitCase.actual !== undefined) {
+				message.expected = junitCase.expected;
+				message.actual = junitCase.actual;
+			}
+			messages.push(message);
 		}
 	}
 

--- a/src/test/testing/cucumberParser.test.ts
+++ b/src/test/testing/cucumberParser.test.ts
@@ -85,6 +85,31 @@ suite('cucumberParser', () => {
 		assert.strictEqual(cases[0].timeMs, undefined);
 	});
 
+	test('извлекает expected/actual из error_message шага', () => {
+		const json = JSON.stringify([
+			{
+				name: 'Фича',
+				elements: [
+					{
+						name: 'Сравнение значений',
+						type: 'scenario',
+						steps: [
+							{
+								keyword: 'Тогда ',
+								name: 'значения равны',
+								result: { status: 'failed', error_message: 'Ожидаемое значение: 10. Фактическое значение: 20' }
+							}
+						]
+					}
+				]
+			}
+		]);
+
+		const cases = parseCucumberJson(json);
+		assert.strictEqual(cases[0].expected, '10');
+		assert.strictEqual(cases[0].actual, '20');
+	});
+
 	test('битый JSON и не-массив вызывают ошибку', () => {
 		assert.throws(() => parseCucumberJson('{оборвано'), /Cucumber JSON/);
 		assert.throws(() => parseCucumberJson('{"name": "не массив"}'), /массив/);

--- a/src/test/testing/expectedActual.test.ts
+++ b/src/test/testing/expectedActual.test.ts
@@ -1,0 +1,69 @@
+import * as assert from 'node:assert';
+import { extractExpectedActual } from '../../features/testing/parsers/expectedActual';
+
+suite('extractExpectedActual', () => {
+	test('классический JUnit assertEquals: expected:<4> but was:<5>', () => {
+		assert.deepStrictEqual(extractExpectedActual('expected:<4> but was:<5>'), {
+			expected: '4',
+			actual: '5'
+		});
+	});
+
+	test('английский Expected/Actual на разных строках', () => {
+		assert.deepStrictEqual(extractExpectedActual('Expected: 42\nActual: 7'), {
+			expected: '42',
+			actual: '7'
+		});
+	});
+
+	test('английский Expected ... but was без знака-разделителя', () => {
+		assert.deepStrictEqual(extractExpectedActual('Expected: foo but was: bar'), {
+			expected: 'foo',
+			actual: 'bar'
+		});
+	});
+
+	test('русский: Ожидали X, получили Y', () => {
+		assert.deepStrictEqual(extractExpectedActual('Ожидали: 4, получили: 5'), {
+			expected: '4',
+			actual: '5'
+		});
+	});
+
+	test('русский: Ожидаемое значение ... Фактическое значение', () => {
+		assert.deepStrictEqual(
+			extractExpectedActual('Ожидаемое значение: Иванов. Фактическое значение: Петров'),
+			{ expected: 'Иванов', actual: 'Петров' }
+		);
+	});
+
+	test('снимает обрамляющие кавычки со значений', () => {
+		assert.deepStrictEqual(extractExpectedActual('Ожидали: «10», получили: «20»'), {
+			expected: '10',
+			actual: '20'
+		});
+	});
+
+	test('ищет пару среди нескольких текстов по приоритету', () => {
+		const result = extractExpectedActual(undefined, 'нет пары', 'expected:<a> but was:<b>');
+		assert.deepStrictEqual(result, { expected: 'a', actual: 'b' });
+	});
+
+	test('находит пару внутри многострочного стека', () => {
+		const text = 'Тест упал\nОжидаемое значение: 100\nФактическое значение: 200\n  at module.bsl:42';
+		const result = extractExpectedActual(text);
+		assert.ok(result);
+		assert.strictEqual(result.expected, '100');
+		assert.ok(result.actual.startsWith('200'));
+	});
+
+	test('без распознаваемой пары возвращает undefined', () => {
+		assert.strictEqual(extractExpectedActual('Кнопка «Создать» не найдена на форме'), undefined);
+		assert.strictEqual(extractExpectedActual(undefined), undefined);
+		assert.strictEqual(extractExpectedActual(''), undefined);
+	});
+
+	test('совпадающие значения не дают diff (undefined)', () => {
+		assert.strictEqual(extractExpectedActual('expected:<5> but was:<5>'), undefined);
+	});
+});

--- a/src/test/testing/junitParser.test.ts
+++ b/src/test/testing/junitParser.test.ts
@@ -76,6 +76,30 @@ suite('junitParser', () => {
 		assert.strictEqual(cases[0].timeMs, 250);
 	});
 
+	test('извлекает expected/actual из текста падения (классический assertEquals)', () => {
+		const xml = `<testsuite name="S">
+	<testcase name="Сложение">
+		<failure message="expected:&lt;4&gt; but was:&lt;5&gt;">Стек вызовов</failure>
+	</testcase>
+</testsuite>`;
+
+		const cases = parseJUnitXml(xml);
+		assert.strictEqual(cases[0].expected, '4');
+		assert.strictEqual(cases[0].actual, '5');
+	});
+
+	test('без распознанной пары expected/actual остаются undefined', () => {
+		const xml = `<testsuite name="S">
+	<testcase name="Без пары">
+		<failure message="Объект не найден">детали</failure>
+	</testcase>
+</testsuite>`;
+
+		const cases = parseJUnitXml(xml);
+		assert.strictEqual(cases[0].expected, undefined);
+		assert.strictEqual(cases[0].actual, undefined);
+	});
+
 	test('пустой testsuite даёт пустой список', () => {
 		assert.deepStrictEqual(parseJUnitXml('<testsuite name="Пусто"/>'), []);
 	});

--- a/src/test/testing/testResultMapper.test.ts
+++ b/src/test/testing/testResultMapper.test.ts
@@ -32,7 +32,7 @@ suite('testResultMapper', () => {
 		const mapped = results.get('id-1');
 		assert.ok(mapped);
 		assert.strictEqual(mapped.status, 'failed');
-		assert.deepStrictEqual(mapped.messages, ['Упал']);
+		assert.deepStrictEqual(mapped.messages, [{ text: 'Упал' }]);
 	});
 
 	test('подстрочное совпадение: единственный кандидат привязывается', () => {
@@ -69,7 +69,7 @@ suite('testResultMapper', () => {
 		assert.ok(mapped);
 		assert.strictEqual(mapped.status, 'failed', 'failed важнее passed');
 		assert.strictEqual(mapped.durationMs, 300);
-		assert.deepStrictEqual(mapped.messages, ['Строка 2 упала']);
+		assert.deepStrictEqual(mapped.messages, [{ text: 'Строка 2 упала' }]);
 	});
 
 	test('error важнее failed, skipped — только если все пропущены', () => {
@@ -98,6 +98,36 @@ suite('testResultMapper', () => {
 	test('падение без message получает заглушку', () => {
 		const { results } = mapResults([junitCase('Параметризованный', 'failed')], known);
 		assert.strictEqual(results.get('id-3')?.messages.length, 1);
-		assert.ok(results.get('id-3')?.messages[0].length);
+		assert.ok(results.get('id-3')?.messages[0].text.length);
+	});
+
+	test('пара expected/actual пробрасывается в сообщение для diff', () => {
+		const { results } = mapResults(
+			[
+				junitCase('ТестДолжен_ПроверитьСложение', 'failed', {
+					message: 'expected:<4> but was:<5>',
+					expected: '4',
+					actual: '5'
+				})
+			],
+			known
+		);
+		const mapped = results.get('id-2');
+		assert.ok(mapped);
+		assert.strictEqual(mapped.messages.length, 1);
+		assert.strictEqual(mapped.messages[0].expected, '4');
+		assert.strictEqual(mapped.messages[0].actual, '5');
+		assert.ok(mapped.messages[0].text.includes('expected:<4>'));
+	});
+
+	test('без пары expected/actual поля diff не выставляются (fallback на текст)', () => {
+		const { results } = mapResults(
+			[junitCase('ТестДолжен_ПроверитьСложение', 'failed', { message: 'Просто упал' })],
+			known
+		);
+		const message = results.get('id-2')?.messages[0];
+		assert.ok(message);
+		assert.strictEqual(message.expected, undefined);
+		assert.strictEqual(message.actual, undefined);
 	});
 });


### PR DESCRIPTION
## Что это
Падения тестов с распознанной парой «ожидаемое/фактическое» показываются нативным diff VS Code (`vscode.TestMessage.diff`), а не простым текстом.

## Как работает
- Новый `extractExpectedActual` (`src/features/testing/parsers/expectedActual.ts`) — эвристика «по возможности», распознаёт распространённые форматы ассертов:
  - классический JUnit: `expected:<4> but was:<5>`
  - английский: `Expected: 42 / Actual: 7`, `Expected: foo but was: bar`
  - русский (YAxUnit/xUnitFor1C/Vanessa): `Ожидали: 4, получили: 5`, `Ожидаемое значение: X. Фактическое значение: Y`
- jUnit/Cucumber-парсеры заполняют новые поля `expected`/`actual` у `JUnitCase`.
- 1bdd-адаптер пробрасывает пару упавшего шага при агрегации шагов в сценарии.
- `MappedResult.messages` стал `FailureMessage[]` (`{ text, expected?, actual? }`).
- `testController.applyResults` строит `TestMessage.diff(...)` при наличии пары, иначе — обычное текстовое сообщение.

## Критерии готовности
- [x] При наличии expected/actual показывается diff.
- [x] Иначе fallback на обычное текстовое сообщение.
- [x] Тесты парсера на извлечение пары (`expectedActual.test.ts`) + кейсы в junit/cucumber-парсерах + проброс через маппер.

## Проверка
`tsc --noEmit` чисто, `eslint` чисто, сборка esbuild ок. Чистые тесты под Mocha — 36 passing.

Закрывает #126
