### PR TITLE
chore(schema): фиксируем LF для hooks.schema.json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Генерируемый скриптом файл: сравнивается с LF-выводом gen-hooks-schema,
+# поэтому фиксируем LF, чтобы --check не падал на Windows (autocrlf)
+resources/schemas/hooks.schema.json text eol=lf


### PR DESCRIPTION
## Проблема
На Windows (`core.autocrlf=true`) рабочая копия `resources/schemas/hooks.schema.json` получает CRLF, а `gen-hooks-schema` сравнивает с LF-выводом — `--check` (внутри `pretest`) падает с «hooks.schema.json устарел», хотя список command id актуален. На Linux CI проблемы нет, поэтому проявляется только локально на Windows.

## Решение
Закрепляем `eol=lf` для генерируемого файла через `.gitattributes`. Содержимое схемы не меняется.

## Как проверить
```
node scripts/gen-hooks-schema.mjs --check   # актуален, exit 0
```
На Windows после переключения на ветку файл выкладывается уже с LF.
