### PR TITLE
fix(dependencies): определение opm без обёртки в PATH и OVM

### DIFF
--- a/src/shared/ovmPaths.ts
+++ b/src/shared/ovmPaths.ts
@@ -12,18 +12,27 @@ import * as os from 'node:os';
  */
 
 /**
+ * Корневой каталог активной версии OneScript из установки OVM.
+ *
+ * @returns Абсолютный путь к каталогу current OVM
+ */
+export function getOvmRootDir(): string {
+	return process.platform === 'win32'
+		? path.join(process.env.LOCALAPPDATA || '', 'ovm', 'current')
+		: path.join(os.homedir(), '.local', 'share', 'ovm', 'current');
+}
+
+/**
  * Каталог bin активной версии OneScript из установки OVM.
  *
  * @returns Абсолютный путь к каталогу bin OVM
  */
 export function getOvmBinDir(): string {
-	return process.platform === 'win32'
-		? path.join(process.env.LOCALAPPDATA || '', 'ovm', 'current', 'bin')
-		: path.join(os.homedir(), '.local', 'share', 'ovm', 'current', 'bin');
+	return path.join(getOvmRootDir(), 'bin');
 }
 
 /**
- * Полный путь к бинарю инструмента OneScript (oscript, opm и т. п.) в установке OVM.
+ * Полный путь к бинарю инструмента OneScript (oscript и т. п.) в установке OVM.
  * На Windows добавляется расширение `.exe`.
  *
  * @param name - Имя инструмента без расширения (например, 'oscript')
@@ -32,4 +41,35 @@ export function getOvmBinDir(): string {
 export function getOvmBinaryPath(name: string): string {
 	const binary = process.platform === 'win32' ? `${name}.exe` : name;
 	return path.join(getOvmBinDir(), binary);
+}
+
+/**
+ * Возможные пути запускаемого файла opm в каталоге bin установки OneScript.
+ *
+ * В дистрибутиве OneScript opm — не exe, а обёртка над скриптом: на Windows
+ * `opm.bat`, на остальных ОС — шелл-скрипт `opm`. На Windows проверяются
+ * несколько расширений на случай различий между версиями дистрибутива.
+ *
+ * @param binDir - Каталог bin установки OneScript
+ * @returns Пути-кандидаты к запускаемому файлу opm (в порядке приоритета)
+ */
+export function getOpmBinaryCandidates(binDir: string): string[] {
+	if (process.platform === 'win32') {
+		return [path.join(binDir, 'opm.bat'), path.join(binDir, 'opm.cmd'), path.join(binDir, 'opm.exe')];
+	}
+	return [path.join(binDir, 'opm')];
+}
+
+/**
+ * Путь к скрипту opm внутри установки OneScript.
+ *
+ * Обёртка bin/opm(.bat) дистрибутива запускает `oscript <корень>/lib/opm/src/cmd/opm.os`.
+ * Если обёртки в bin нет (наблюдается в установках OVM на Linux), opm можно
+ * запустить напрямую через oscript по этому пути.
+ *
+ * @param installRoot - Корень установки OneScript (каталог с bin и lib)
+ * @returns Абсолютный путь к opm.os
+ */
+export function getOpmScriptPath(installRoot: string): string {
+	return path.join(installRoot, 'lib', 'opm', 'src', 'cmd', 'opm.os');
 }

