### PR TITLE
feat(testing): батч-прогон OneScript, фильтр утиля, выбор и установка oneunit

### DIFF
--- a/src/commands/dependenciesCommands.ts
+++ b/src/commands/dependenciesCommands.ts
@@ -242,10 +242,12 @@ export class DependenciesCommands extends BaseCommand {
 
 	/**
 	 * Устанавливает зависимости проекта
-	 * 
-	 * Выполняет команду opm install -l в терминале для установки всех зависимостей,
-	 * указанных в packagedef файле проекта.
-	 * 
+	 *
+	 * Выполняет команду opm install --dev -l в терминале для установки всех
+	 * зависимостей из packagedef. Флаг --dev добавляет зависимости разработки
+	 * (РазработкаЗависитОт): без него не ставятся раннеры/хелперы тестов
+	 * (oneunit, asserts), и панель тестирования не находит раннер.
+	 *
 	 * @returns Промис, который разрешается после запуска команды
 	 */
 	async installDependencies(): Promise<void> {
@@ -258,7 +260,7 @@ export class DependenciesCommands extends BaseCommand {
 		}
 
 		const commandName = getInstallDependenciesCommandName();
-		this.vrunner.executeOpmInTerminal(['install', '-l'], {
+		this.vrunner.executeOpmInTerminal(['install', '--dev', '-l'], {
 			cwd: workspaceRoot,
 			name: commandName.title
 		});
@@ -600,7 +602,7 @@ export class DependenciesCommands extends BaseCommand {
 			[
 				{
 					label: '$(check) Да, установить зависимости',
-					description: 'opm install -l по списку из packagedef',
+					description: 'opm install --dev -l по списку из packagedef',
 					detail: 'Требуется OneScript (oscript, opm)',
 					picked: true,
 					installDeps: true
@@ -698,7 +700,7 @@ export class DependenciesCommands extends BaseCommand {
 			if (installDependencies && context) {
 				await context.globalState.update(DependenciesCommands.INSTALL_DEPS_AFTER_CREATE_KEY, targetDir);
 				vscode.window.showInformationMessage(
-					'После открытия папки будет предложена установка зависимостей (opm install -l).'
+					'После открытия папки будет предложена установка зависимостей (opm install --dev -l).'
 				);
 			}
 			// Показать панель «Начало работы» после открытия только что созданного проекта

--- a/src/features/testing/adapters/onescriptAdapter.ts
+++ b/src/features/testing/adapters/onescriptAdapter.ts
@@ -19,8 +19,9 @@ type OneScriptRunner = '1testrunner' | 'oneunit';
  * Discovery: .os модули в каталоге тестов OneScript — классический стиль
  * (ИсполняемыеСценарии) и аннотационный (&Тест над процедурой).
  *
- * Запуск — без платформы 1С, раннер выбирается настройкой
- * testing.onescriptRunner ('auto' — по наличию oneunit в oscript_modules/bin):
+ * Запуск — без платформы 1С, раннер выбирается настройкой testing.onescriptRunner
+ * ('auto' — oneunit, если он локально в oscript_modules/bin или объявлен в packagedef,
+ * иначе 1testrunner):
  * - 1testrunner: `-run <файл> xddReportPath <каталог>` — jUnit-отчёт. Имя файла
  *   отчёта раннер выбирает сам по набору тестов, поэтому точечный фильтр не
  *   передаём (при одном тесте имя расходится с <файл>.os.xml и отчёт не находится)
@@ -61,6 +62,15 @@ export class OneScriptAdapter implements TestFrameworkAdapter {
 		return parseBslTestModule(content, 'xunit');
 	}
 
+	public isTestFile(content: string): boolean {
+		// glob матчит все .os под каталогом тестов, включая вспомогательные классы
+		// (билдеры/стабы/фикстуры, например в tests/unit/utils/). Тестовый — лишь
+		// модуль с ИсполняемыеСценарии/ЗаполнитьНаборТестов/ПолучитьСписокТестов или
+		// аннотацией &Тест; по нему же parseFile строит кейсы. Без этой проверки
+		// дерево заполняли бы все хелперы, а их «прогон» падал бы без jUnit-отчёта.
+		return parseBslTestModule(content, 'xunit') !== undefined;
+	}
+
 	public describeFileLocation(fileUri: vscode.Uri, workspaceRoot: string) {
 		const config = vscode.workspace.getConfiguration('1c-platform-tools');
 		const base = config.get<string>('testing.onescriptTestsPath', DEFAULT_TESTING.onescriptTestsPath);
@@ -74,11 +84,7 @@ export class OneScriptAdapter implements TestFrameworkAdapter {
 		// У 1testrunner имя отчёта выбирается раннером — фильтр его ломает (см. ниже).
 		const singleCase = unit.caseNames?.length === 1 ? unit.caseNames[0] : undefined;
 
-		// Отчёты складываем в build/out/onescript (постоянное место):
-		// оттуда их читает и панель, и команда «Allure отчёт»
-		const workspaceRoot = this.vrunner.getWorkspaceRoot() ?? '';
-		const reportsDir = path.join(workspaceRoot, this.vrunner.getOutPath(), 'onescript');
-		await fs.mkdir(reportsDir, { recursive: true });
+		const reportsDir = await this.ensureReportsDir();
 		const reportFile = path.join(reportsDir, `${path.basename(unit.fileUri.fsPath)}.xml`);
 
 		if (runner.kind === 'oneunit') {
@@ -114,6 +120,53 @@ export class OneScriptAdapter implements TestFrameworkAdapter {
 	}
 
 	/**
+	 * Строит план батч-прогона нескольких файлов одним процессом OneUnit
+	 *
+	 * `oneunit execute -f <файл1> -f <файл2> ... --junit <общий отчёт>` гонит все
+	 * выбранные файлы за один запуск (один холодный старт вместо N) и пишет общий
+	 * jUnit-отчёт; контроллер раскладывает его по файлам. Передаём именно -f по
+	 * каждому файлу (а не -d по каталогу), чтобы прогнать ровно отобранные тесты и
+	 * не зацепить вспомогательные классы из utils/ (см. isTestFile).
+	 *
+	 * Для 1testrunner батч не поддержан (имя отчёта раннер выбирает сам) — возвращаем
+	 * undefined, контроллер прогонит файлы поштучно.
+	 */
+	public async buildBatchRunPlan(units: RunUnit[], _reportDir: string): Promise<AdapterRunPlan | undefined> {
+		const runner = this.resolveRunner();
+		if (runner.kind !== 'oneunit') {
+			return undefined;
+		}
+
+		const reportsDir = await this.ensureReportsDir();
+		const reportFile = path.join(reportsDir, '_oneunit-batch.xml');
+
+		const args = [runner.command, 'execute'];
+		for (const unit of units) {
+			args.push('-f', `"${unit.fileUri.fsPath}"`);
+		}
+		args.push('--junit', `"${reportFile}"`);
+
+		return {
+			tool: 'shell',
+			args: [args.join(' ')],
+			reportTarget: { format: 'junit', path: reportFile }
+		};
+	}
+
+	/**
+	 * Гарантирует существование постоянного каталога отчётов build/out/onescript
+	 *
+	 * Отчёты складываются туда (а не во временный каталог прогона): оттуда их
+	 * читает и панель тестирования, и команда «Allure отчёт».
+	 */
+	private async ensureReportsDir(): Promise<string> {
+		const workspaceRoot = this.vrunner.getWorkspaceRoot() ?? '';
+		const reportsDir = path.join(workspaceRoot, this.vrunner.getOutPath(), 'onescript');
+		await fs.mkdir(reportsDir, { recursive: true });
+		return reportsDir;
+	}
+
+	/**
 	 * Определяет раннер и команду его запуска
 	 *
 	 * Порядок: testing.onescriptRunnerPath (относительные пути — от корня
@@ -144,16 +197,46 @@ export class OneScriptAdapter implements TestFrameworkAdapter {
 
 	/**
 	 * Выбирает вид раннера: явная настройка либо автоопределение
-	 * по наличию oneunit в локальных зависимостях
+	 *
+	 * auto → oneunit, если он стоит локально (oscript_modules/bin) ИЛИ объявлен
+	 * зависимостью проекта в packagedef (.ЗависитОт/.РазработкаЗависитОт("oneunit")).
+	 * Второй признак ловит случай, когда oneunit установлен глобально (в PATH, не в
+	 * проекте): без него автоопределение молча уступало бы место 1testrunner, и
+	 * oneunit-тесты падали бы на нём с ошибкой компиляции. Иначе — исторический
+	 * дефолт 1testrunner. Глобальный oneunit как команда подхватится из PATH
+	 * (resolveRunner отдаёт голое имя, если локального бинарника нет).
 	 */
 	private resolveRunnerKind(setting: string, workspaceRoot: string | undefined): OneScriptRunner {
 		if (setting === '1testrunner' || setting === 'oneunit') {
 			return setting;
 		}
-		if (this.findLocalRunner('oneunit', workspaceRoot)) {
+		if (
+			this.findLocalRunner('oneunit', workspaceRoot) ||
+			this.packagedefDependsOn('oneunit', workspaceRoot)
+		) {
 			return 'oneunit';
 		}
 		return '1testrunner';
+	}
+
+	/**
+	 * Объявляет ли packagedef проекта зависимость от пакета
+	 *
+	 * Признак «проект использует этот раннер»: например, vanessa-runner объявляет
+	 * .РазработкаЗависитОт("oneunit", ...). Файл packagedef небольшой, читаем
+	 * синхронно (как и проверку локального бинарника).
+	 */
+	private packagedefDependsOn(packageName: string, workspaceRoot: string | undefined): boolean {
+		if (!workspaceRoot) {
+			return false;
+		}
+		try {
+			const content = fsSync.readFileSync(path.join(workspaceRoot, 'packagedef'), 'utf8');
+			return packagedefDeclaresDependency(content, packageName);
+		} catch {
+			// packagedef нет (не oscript-пакет) или не прочитан — признак отсутствует
+			return false;
+		}
 	}
 
 	/**
@@ -170,4 +253,19 @@ export class OneScriptAdapter implements TestFrameworkAdapter {
 		const localPath = path.join(workspaceRoot, 'oscript_modules', 'bin', name);
 		return fsSync.existsSync(localPath) ? localPath : undefined;
 	}
+}
+
+/**
+ * Объявляет ли содержимое packagedef зависимость от пакета
+ *
+ * Совпадает и с `.ЗависитОт("имя", ...)`, и с `.РазработкаЗависитОт("имя", ...)` —
+ * во втором случае искомое `ЗависитОт("имя"` входит подстрокой. Чистая функция
+ * без vscode/fs — покрыта юнит-тестами.
+ *
+ * @param packagedef - Содержимое файла packagedef
+ * @param packageName - Имя пакета (например, 'oneunit')
+ */
+export function packagedefDeclaresDependency(packagedef: string, packageName: string): boolean {
+	const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	return new RegExp(`ЗависитОт\\s*\\(\\s*"${escaped}"`, 'i').test(packagedef);
 }

--- a/src/features/testing/batchRouter.ts
+++ b/src/features/testing/batchRouter.ts
@@ -1,0 +1,152 @@
+import * as path from 'node:path';
+import { JUnitCase } from './parsers/junitParser';
+
+/**
+ * Раскладка кейсов общего jUnit-отчёта по файлам (для батч-прогона)
+ *
+ * При батч-прогоне несколько тестовых файлов исполняются одним процессом и
+ * пишут общий отчёт. Чтобы разложить результаты обратно по узлам-файлам дерева,
+ * каждый testcase нужно сопоставить со своим файлом. Логика вынесена сюда —
+ * чистая, без vscode.*, покрыта юнит-тестами.
+ */
+
+/**
+ * Файл-цель раскладки
+ */
+export interface RoutableFile {
+	/** ID узла-файла в дереве */
+	id: string;
+	/** Абсолютный путь к файлу теста */
+	fsPath: string;
+}
+
+/**
+ * Результат раскладки общего отчёта по файлам
+ */
+export interface RouteOutcome {
+	/** ID узла-файла → его кейсы из общего отчёта */
+	byFile: Map<string, JUnitCase[]>;
+	/** Кейсы, которые не удалось привязать ни к одному файлу */
+	unrouted: JUnitCase[];
+}
+
+interface FileKey {
+	id: string;
+	/** Полный путь в нижнем регистре с прямыми слэшами */
+	pathNorm: string;
+	/** Имя файла (basename) в нижнем регистре */
+	base: string;
+	/** Имя файла без расширения в нижнем регистре (для сопоставления с classname) */
+	stem: string;
+}
+
+/** Приводит путь к сравнимому виду: прямые слэши, без ведущего ./, нижний регистр */
+function normalizePath(value: string): string {
+	// OneUnit пишет file в виде ".\tests\unit\...\X.os" — нормализуем слэши и
+	// ведущий ./ , чтобы хвост пути совпал с абсолютным путём узла-файла
+	return value.replace(/\\/g, '/').replace(/^\.\//, '').toLowerCase();
+}
+
+/**
+ * Заканчивается ли полный путь на относительный «хвост» по границе сегмента
+ *
+ * Граница сегмента отсекает ложные совпадения вида .../mytests.os ≠ tests.os.
+ */
+function endsWithPathSegment(full: string, tail: string): boolean {
+	if (full === tail) {
+		return true;
+	}
+	return full.endsWith(tail) && full[full.length - tail.length - 1] === '/';
+}
+
+/**
+ * Возвращает единственный подходящий файл по предикату либо undefined,
+ * если совпадений нет или они неоднозначны (больше одного)
+ */
+function singleMatch(files: FileKey[], predicate: (file: FileKey) => boolean): FileKey | undefined {
+	let found: FileKey | undefined;
+	for (const file of files) {
+		if (!predicate(file)) {
+			continue;
+		}
+		if (found) {
+			return undefined;
+		}
+		found = file;
+	}
+	return found;
+}
+
+/**
+ * Находит файл для одного testcase по убыванию надёжности признака:
+ * атрибут file (полный путь → имя файла) → classname/suiteName (= имя набора).
+ */
+function matchCase(testCase: JUnitCase, files: FileKey[]): FileKey | undefined {
+	if (testCase.file) {
+		const fileNorm = normalizePath(testCase.file);
+		const byPath = singleMatch(files, (file) => endsWithPathSegment(file.pathNorm, fileNorm));
+		if (byPath) {
+			return byPath;
+		}
+		const fileBase = path.posix.basename(fileNorm);
+		const byBase = singleMatch(files, (file) => file.base === fileBase);
+		if (byBase) {
+			return byBase;
+		}
+	}
+
+	// classname у OneUnit — имя набора (как правило, имя модуля без расширения);
+	// suiteName — запасной источник того же признака
+	for (const suiteKey of [testCase.className, testCase.suiteName]) {
+		const key = suiteKey?.trim().toLowerCase();
+		if (!key) {
+			continue;
+		}
+		const byStem = singleMatch(files, (file) => file.stem === key);
+		if (byStem) {
+			return byStem;
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Раскладывает кейсы общего отчёта по файлам батч-прогона
+ *
+ * @param cases - Кейсы из общего jUnit-отчёта
+ * @param files - Файлы, участвовавшие в батч-прогоне
+ * @returns Кейсы, сгруппированные по ID файла, и непривязанные кейсы
+ */
+export function routeReportCases(cases: JUnitCase[], files: RoutableFile[]): RouteOutcome {
+	const keys: FileKey[] = files.map((file) => {
+		const pathNorm = normalizePath(file.fsPath);
+		const base = path.posix.basename(pathNorm);
+		const ext = path.posix.extname(base);
+		return {
+			id: file.id,
+			pathNorm,
+			base,
+			stem: ext.length > 0 ? base.slice(0, -ext.length) : base
+		};
+	});
+
+	const byFile = new Map<string, JUnitCase[]>();
+	const unrouted: JUnitCase[] = [];
+
+	for (const testCase of cases) {
+		const match = matchCase(testCase, keys);
+		if (!match) {
+			unrouted.push(testCase);
+			continue;
+		}
+		const bucket = byFile.get(match.id);
+		if (bucket) {
+			bucket.push(testCase);
+		} else {
+			byFile.set(match.id, [testCase]);
+		}
+	}
+
+	return { byFile, unrouted };
+}

--- a/src/features/testing/frameworkAdapter.ts
+++ b/src/features/testing/frameworkAdapter.ts
@@ -147,4 +147,21 @@ export interface TestFrameworkAdapter {
 	 * @returns План запуска
 	 */
 	buildRunPlan(unit: RunUnit, reportDir: string): Promise<AdapterRunPlan>;
+
+	/**
+	 * Строит план батч-прогона: несколько файлов одним процессом, общий отчёт
+	 *
+	 * Реализуется адаптерами, чей раннер умеет прогнать несколько файлов за один
+	 * запуск (OneScript/OneUnit). Контроллер вызывает метод, когда запрошено ≥2
+	 * полнофайловых единиц этого адаптера (без подмножества кейсов), и раскладывает
+	 * общий отчёт обратно по файлам (по атрибуту file/classname кейса).
+	 *
+	 * Возврат undefined означает «батч в текущей конфигурации недоступен»
+	 * (например, выбран другой раннер) — контроллер прогонит файлы поштучно.
+	 *
+	 * @param units - Полнофайловые единицы запуска (caseNames не заданы)
+	 * @param reportDir - Каталог отчёта прогона (пустая строка, если usesReportDir === false)
+	 * @returns План батч-прогона либо undefined
+	 */
+	buildBatchRunPlan?(units: RunUnit[], reportDir: string): Promise<AdapterRunPlan | undefined>;
 }

--- a/src/features/testing/parsers/junitParser.ts
+++ b/src/features/testing/parsers/junitParser.ts
@@ -20,6 +20,8 @@ export interface JUnitCase {
 	className: string;
 	/** Атрибут name testcase */
 	name: string;
+	/** Атрибут file testcase (путь к файлу теста; OneUnit его проставляет) */
+	file?: string;
 	/** Статус по дочерним элементам */
 	status: 'passed' | 'failed' | 'error' | 'skipped';
 	/** Длительность в миллисекундах */
@@ -84,7 +86,11 @@ function parseTimeMs(time: unknown): number | undefined {
 /**
  * Разбирает один testcase
  */
-function parseTestCase(testcase: Record<string, unknown>, suiteName: string): JUnitCase {
+function parseTestCase(
+	testcase: Record<string, unknown>,
+	suiteName: string,
+	suiteFile: string | undefined
+): JUnitCase {
 	const failures = toArray(testcase['failure']);
 	const errors = toArray(testcase['error']);
 	const skipped = toArray(testcase['skipped']);
@@ -115,10 +121,12 @@ function parseTestCase(testcase: Record<string, unknown>, suiteName: string): JU
 	const { message, details } = extractFailureInfo(failureNode);
 	const diff = extractExpectedActual(message, details);
 
+	const file = typeof testcase['@_file'] === 'string' ? testcase['@_file'] : suiteFile;
 	return {
 		suiteName,
 		className: typeof testcase['@_classname'] === 'string' ? testcase['@_classname'] : '',
 		name: typeof testcase['@_name'] === 'string' ? testcase['@_name'] : String(testcase['@_name'] ?? ''),
+		file: file && file.length > 0 ? file : undefined,
 		status,
 		timeMs: parseTimeMs(testcase['@_time']),
 		message,
@@ -133,10 +141,12 @@ function parseTestCase(testcase: Record<string, unknown>, suiteName: string): JU
  */
 function collectFromSuite(suite: Record<string, unknown>, results: JUnitCase[]): void {
 	const suiteName = typeof suite['@_name'] === 'string' ? suite['@_name'] : '';
+	// file наследуется кейсами набора, если у самого testcase атрибута нет
+	const suiteFile = typeof suite['@_file'] === 'string' ? suite['@_file'] : undefined;
 
 	for (const testcase of toArray(suite['testcase'])) {
 		if (testcase && typeof testcase === 'object') {
-			results.push(parseTestCase(testcase as Record<string, unknown>, suiteName));
+			results.push(parseTestCase(testcase as Record<string, unknown>, suiteName, suiteFile));
 		}
 	}
 

--- a/src/features/testing/testController.ts
+++ b/src/features/testing/testController.ts
@@ -20,6 +20,7 @@ import { parseJUnitXml, JUnitCase } from './parsers/junitParser';
 import { parseCucumberJson } from './parsers/cucumberParser';
 import { ReportTarget } from './projectTestConfig';
 import { RunQueue } from './runQueue';
+import { routeReportCases, RoutableFile } from './batchRouter';
 import { DEFAULT_TESTING } from '../../shared/pathDefaults';
 
 const log = logger.scope('testing');
@@ -71,6 +72,25 @@ function missingRunnerHint(result: { stdout: string; stderr: string; exitCode: n
 		'\nПохоже, раннер тестов не найден. Установите зависимости проекта ' +
 		'(команда «Установить зависимости» или opm install --dev -l) ' +
 		'либо укажите путь к раннеру в настройках testing.*Path.'
+	);
+}
+
+/**
+ * Подсказка при падении прогона из-за неустановленных зависимостей проекта
+ *
+ * oscript-раннер не находит библиотеку, которую #Использует тест, если
+ * зависимости проекта не установлены — сообщение раннера «Библиотека не найдена:
+ * 'irac'». Это общая проблема прогона (затрагивает все файлы), а не конкретного теста.
+ */
+function missingDependencyHint(result: { stdout: string; stderr: string }): string {
+	const match = /Библиотека не найдена:?\s*['"«]?([\wа-яёА-ЯЁ.\-]+)/i.exec(result.stdout + result.stderr);
+	if (!match) {
+		return '';
+	}
+	return (
+		`\nНе найдена библиотека «${match[1]}», которую используют тесты — ` +
+		'похоже, зависимости проекта не установлены. Выполните «Установить зависимости» ' +
+		'(opm install --dev -l) и повторите прогон.'
 	);
 }
 
@@ -586,12 +606,7 @@ export class TestingController implements vscode.Disposable {
 
 			await this.queue.enqueue(async () => {
 				try {
-					for (const unit of units) {
-						if (token.isCancellationRequested) {
-							break;
-						}
-						await this.runUnit(run, unit, token);
-					}
+					await this.runUnits(run, units, token);
 				} finally {
 					run.end();
 				}
@@ -600,6 +615,220 @@ export class TestingController implements vscode.Disposable {
 			this.activeRuns -= 1;
 			this.flushPendingRebuild();
 		}
+	}
+
+	/**
+	 * Выполняет единицы запроса: батчит полнофайловые прогоны адаптеров,
+	 * умеющих прогнать несколько файлов одним процессом, остальное — поштучно
+	 *
+	 * Батч (один холодный старт раннера вместо N) применяется к ≥2 полнофайловым
+	 * единицам одного адаптера без подмножества кейсов. Группируем по каталогу:
+	 * файлы одной папки совместимы в одном процессе, а разнородные категории
+	 * (например, unit и e2e) не валят друг друга конфликтом регистрации наборов.
+	 * Прогон подмножества кейсов и адаптеры без батча идут прежним поштучным путём.
+	 * Если адаптер вернул undefined-план (батч недоступен) или батч не дал отчёта,
+	 * файлы группы прогоняются поштучно.
+	 */
+	private async runUnits(
+		run: vscode.TestRun,
+		units: { entry: FileEntry; caseNames?: string[] }[],
+		token: vscode.CancellationToken
+	): Promise<void> {
+		const batches = new Map<string, { entry: FileEntry; caseNames?: string[] }[]>();
+		const individual: { entry: FileEntry; caseNames?: string[] }[] = [];
+
+		for (const unit of units) {
+			const uri = unit.entry.item.uri;
+			if (!unit.caseNames && unit.entry.adapter.buildBatchRunPlan && uri) {
+				const key = `${unit.entry.adapter.id} ${path.dirname(uri.fsPath)}`;
+				const group = batches.get(key);
+				if (group) {
+					group.push(unit);
+				} else {
+					batches.set(key, [unit]);
+				}
+			} else {
+				individual.push(unit);
+			}
+		}
+
+		for (const group of batches.values()) {
+			if (token.isCancellationRequested) {
+				return;
+			}
+			// Один файл проще и не дешевле прогнать обычным путём (без раскладки общего отчёта)
+			if (group.length < 2 || !(await this.runBatch(run, group, token))) {
+				individual.push(...group);
+			}
+		}
+
+		for (const unit of individual) {
+			if (token.isCancellationRequested) {
+				break;
+			}
+			await this.runUnit(run, unit, token);
+		}
+	}
+
+	/**
+	 * Прогоняет несколько файлов одним процессом и раскладывает общий отчёт по файлам
+	 *
+	 * @returns true — батч обработан (исполнен или размечен ошибкой); false — батч
+	 *          в текущей конфигурации недоступен, файлы нужно прогнать поштучно
+	 */
+	private async runBatch(
+		run: vscode.TestRun,
+		units: { entry: FileEntry; caseNames?: string[] }[],
+		token: vscode.CancellationToken
+	): Promise<boolean> {
+		const adapter = units[0].entry.adapter;
+		const entries = units.map((unit) => unit.entry);
+		const allLeaves = entries.flatMap((entry) => this.leafItems(entry.item));
+
+		const runUnits: RunUnit[] = [];
+		for (const entry of entries) {
+			if (!entry.item.uri) {
+				this.markAll(run, allLeaves, 'errored', 'У элемента теста нет привязанного файла');
+				return true;
+			}
+			runUnits.push({ fileUri: entry.item.uri });
+		}
+
+		let reportDir = '';
+		if (adapter.usesReportDir !== false) {
+			const created = await this.createReportDir(adapter.id);
+			if (!created) {
+				this.markAll(run, allLeaves, 'errored', 'Не удалось создать каталог отчёта прогона');
+				return true;
+			}
+			reportDir = created;
+		}
+
+		let plan: AdapterRunPlan | undefined;
+		let result: CancellableProcessResult;
+		try {
+			plan = await adapter.buildBatchRunPlan!(runUnits, reportDir);
+			if (!plan) {
+				await this.cleanupReportDir(reportDir);
+				return false;
+			}
+
+			if (plan.reportTarget) {
+				await this.clearReportTarget(plan.reportTarget);
+			}
+
+			// Вывод общий (один процесс на все файлы) — привязываем к прогону, не к узлу
+			const onOutput = (chunk: string) => run.appendOutput(chunk.replaceAll(/(?<!\r)\n/g, '\r\n'));
+			run.appendOutput(`\r\n=== ${adapter.label}: батч-прогон (${entries.length} файлов) ===\r\n`);
+
+			for (const item of allLeaves) {
+				run.started(item);
+			}
+
+			for (const step of plan.prepare ?? []) {
+				if (token.isCancellationRequested) {
+					await this.cleanupReportDir(reportDir);
+					return true;
+				}
+				run.appendOutput(`\r\n--- ${step.title} ---\r\n`);
+				const stepResult = await this.executeStep(step.tool, step.args, plan.env, token, onOutput);
+				if (stepResult.cancelled) {
+					await this.cleanupReportDir(reportDir);
+					return true;
+				}
+				if (!stepResult.success) {
+					const tail = (stepResult.stdout + '\n' + stepResult.stderr).slice(-ERROR_OUTPUT_TAIL_LENGTH);
+					this.markAll(
+						run,
+						allLeaves,
+						'errored',
+						`Шаг «${step.title}» завершился с кодом ${stepResult.exitCode}.\n${tail}`
+					);
+					await this.cleanupReportDir(reportDir);
+					return true;
+				}
+			}
+
+			result = await this.executeStep(plan.tool, plan.args, plan.env, token, onOutput);
+		} catch (error) {
+			this.markAll(run, allLeaves, 'errored', `Ошибка запуска: ${(error as Error).message}`);
+			await this.cleanupReportDir(reportDir);
+			return true;
+		}
+
+		if (result.cancelled) {
+			await this.cleanupReportDir(reportDir);
+			return true;
+		}
+
+		const target: ReportTarget = plan.reportTarget ?? { format: 'junit', path: reportDir };
+		let junitCases = await this.readReports(target);
+		if (junitCases && adapter.transformReportCases) {
+			junitCases = adapter.transformReportCases(junitCases);
+		}
+
+		if (junitCases === undefined || junitCases.length === 0) {
+			const tail = (result.stdout + '\n' + result.stderr).slice(-ERROR_OUTPUT_TAIL_LENGTH);
+			const runnerHint = missingRunnerHint(result);
+			const depHint = missingDependencyHint(result);
+
+			// Раннер не найден или не установлены зависимости — это общая проблема всех
+			// файлов, поштучный прогон её не вылечит. Помечаем ошибкой с подсказкой,
+			// не плодя бесполезные повторные запуски.
+			if (runnerHint || depHint) {
+				const planHint = plan.noReportHint ? `\n${plan.noReportHint}` : '';
+				this.markAll(
+					run,
+					allLeaves,
+					'errored',
+					`Батч-прогон завершился без jUnit-отчёта (код возврата ${result.exitCode}).` +
+						`${planHint}${runnerHint}${depHint}\n${tail}`
+				);
+				await this.cleanupReportDir(reportDir);
+				return true;
+			}
+
+			// Иначе вероятен сбой одного файла или конфликт (двойная регистрация набора):
+			// откатываемся на поштучный прогон — он изолирует сбойный файл, остальные
+			// дадут результат (поведение прежней версии). Узлы остаются enqueued/started —
+			// runUnit проставит им финальный статус.
+			log.warn(
+				`Батч-прогон ${adapter.label} без jUnit-отчёта (код ${result.exitCode}) — откат на поштучный прогон`
+			);
+			run.appendOutput(
+				`\r\n[батч] прогон одним процессом не дал отчёта (код ${result.exitCode}) — повторяю по файлам\r\n` +
+					`${tail.replaceAll(/(?<!\r)\n/g, '\r\n')}\r\n`
+			);
+			await this.cleanupReportDir(reportDir);
+			return false;
+		}
+
+		// Раскладываем общий отчёт по файлам (по атрибуту file/classname кейса)
+		const routable: RoutableFile[] = entries.map((entry) => ({
+			id: entry.item.id,
+			fsPath: entry.item.uri!.fsPath
+		}));
+		const { byFile, unrouted } = routeReportCases(junitCases, routable);
+
+		for (const entry of entries) {
+			const cases = byFile.get(entry.item.id);
+			// Раскладка не дала кейсов файлу (нестандартный формат отчёта) — запасной путь:
+			// применяем весь отчёт по совпадению имён, чтобы не пометить пройденный файл
+			// ошибкой; в обычном случае сюда приходят только свои кейсы файла
+			this.applyResults(run, entry, cases && cases.length > 0 ? cases : junitCases);
+		}
+
+		// unrouted логируем только если он не «съест» весь отчёт запасным путём выше
+		if (byFile.size > 0) {
+			for (const orphan of unrouted) {
+				run.appendOutput(
+					`\r\n[предупреждение] testcase «${orphan.name}» (${orphan.status}) не сопоставлен ни с одним файлом\r\n`
+				);
+			}
+		}
+
+		await this.cleanupReportDir(reportDir);
+		return true;
 	}
 
 	/**
@@ -813,7 +1042,7 @@ export class TestingController implements vscode.Disposable {
 				leaves,
 				'errored',
 				`Прогон завершился без jUnit-отчёта (код возврата ${result.exitCode}).` +
-					`${planHint}${missingRunnerHint(result)}\n${tail}`
+					`${planHint}${missingRunnerHint(result)}${missingDependencyHint(result)}\n${tail}`
 			);
 			await this.cleanupReportDir(reportDir);
 			return;

--- a/src/shared/vrunnerManager.ts
+++ b/src/shared/vrunnerManager.ts
@@ -1321,7 +1321,7 @@ export class VRunnerManager {
 	 * Создает терминал и выполняет команду opm (OneScript Package Manager).
 	 * Используется для установки и управления зависимостями проекта.
 	 *
-	 * @param args - Аргументы команды opm (например, ['install', '-l'])
+	 * @param args - Аргументы команды opm (например, ['install', '--dev', '-l'])
 	 * @param options - Опции выполнения
 	 * @param options.cwd - Рабочая директория (по умолчанию workspace root)
 	 * @param options.name - Имя терминала (по умолчанию '1C: Platform Tools')

--- a/src/test/testing/batchRouter.test.ts
+++ b/src/test/testing/batchRouter.test.ts
@@ -1,0 +1,94 @@
+import * as assert from 'node:assert';
+import { routeReportCases } from '../../features/testing/batchRouter';
+import { JUnitCase } from '../../features/testing/parsers/junitParser';
+
+function makeCase(partial: Partial<JUnitCase> & { name: string }): JUnitCase {
+	return {
+		suiteName: '',
+		className: '',
+		status: 'passed',
+		...partial
+	};
+}
+
+suite('batchRouter', () => {
+	const files = [
+		{ id: 'a', fsPath: 'C:\\proj\\tests\\unit\\Сервисы\\ТестСервисEDT.os' },
+		{ id: 'b', fsPath: 'C:\\proj\\tests\\unit\\Движки\\ТестДвижокIbCmd.os' }
+	];
+
+	test('раскладывает по относительному пути в атрибуте file', () => {
+		const cases = [
+			makeCase({ name: 'Тест1', file: 'tests/unit/Сервисы/ТестСервисEDT.os' }),
+			makeCase({ name: 'Тест2', file: 'tests/unit/Движки/ТестДвижокIbCmd.os' })
+		];
+
+		const { byFile, unrouted } = routeReportCases(cases, files);
+		assert.strictEqual(unrouted.length, 0);
+		assert.deepStrictEqual(byFile.get('a')?.map((c) => c.name), ['Тест1']);
+		assert.deepStrictEqual(byFile.get('b')?.map((c) => c.name), ['Тест2']);
+	});
+
+	test('раскладывает по реальному формату OneUnit (.\\tests\\...)', () => {
+		// Точный вид атрибута file из отчёта oneunit 0.3.3
+		const cases = [makeCase({ name: 'Тест1', file: '.\\tests\\unit\\Сервисы\\ТестСервисEDT.os', className: 'ТестСервисEDT' })];
+
+		const { byFile, unrouted } = routeReportCases(cases, files);
+		assert.strictEqual(unrouted.length, 0);
+		assert.deepStrictEqual(byFile.get('a')?.map((c) => c.name), ['Тест1']);
+	});
+
+	test('раскладывает по абсолютному пути с обратными слэшами', () => {
+		const cases = [makeCase({ name: 'Тест1', file: 'C:\\proj\\tests\\unit\\Сервисы\\ТестСервисEDT.os' })];
+
+		const { byFile } = routeReportCases(cases, files);
+		assert.deepStrictEqual(byFile.get('a')?.map((c) => c.name), ['Тест1']);
+	});
+
+	test('группирует несколько кейсов одного файла', () => {
+		const cases = [
+			makeCase({ name: 'Тест1', file: 'tests/unit/Сервисы/ТестСервисEDT.os' }),
+			makeCase({ name: 'Тест2', file: 'tests/unit/Сервисы/ТестСервисEDT.os' })
+		];
+
+		const { byFile } = routeReportCases(cases, files);
+		assert.deepStrictEqual(byFile.get('a')?.map((c) => c.name), ['Тест1', 'Тест2']);
+	});
+
+	test('запасной признак — classname по имени модуля без расширения', () => {
+		const cases = [makeCase({ name: 'Тест1', className: 'ТестСервисEDT' })];
+
+		const { byFile, unrouted } = routeReportCases(cases, files);
+		assert.strictEqual(unrouted.length, 0);
+		assert.deepStrictEqual(byFile.get('a')?.map((c) => c.name), ['Тест1']);
+	});
+
+	test('кейс без признаков файла попадает в unrouted', () => {
+		const cases = [makeCase({ name: 'Сирота', file: 'tests/unit/Прочее/Неизвестный.os' })];
+
+		const { byFile, unrouted } = routeReportCases(cases, files);
+		assert.strictEqual(byFile.size, 0);
+		assert.deepStrictEqual(unrouted.map((c) => c.name), ['Сирота']);
+	});
+
+	test('совпадение по имени файла не цепляет «хвостовой» файл', () => {
+		// tests.os не должен сматчиться на mytests.os (граница сегмента)
+		const onlyFiles = [{ id: 'x', fsPath: 'C:\\proj\\tests\\mytests.os' }];
+		const cases = [makeCase({ name: 'Т', file: 'tests.os' })];
+
+		const { unrouted } = routeReportCases(cases, onlyFiles);
+		assert.strictEqual(unrouted.length, 1, 'tests.os не привязан к mytests.os');
+	});
+
+	test('неоднозначный basename разводится по полному пути', () => {
+		const dupFiles = [
+			{ id: 'u', fsPath: 'C:\\proj\\tests\\unit\\Общий.os' },
+			{ id: 'e', fsPath: 'C:\\proj\\tests\\e2e\\Общий.os' }
+		];
+		const cases = [makeCase({ name: 'Т', file: 'tests/e2e/Общий.os' })];
+
+		const { byFile } = routeReportCases(cases, dupFiles);
+		assert.deepStrictEqual(byFile.get('e')?.map((c) => c.name), ['Т']);
+		assert.strictEqual(byFile.has('u'), false);
+	});
+});

--- a/src/test/testing/junitParser.test.ts
+++ b/src/test/testing/junitParser.test.ts
@@ -104,6 +104,18 @@ suite('junitParser', () => {
 		assert.deepStrictEqual(parseJUnitXml('<testsuite name="Пусто"/>'), []);
 	});
 
+	test('читает атрибут file у testcase и наследует его у набора', () => {
+		const xml = `<testsuites>
+	<testsuite name="Набор" file="tests/Набор.os">
+		<testcase name="Свой" file="tests/Свой.os"/>
+		<testcase name="Унаследованный"/>
+	</testsuite>
+</testsuites>`;
+		const cases = parseJUnitXml(xml);
+		assert.strictEqual(cases[0].file, 'tests/Свой.os', 'берётся file самого testcase');
+		assert.strictEqual(cases[1].file, 'tests/Набор.os', 'наследуется file набора');
+	});
+
 	test('XML без testsuite вызывает ошибку', () => {
 		assert.throws(() => parseJUnitXml('<root/>'), /testsuites\/testsuite/);
 	});

--- a/src/test/testing/onescriptAdapter.test.ts
+++ b/src/test/testing/onescriptAdapter.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert';
 import * as vscode from 'vscode';
 import { VRunnerManager } from '../../shared/vrunnerManager';
-import { OneScriptAdapter } from '../../features/testing/adapters/onescriptAdapter';
+import { OneScriptAdapter, packagedefDeclaresDependency } from '../../features/testing/adapters/onescriptAdapter';
 
 suite('onescriptAdapter', () => {
 	const fileUri = vscode.Uri.file('C:\\proj\\tests os\\test_example.os');
@@ -44,6 +44,49 @@ suite('onescriptAdapter', () => {
 			plan.reportTarget?.path.endsWith('test_example.os.xml'),
 			'Отчёт по имени файла теста'
 		);
+	});
+
+	test('isTestFile: тестовый модуль — да, хелпер без тестов — нет', () => {
+		const adapter = new OneScriptAdapter(VRunnerManager.getInstance());
+		const testModule = [
+			'Функция ИсполняемыеСценарии() Экспорт',
+			'КонецФункции',
+			'Процедура Тест_Один() Экспорт',
+			'КонецПроцедуры'
+		].join('\n');
+		// Хелпер/билдер из utils/: экспортные методы есть, но нет ни ИсполняемыеСценарии,
+		// ни &Тест — в дереве тестов ему не место
+		const helper = [
+			'Функция Построить() Экспорт',
+			'	Возврат Новый Структура;',
+			'КонецФункции'
+		].join('\n');
+
+		assert.strictEqual(adapter.isTestFile(testModule), true);
+		assert.strictEqual(adapter.isTestFile('&Тест\nПроцедура Т() Экспорт\nКонецПроцедуры'), true);
+		assert.strictEqual(adapter.isTestFile(helper), false);
+	});
+
+	test('packagedefDeclaresDependency: ловит ЗависитОт и РазработкаЗависитОт', () => {
+		const packagedef = [
+			'Пакет',
+			'	.Имя("проект")',
+			'	.ЗависитОт("irac", "1.4.0")',
+			'	.РазработкаЗависитОт("oneunit", "0.3.3")',
+			';'
+		].join('\n');
+
+		assert.strictEqual(packagedefDeclaresDependency(packagedef, 'oneunit'), true, 'РазработкаЗависитОт');
+		assert.strictEqual(packagedefDeclaresDependency(packagedef, 'irac'), true, 'ЗависитОт');
+		assert.strictEqual(packagedefDeclaresDependency(packagedef, '1testrunner'), false, 'не объявлен');
+	});
+
+	test('buildBatchRunPlan: для 1testrunner батч недоступен (undefined)', async () => {
+		// В тестовом окружении (без локального oneunit) раннер — 1testrunner,
+		// батч им не поддержан: контроллер прогонит файлы поштучно
+		const adapter = new OneScriptAdapter(VRunnerManager.getInstance());
+		const plan = await adapter.buildBatchRunPlan([{ fileUri }], 'C:\\proj\\build\\report');
+		assert.strictEqual(plan, undefined);
 	});
 
 	test('parseFile распознаёт xdd-структуру и аннотации', () => {


### PR DESCRIPTION
## Что

Оптимизация и исправления панели тестирования OneScript (по обратной связи о медленном прогоне и «тестах» в каталоге `utils`).

## Изменения

- **Discovery**: `.os` без тестовых маркеров (хелперы и фикстуры, например в `tests/unit/utils/`) больше не попадают ни в дерево тестов, ни в прогон (`OneScriptAdapter.isTestFile`). Раньше они засоряли панель и «прогонялись» как тесты, падая без отчёта.
- **Батч-прогон**: oneunit запускает несколько файлов одним процессом, сгруппированными по каталогу, вместо процесса на файл (один холодный старт раннера вместо N).
  - Если общий отчёт не получен из-за сбоя одного файла или конфликта регистрации наборов — откат на поштучный прогон, он изолирует сбойный файл.
  - Если отчёта нет из-за общей причины (раннер или библиотека не найдены) — откат не делается, выводится подсказка.
  - Результаты общего отчёта раскладываются по файлам через атрибут `file` (новый модуль `batchRouter`).
- **Выбор раннера**: автодетект oneunit срабатывает и когда он объявлен в `packagedef` (`РазработкаЗависитОт`), а не только при наличии локального бинарника. Глобально установленный oneunit больше не уступает молча место 1testrunner.
- **Установка зависимостей**: команда «Установить зависимости» ставит и dev-зависимости (`opm install --dev -l`), иначе раннеры тестов (oneunit, asserts) не устанавливались.
- **Диагностика**: при сообщении раннера «Библиотека не найдена» к ошибке прогона добавляется подсказка, что зависимости проекта не установлены.

## Проверка

- `tsc`, `eslint` — чисто; юнит-тесты — 331 passing (новые: `batchRouter`, парсинг атрибута `file`, `isTestFile`, `packagedefDeclaresDependency`).
- Раскладка отчёта и формат вывода oneunit проверены на живом репозитории vanessa-runner (oneunit 0.3.3): атрибут `file` присутствует и при абсолютных путях остаётся раскладываемым.

## Вне scope

- Прогон e2e-тестов из панели требует предварительной сборки `.epf` (отдельный шаг, который делает таск проекта, а не oneunit) — поддержка e2e не входит в этот PR.
