### PR TITLE
fix(deps): находим oscript/opm из установки OVM, когда их нет в PATH

### DIFF
--- a/src/commands/dependenciesCommands.ts
+++ b/src/commands/dependenciesCommands.ts
@@ -13,6 +13,7 @@ import {
 import { logger } from '../shared/logger';
 import { notifyProjectCreated } from '../shared/projectContext';
 import { PROJECT_STRUCTURE } from '../shared/projectStructure';
+import { getOvmBinaryPath } from '../shared/ovmPaths';
 
 const log = logger.scope('commands');
 
@@ -124,10 +125,7 @@ async function getOscriptVersionFromPackagedef(workspaceRoot: string): Promise<O
  * Возвращает путь к oscript в каталоге OVM и его текущее время модификации (или 0, если файла нет).
  */
 function getOvmOscriptPathAndMtime(): { path: string; mtimeMs: number } {
-	const oscriptPath =
-		process.platform === 'win32'
-			? path.join(process.env.LOCALAPPDATA || '', 'ovm', 'current', 'bin', 'oscript.exe')
-			: path.join(os.homedir(), '.local', 'share', 'ovm', 'current', 'bin', 'oscript');
+	const oscriptPath = getOvmBinaryPath('oscript');
 	let mtimeMs = 0;
 	try {
 		const stat = fsSync.statSync(oscriptPath);

--- a/src/shared/ovmPaths.ts
+++ b/src/shared/ovmPaths.ts
@@ -1,0 +1,35 @@
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+/**
+ * Пути к инструментам OneScript, установленным через OVM (OneScript Version Manager).
+ *
+ * OVM ставит активную версию в каталог `current/bin`, где `current` — симлинк на
+ * выбранную версию (меняется командой `ovm use`). Расположение детерминировано и
+ * не зависит от PATH, поэтому используется как запасной источник, когда бинарь не
+ * найден в PATH (типично для VS Code, запущенного из GUI, который не наследует
+ * PATH интерактивной оболочки).
+ */
+
+/**
+ * Каталог bin активной версии OneScript из установки OVM.
+ *
+ * @returns Абсолютный путь к каталогу bin OVM
+ */
+export function getOvmBinDir(): string {
+	return process.platform === 'win32'
+		? path.join(process.env.LOCALAPPDATA || '', 'ovm', 'current', 'bin')
+		: path.join(os.homedir(), '.local', 'share', 'ovm', 'current', 'bin');
+}
+
+/**
+ * Полный путь к бинарю инструмента OneScript (oscript, opm и т. п.) в установке OVM.
+ * На Windows добавляется расширение `.exe`.
+ *
+ * @param name - Имя инструмента без расширения (например, 'oscript')
+ * @returns Абсолютный путь к исполняемому файлу в каталоге bin OVM
+ */
+export function getOvmBinaryPath(name: string): string {
+	const binary = process.platform === 'win32' ? `${name}.exe` : name;
+	return path.join(getOvmBinDir(), binary);
+}

--- a/src/shared/vrunnerManager.ts
+++ b/src/shared/vrunnerManager.ts
@@ -18,6 +18,7 @@ import {
 import { logger } from './logger';
 import { runCancellableCommand, CancellableProcessResult } from './cancellableProcess';
 import { DEFAULT_PATHS, DEFAULT_VRUNNER, DEFAULT_ENV } from './pathDefaults';
+import { getOvmBinaryPath } from './ovmPaths';
 import {
 	ACTIVE_ENV_PROFILE_KEY,
 	ACTIVE_ENV_OVERRIDES_KEY,
@@ -94,6 +95,14 @@ export class VRunnerManager {
 	 * undefined — ещё не определяли; null — определить не удалось.
 	 */
 	private vrunnerVersionCache: VRunnerVersion | null | undefined = undefined;
+	/**
+	 * Разрешённый путь к oscript: имя для PATH, абсолютный путь установки OVM или
+	 * undefined, пока проверка не выполнялась. Обновляется в checkOscriptAvailable
+	 * и используется синхронными getOnescriptPath/исполнением.
+	 */
+	private resolvedOscriptPath: string | undefined = undefined;
+	/** Разрешённый путь к opm (по той же схеме, что и resolvedOscriptPath). */
+	private resolvedOpmPath: string | undefined = undefined;
 
 	/** Событие смены активного env-профиля (id в workspaceState) */
 	private readonly _onDidChangeActiveEnvProfile = new vscode.EventEmitter<void>();
@@ -177,10 +186,13 @@ export class VRunnerManager {
 	/**
 	 * Получает путь к opm (OneScript Package Manager)
 	 *
-	 * @returns Имя команды для поиска в PATH
+	 * Возвращает путь, разрешённый последней проверкой checkOpmAvailable (имя для
+	 * PATH или абсолютный путь установки OVM). До первой проверки — имя 'opm'.
+	 *
+	 * @returns Имя команды для PATH или абсолютный путь к opm
 	 */
 	private getOpmPath(): string {
-		return 'opm';
+		return this.resolvedOpmPath ?? 'opm';
 	}
 
 	/**
@@ -333,21 +345,51 @@ export class VRunnerManager {
 	}
 
 	/**
-	 * Проверяет, доступны ли oscript и opm (по настройкам путей или PATH).
+	 * Проверяет, доступен ли oscript: сначала в PATH, затем в установке OVM.
 	 *
-	 * @returns Промис, который разрешается true, если обе утилиты доступны, иначе false
+	 * Найденный путь запоминается и используется при последующем выполнении,
+	 * чтобы детекция и реальный запуск работали с одним и тем же бинарём.
+	 *
+	 * @returns Промис, который разрешается true, если oscript доступен, иначе false
 	 */
 	public async checkOscriptAvailable(): Promise<boolean> {
-		return this.runCommandForCheck(this.getOnescriptPath(), ['-version']);
+		this.resolvedOscriptPath = await this.resolveBinaryPath('oscript', '-version');
+		return this.resolvedOscriptPath !== undefined;
 	}
 
 	/**
-	 * Проверяет, доступен ли opm (по настройкам путей или PATH).
+	 * Проверяет, доступен ли opm: сначала в PATH, затем в установке OVM.
 	 *
 	 * @returns Промис, который разрешается true, если opm доступен, иначе false
 	 */
 	public async checkOpmAvailable(): Promise<boolean> {
-		return this.runCommandForCheck(this.getOpmPath(), ['--version']);
+		this.resolvedOpmPath = await this.resolveBinaryPath('opm', '--version');
+		return this.resolvedOpmPath !== undefined;
+	}
+
+	/**
+	 * Разрешает исполняемый путь инструмента OneScript.
+	 *
+	 * Порядок: имя в PATH (нативная установка или настроенный PATH), затем
+	 * известный путь установки OVM. Путь OVM детерминирован, поэтому отдельная
+	 * настройка не нужна. Возвращает рабочий путь или undefined, если бинарь
+	 * недоступен ни одним способом.
+	 *
+	 * @param name - Имя бинаря (oscript/opm)
+	 * @param versionArg - Аргумент проверки версии (-version / --version)
+	 * @returns Имя для PATH, абсолютный путь OVM или undefined
+	 */
+	private async resolveBinaryPath(name: string, versionArg: string): Promise<string | undefined> {
+		if (await this.runCommandForCheck(name, [versionArg])) {
+			return name;
+		}
+		const ovmPath = getOvmBinaryPath(name);
+		if (fsSync.existsSync(ovmPath) && await this.runCommandForCheck(ovmPath, [versionArg])) {
+			log.info(`${name} не найден в PATH, используется установка OVM: ${ovmPath}`);
+			return ovmPath;
+		}
+		log.warn(`${name} не найден ни в PATH, ни в установке OVM: ${ovmPath}`);
+		return undefined;
 	}
 
 	/**
@@ -696,10 +738,13 @@ export class VRunnerManager {
 	/**
 	 * Получает путь к OneScript
 	 *
-	 * @returns Имя команды для поиска в PATH
+	 * Возвращает путь, разрешённый последней проверкой checkOscriptAvailable (имя
+	 * для PATH или абсолютный путь установки OVM). До первой проверки — имя 'oscript'.
+	 *
+	 * @returns Имя команды для PATH или абсолютный путь к oscript
 	 */
 	private getOnescriptPath(): string {
-		return 'oscript';
+		return this.resolvedOscriptPath ?? 'oscript';
 	}
 
 	/**


### PR DESCRIPTION
## Проблема

При запуске любого инструмента 1С — ошибка «OneScript не найден» с предложением установить, хотя OneScript установлен через OVM в `~/.local/share/ovm/current/bin`.

Причина: детекция (`checkOscriptAvailable`/`checkOpmAvailable`) запускала `oscript`/`opm` только по имени из PATH. VS Code, запущенный из GUI (иконка/меню приложений), не наследует PATH интерактивной оболочки, куда OVM прописывает свой `bin`. Поэтому `exec('oscript -version')` падал с ENOENT, и срабатывал гейт «OneScript не найден».

Дополнительно: указание пути через `language-1c-bsl.onescriptPath` не помогало — это настройка **другого** расширения (`xDrivenDevelopment.language-1c-bsl`), наше её не читает. А неуспех детекции нигде не логировался («в логах ошибки нет»).

## Решение

Путь к oscript/opm разрешается по схеме **«сначала PATH, затем известный путь установки OVM»**. Путь OVM детерминирован (`current` — симлинк на активную версию, меняется через `ovm use`), поэтому отдельная настройка не нужна — расширение и так строит этот путь для отслеживания установки.

- Новый общий модуль `src/shared/ovmPaths.ts` — единый источник путей OVM (`getOvmBinDir`/`getOvmBinaryPath`), переиспользован в `dependenciesCommands`.
- `checkOscriptAvailable`/`checkOpmAvailable` пробуют PATH, затем путь OVM; найденный путь кэшируется и используется при реальном запуске, чтобы детекция и исполнение работали с одним бинарём.
- Неуспех детекции пишется в лог (`log.info` при использовании OVM-пути, `log.warn` если бинарь не найден нигде).

## Покрытие случаев

- Нативная установка (deb/msi) или настроенный PATH → работает как раньше (PATH).
- OVM + запуск VS Code из GUI → теперь находим бинарь по пути OVM (случай из issue).
- Произвольная установка мимо PATH и мимо OVM → стандартный механизм PATH (добавить каталог в PATH самостоятельно); отдельная настройка пути сознательно не вводится (YAGNI).

## Проверка

- `npx tsc --noEmit` — без ошибок
- `eslint` — без замечаний
- `npm run compile` — успешно

Закрывает #157