--- a/src/shared/vrunnerManager.ts
+++ b/src/shared/vrunnerManager.ts
@@ -18,7 +18,7 @@ import {
 import { logger } from './logger';
 import { runCancellableCommand, CancellableProcessResult } from './cancellableProcess';
 import { DEFAULT_PATHS, DEFAULT_VRUNNER, DEFAULT_ENV } from './pathDefaults';
-import { getOvmBinaryPath } from './ovmPaths';
+import { getOvmBinaryPath, getOvmBinDir, getOvmRootDir, getOpmBinaryCandidates, getOpmScriptPath } from './ovmPaths';
 import {
 	ACTIVE_ENV_PROFILE_KEY,
 	ACTIVE_ENV_OVERRIDES_KEY,
@@ -101,8 +101,12 @@ export class VRunnerManager {
 	 * и используется синхронными getOnescriptPath/исполнением.
 	 */
 	private resolvedOscriptPath: string | undefined = undefined;
-	/** Разрешённый путь к opm (по той же схеме, что и resolvedOscriptPath). */
-	private resolvedOpmPath: string | undefined = undefined;
+	/**
+	 * Разрешённый способ запуска opm: путь к запускаемому файлу и ведущие
+	 * аргументы. Для обёртки из PATH/bin аргументы пусты; если обёртки нет,
+	 * opm запускается через oscript со скриптом opm.os из установки OneScript.
+	 */
+	private resolvedOpm: { path: string; leadingArgs: string[] } | undefined = undefined;
 
 	/** Событие смены активного env-профиля (id в workspaceState) */
 	private readonly _onDidChangeActiveEnvProfile = new vscode.EventEmitter<void>();
@@ -200,8 +204,8 @@ export class VRunnerManager {
 	 *
 	 * @returns Имя команды для PATH или абсолютный путь к opm
 	 */
-	private getOpmPath(): string {
-		return this.resolvedOpmPath ?? 'opm';
+	private getOpmInvocation(): { path: string; leadingArgs: string[] } {
+		return this.resolvedOpm ?? { path: 'opm', leadingArgs: [] };
 	}
 
 	/**
@@ -367,13 +371,60 @@ export class VRunnerManager {
 	}
 
 	/**
-	 * Проверяет, доступен ли opm: сначала в PATH, затем в установке OVM.
+	 * Проверяет, доступен ли opm: в PATH, затем обёртка в bin установки OVM,
+	 * затем запуск скрипта opm.os через oscript.
+	 *
+	 * В дистрибутиве OneScript opm — обёртка (opm.bat на Windows, шелл-скрипт
+	 * на остальных ОС) над `oscript <корень>/lib/opm/src/cmd/opm.os`. В части
+	 * установок (OVM на Linux) обёртки в bin нет, при этом сам opm.os в lib
+	 * присутствует — тогда opm запускается напрямую через найденный oscript.
 	 *
 	 * @returns Промис, который разрешается true, если opm доступен, иначе false
 	 */
 	public async checkOpmAvailable(): Promise<boolean> {
-		this.resolvedOpmPath = await this.resolveBinaryPath('opm', '--version');
-		return this.resolvedOpmPath !== undefined;
+		this.resolvedOpm = await this.resolveOpmInvocation();
+		return this.resolvedOpm !== undefined;
+	}
+
+	/**
+	 * Разрешает способ запуска opm (см. {@link checkOpmAvailable}).
+	 *
+	 * @returns Инвокация opm или undefined, если opm недоступен
+	 */
+	private async resolveOpmInvocation(): Promise<{ path: string; leadingArgs: string[] } | undefined> {
+		if (await this.runCommandForCheck('opm', ['--version'])) {
+			return { path: 'opm', leadingArgs: [] };
+		}
+
+		for (const candidate of getOpmBinaryCandidates(getOvmBinDir())) {
+			if (fsSync.existsSync(candidate) && await this.runCommandForCheck(candidate, ['--version'])) {
+				log.info(`opm не найден в PATH, используется установка OVM: ${candidate}`);
+				return { path: candidate, leadingArgs: [] };
+			}
+		}
+
+		// Обёртки opm нет: пробуем запустить opm.os через oscript из тех же установок
+		if (this.resolvedOscriptPath === undefined) {
+			await this.checkOscriptAvailable();
+		}
+		const oscriptPath = this.resolvedOscriptPath;
+		if (oscriptPath !== undefined) {
+			const installRoots: string[] = [];
+			if (path.isAbsolute(oscriptPath)) {
+				installRoots.push(path.dirname(path.dirname(oscriptPath)));
+			}
+			installRoots.push(getOvmRootDir());
+			for (const root of new Set(installRoots)) {
+				const opmScript = getOpmScriptPath(root);
+				if (fsSync.existsSync(opmScript) && await this.runCommandForCheck(oscriptPath, [opmScript, '--version'])) {
+					log.info(`opm запускается через oscript: ${opmScript}`);
+					return { path: oscriptPath, leadingArgs: [opmScript] };
+				}
+			}
+		}
+
+		log.warn('opm не найден ни в PATH, ни в установке OVM, ни как opm.os в lib установки OneScript');
+		return undefined;
 	}
 
 	/**
@@ -1356,10 +1407,10 @@ export class VRunnerManager {
 		args: string[],
 		options?: { cwd?: string; env?: NodeJS.ProcessEnv; name?: string }
 	): Promise<void> {
-		const opmPath = this.getOpmPath();
+		const { path: opmPath, leadingArgs } = this.getOpmInvocation();
 		const cwd = options?.cwd || this.workspaceRoot || os.homedir();
 		const quotedPath = opmPath.includes(' ') ? `"${opmPath}"` : opmPath;
-		const command = `${quotedPath} ${escapeCommandArgs(args)}`;
+		const command = `${quotedPath} ${escapeCommandArgs([...leadingArgs, ...args])}`;
 		const task = createVRunnerTask({
 			name: options?.name || '1C: Platform Tools',
 			command,
@@ -1390,10 +1441,10 @@ export class VRunnerManager {
 			void this.executeOpmTask(args, options);
 			return;
 		}
-		const opmPath = this.getOpmPath();
+		const { path: opmPath, leadingArgs } = this.getOpmInvocation();
 		const shellType = options?.shellType || detectShellType();
 		const cwd = options?.cwd || this.workspaceRoot || os.homedir();
-		const processedArgs = this.processCommandArgs(args, cwd, shellType);
+		const processedArgs = this.processCommandArgs([...leadingArgs, ...args], cwd, shellType);
 		const command = buildCommand(opmPath, processedArgs, shellType);
 
 		const opmTerminalName = options?.name || '1C: Platform Tools';
@@ -1420,8 +1471,8 @@ export class VRunnerManager {
 		options?: { cwd?: string }
 	): Promise<VRunnerExecutionResult> {
 		return new Promise((resolve) => {
-			const opmPath = this.getOpmPath();
-			const argsString = escapeCommandArgs(args);
+			const { path: opmPath, leadingArgs } = this.getOpmInvocation();
+			const argsString = escapeCommandArgs([...leadingArgs, ...args]);
 			const quotedPath = opmPath.includes(' ') ? `"${opmPath}"` : opmPath;
 			const command = `${quotedPath} ${argsString}`;
 

--- a/src/test/shared/ovmPaths.test.ts
+++ b/src/test/shared/ovmPaths.test.ts
@@ -1,0 +1,32 @@
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import {
+	getOvmRootDir,
+	getOvmBinDir,
+	getOpmBinaryCandidates,
+	getOpmScriptPath,
+} from '../../shared/ovmPaths';
+
+suite('ovmPaths', () => {
+	test('getOvmBinDir — каталог bin внутри корня OVM', () => {
+		assert.strictEqual(getOvmBinDir(), path.join(getOvmRootDir(), 'bin'));
+	});
+
+	test('getOpmBinaryCandidates: обёртка opm без .exe в приоритете', () => {
+		const candidates = getOpmBinaryCandidates(path.join('root', 'bin'));
+		assert.ok(candidates.length > 0);
+		if (process.platform === 'win32') {
+			assert.strictEqual(path.basename(candidates[0]), 'opm.bat');
+			assert.ok(candidates.every((c) => path.dirname(c) === path.join('root', 'bin')));
+		} else {
+			assert.deepStrictEqual(candidates, [path.join('root', 'bin', 'opm')]);
+		}
+	});
+
+	test('getOpmScriptPath — opm.os в lib установки', () => {
+		assert.strictEqual(
+			getOpmScriptPath(path.join('install', 'root')),
+			path.join('install', 'root', 'lib', 'opm', 'src', 'cmd', 'opm.os')
+		);
+	});
+});


### PR DESCRIPTION
## Проблема

На Linux после 0.7.14 oscript находится через установку OVM, но opm считается отсутствующим, хотя установка OneScript рабочая.

Точная причина (подтверждено дистрибутивом OneScript 2.0.0 и исходниками ovm):

- в дистрибутиве OneScript opm — не exe, а обёртка над скриптом: `bin/opm.bat` на Windows, bash-скрипт `bin/opm` на Linux. Прежний поиск `opm.exe` в bin OVM всегда промахивался;
- в zip-архиве дистрибутива у файлов нет бита исполнения, а ovm после распаковки выполняет `chmod +x` только для исполняемого файла oscript (`УстановщикOneScript.os`). `bin/opm` остаётся неисполняемым — его запуск завершается ошибкой, и opm выглядит отсутствующим;
- сама обёртка `bin/opm` вызывает `oscript` из PATH, поэтому в VS Code, запущенном из GUI без PATH интерактивной оболочки, она не работает даже с правами на исполнение.

## Решение

- поиск обёртки opm в bin OVM по реальным именам файлов (`opm.bat`/`opm.cmd`/`opm.exe` на Windows, `opm` на остальных ОС);
- если обёртка недоступна — opm запускается напрямую через уже найденный oscript: `oscript <корень установки>/lib/opm/src/cmd/opm.os`. Это в точности то, что делает штатная обёртка дистрибутива, но с явным путём к oscript вместо PATH; корень установки берётся из расположения oscript и из установки OVM;
- разрешённый способ запуска используется всеми командами opm (задачи, терминал, синхронные вызовы).

## Проверка

- юнит-тесты путей установки (`ovmPaths`), 315 passing в vscode-test;
- на Windows живьём проверены обе инвокации: обёртка `opm.bat` и `oscript lib/opm/src/cmd/opm.os --version` (обе печатают версию, код возврата 0);
- структура Linux-дистрибутива (`bin/opm`, `lib/opm/src/cmd/opm.os`, отсутствие бита исполнения в zip) проверена по артефакту OneScript-2.0.0-linux-x64.zip.

Закрывает #157