### PR TITLE
fix(server): находим ibsrv в Linux-раскладках без каталога bin

### DIFF
--- a/docs/autonomous-server.md
+++ b/docs/autonomous-server.md
@@ -61,7 +61,7 @@
 
 | Настройка | По умолчанию | Назначение |
 | --- | --- | --- |
-| `1c-platform-tools.server.platformPath` | пусто | Каталог установки платформы для поиска `ibsrv`. Пусто — автоопределение (`%PROGRAMFILES%\1cv8` в Windows, `/opt/1C/v8.3/x86_64` в Linux). |
+| `1c-platform-tools.server.platformPath` | пусто | Каталог установки платформы для поиска `ibsrv`. Пусто — автоопределение (`%PROGRAMFILES%\1cv8` в Windows, `/opt/1cv8/x86_64` и `/opt/1C/v8.3/x86_64` в Linux). `ibsrv` ищется в `bin/`, напрямую в каталоге версии и в самой базе — каталог `bin` в Linux-раскладке не обязателен. |
 | `1c-platform-tools.server.platformVersion` | пусто | Версия платформы (`8.3.27.1936` или префикс `8.3.27`). Пусто — наибольшая установленная. |
 | `1c-platform-tools.server.host` | `localhost` | Сетевой интерфейс (`localhost` / `any` / IP). |
 | `1c-platform-tools.server.port` | `8314` | HTTP-порт. |

--- a/package.json
+++ b/package.json
@@ -2816,7 +2816,7 @@
           "1c-platform-tools.server.platformPath": {
             "type": "string",
             "default": "",
-            "description": "Каталог установки платформы 1С для поиска ibsrv (автономный сервер). Пусто — определяется автоматически (%PROGRAMFILES%\\1cv8 в Windows, /opt/1C/v8.3/x86_64 в Linux)."
+            "description": "Каталог установки платформы 1С для поиска ibsrv (автономный сервер). Пусто — определяется автоматически (%PROGRAMFILES%\\1cv8 в Windows, /opt/1cv8/x86_64 и /opt/1C/v8.3/x86_64 в Linux). Бинарь ищется в bin/, напрямую в каталоге версии и в самой базе."
           },
           "1c-platform-tools.server.platformVersion": {
             "type": "string",

--- a/src/features/launch/platformServerManager.ts
+++ b/src/features/launch/platformServerManager.ts
@@ -20,7 +20,7 @@ import * as fs from 'node:fs/promises';
 import { VRunnerManager } from '../../shared/vrunnerManager';
 import { resolveFileIbAbsolutePath } from '../../shared/ibConnectionPath';
 import { logger } from '../../shared/logger';
-import { resolvePlatformBinary } from '../../shared/platformBinary';
+import { resolvePlatformBinary, defaultPlatformBasePaths } from '../../shared/platformBinary';
 import {
 	PublicationOptions,
 	ServerUrls,
@@ -80,16 +80,30 @@ const STOP_EXIT_TIMEOUT_MS = 8_000;
 const STOP_PORT_TIMEOUT_MS = 8_000;
 
 /**
- * Базовый каталог установки платформы по умолчанию (если не задан в настройках).
+ * Находит ibsrv в настроенном каталоге либо в каталогах установки по умолчанию.
  *
- * @returns Путь к каталогу версий платформы 1С
+ * Возвращает найденный путь к бинарю и перебранные базовые каталоги (для
+ * сообщения об ошибке).
+ *
+ * @param platformPath - Значение настройки `server.platformPath` (пусто — автоопределение)
+ * @param requestedVersion - Запрошенная версия или её префикс
+ * @returns Путь к ibsrv (или undefined) и список проверенных каталогов
  */
-function defaultPlatformBasePath(): string {
-	if (process.platform === 'win32') {
-		const programFiles = process.env.PROGRAMFILES || 'C:\\Program Files';
-		return path.join(programFiles, '1cv8');
+function findServerBinary(
+	platformPath: string,
+	requestedVersion: string
+): { binary: string | undefined; bases: string[] } {
+	const configured = platformPath.trim();
+	const bases = configured ? [configured] : defaultPlatformBasePaths();
+	for (const base of bases) {
+		const binary = resolvePlatformBinary(base, 'ibsrv', {
+			requestedVersion: requestedVersion || undefined,
+		});
+		if (binary) {
+			return { binary, bases };
+		}
 	}
-	return '/opt/1C/v8.3/x86_64';
+	return { binary: undefined, bases };
 }
 
 export class PlatformServerManager {
@@ -171,14 +185,10 @@ export class PlatformServerManager {
 		// Версия платформы: настройка сервера → --v8version активного профиля → наибольшая.
 		const requestedVersion = settings.platformVersion || (await this.vrunner.getActiveV8Version()) || '';
 
-		const binary = resolvePlatformBinary(
-			settings.platformPath || defaultPlatformBasePath(),
-			'ibsrv',
-			{ requestedVersion: requestedVersion || undefined }
-		);
+		const { binary, bases } = findServerBinary(settings.platformPath, requestedVersion);
 		if (!binary) {
 			vscode.window.showErrorMessage(
-				`Не найден ibsrv. Проверьте настройку «server.platformPath» (текущая база: ${settings.platformPath || defaultPlatformBasePath()})` +
+				`Не найден ibsrv. Проверьте настройку «server.platformPath» (проверены: ${bases.join(', ')})` +
 				`${requestedVersion ? ` и версию «${requestedVersion}»` : ''}.`
 			);
 			return;

--- a/src/shared/platformBinary.ts
+++ b/src/shared/platformBinary.ts
@@ -4,9 +4,16 @@ import * as path from 'node:path';
 /**
  * Поиск исполняемых файлов платформы 1С:Предприятие (ibsrv, ibcmd).
  *
- * Бинарь живёт в `<база>/<версия>/bin/<имя>`, где база — каталог установки
- * платформы (по умолчанию `%PROGRAMFILES%/1cv8` на Windows,
- * `/opt/1C/v8.3/x86_64` на Linux), а `<версия>` — каталог вида `8.3.27.1936`.
+ * Раскладка бинарей зависит от ОС и способа установки:
+ *
+ * - Windows: `<база>/<версия>/bin/<имя>` (например `C:/Program Files/1cv8/8.3.27.1936/bin/ibsrv.exe`);
+ * - Linux (.deb-пакеты): `<база>/<версия>/<имя>` без каталога `bin`
+ *   (например `/opt/1cv8/x86_64/8.5.1.1343/ibsrv`);
+ * - Linux (.run-инсталлятор): `<база>/<имя>` — бинарь прямо в каталоге установки,
+ *   без подкаталога версии (например `/opt/1C/v8.3/x86_64/ibsrv`).
+ *
+ * Поэтому резолвер проверяет и `bin/<имя>`, и `<имя>` в каждом каталоге версии,
+ * а если каталогов версий нет — ищет бинарь прямо в базе.
  *
  * Чистая логика (разбор/сравнение версий, выбор) вынесена отдельно и покрыта
  * тестами; файловый резолвер {@link resolvePlatformBinary} — тонкая обёртка.
@@ -93,6 +100,43 @@ export function pickPlatformVersion(versions: string[], requested?: string): str
 	return sortedDesc[0];
 }
 
+/**
+ * Каталоги установки платформы по умолчанию (перебираются по порядку).
+ *
+ * На Linux раскладка зависит от способа установки, поэтому кандидатов несколько:
+ * `/opt/1cv8/x86_64` (.deb-пакеты, версии подкаталогами) и
+ * `/opt/1C/v8.3/x86_64` (.run-инсталлятор, бинари прямо в каталоге).
+ *
+ * @param platform - Платформа ОС (по умолчанию process.platform)
+ * @returns Список каталогов-кандидатов
+ */
+export function defaultPlatformBasePaths(platform: NodeJS.Platform = process.platform): string[] {
+	if (platform === 'win32') {
+		const programFiles = process.env.PROGRAMFILES || 'C:\\Program Files';
+		return [path.join(programFiles, '1cv8')];
+	}
+	return ['/opt/1cv8/x86_64', '/opt/1C/v8.3/x86_64'];
+}
+
+/**
+ * Ищет бинарь в конкретном каталоге, учитывая опциональный подкаталог `bin`.
+ *
+ * @param dir - Каталог (базовый или версии)
+ * @param fileName - Имя файла бинаря
+ * @returns Полный путь или undefined
+ */
+function binaryInDir(dir: string, fileName: string): string | undefined {
+	const withBin = path.join(dir, 'bin', fileName);
+	if (fsSync.existsSync(withBin)) {
+		return withBin;
+	}
+	const direct = path.join(dir, fileName);
+	if (fsSync.existsSync(direct)) {
+		return direct;
+	}
+	return undefined;
+}
+
 /** Опции поиска бинаря платформы. */
 export interface ResolvePlatformBinaryOptions {
 	/** Запрошенная версия платформы или её префикс (пусто — наибольшая доступная). */
@@ -104,8 +148,10 @@ export interface ResolvePlatformBinaryOptions {
 /**
  * Находит путь к исполняемому файлу платформы в каталоге установки.
  *
- * Перебирает каталоги версий, у которых реально присутствует нужный бинарь,
- * и выбирает версию через {@link pickPlatformVersion}.
+ * Сначала перебирает каталоги версий (у которых реально присутствует нужный
+ * бинарь — в `bin/` или напрямую) и выбирает версию через
+ * {@link pickPlatformVersion}. Если каталогов версий нет, ищет бинарь прямо в
+ * базе (раскладка .run-инсталлятора на Linux, где версия из пути не читается).
  *
  * @param baseDir - Каталог установки платформы (например, `C:\Program Files\1cv8`)
  * @param tool - Инструмент платформы (ibsrv/ibcmd)
@@ -127,16 +173,24 @@ export function resolvePlatformBinary(
 		return undefined;
 	}
 
-	// Версии, у которых бинарь реально на месте.
-	const available = entries
-		.filter((e) => e.isDirectory() && is1cVersionDir(e.name))
-		.map((e) => e.name)
-		.filter((name) => fsSync.existsSync(path.join(baseDir, name, 'bin', fileName)));
-
-	const version = pickPlatformVersion(available, options.requestedVersion);
-	if (!version) {
-		return undefined;
+	// Версии, у которых бинарь реально на месте (в `bin/` или напрямую).
+	const byVersion = new Map<string, string>();
+	for (const e of entries) {
+		if (!e.isDirectory() || !is1cVersionDir(e.name)) {
+			continue;
+		}
+		const found = binaryInDir(path.join(baseDir, e.name), fileName);
+		if (found) {
+			byVersion.set(e.name, found);
+		}
 	}
 
-	return path.join(baseDir, version, 'bin', fileName);
+	const version = pickPlatformVersion([...byVersion.keys()], options.requestedVersion);
+	if (version) {
+		return byVersion.get(version);
+	}
+
+	// Нет каталогов версий с бинарём — раскладка без подкаталога версии
+	// (.run-инсталлятор: `/opt/1C/v8.3/x86_64/ibsrv`).
+	return binaryInDir(baseDir, fileName);
 }

--- a/src/test/shared/platformBinary.test.ts
+++ b/src/test/shared/platformBinary.test.ts
@@ -1,9 +1,14 @@
 import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {
 	is1cVersionDir,
 	compare1cVersions,
 	platformBinaryFileName,
 	pickPlatformVersion,
+	resolvePlatformBinary,
+	defaultPlatformBasePaths,
 } from '../../shared/platformBinary';
 
 suite('platformBinary', () => {
@@ -47,5 +52,96 @@ suite('platformBinary', () => {
 	test('pickPlatformVersion: нет подходящих → undefined', () => {
 		assert.strictEqual(pickPlatformVersion(['common', 'conf']), undefined);
 		assert.strictEqual(pickPlatformVersion(['8.3.27.1936'], '8.4'), undefined);
+	});
+
+	test('defaultPlatformBasePaths: кандидаты по ОС', () => {
+		assert.deepStrictEqual(defaultPlatformBasePaths('linux'), [
+			'/opt/1cv8/x86_64',
+			'/opt/1C/v8.3/x86_64',
+		]);
+		const win = defaultPlatformBasePaths('win32');
+		assert.strictEqual(win.length, 1);
+		assert.ok(win[0].endsWith(path.join('', '1cv8')));
+	});
+
+	suite('resolvePlatformBinary (файловые раскладки)', () => {
+		let baseDir: string;
+
+		setup(() => {
+			baseDir = fs.mkdtempSync(path.join(os.tmpdir(), '1c-platform-'));
+		});
+
+		teardown(() => {
+			fs.rmSync(baseDir, { recursive: true, force: true });
+		});
+
+		const touch = (...segments: string[]): string => {
+			const full = path.join(baseDir, ...segments);
+			fs.mkdirSync(path.dirname(full), { recursive: true });
+			fs.writeFileSync(full, '');
+			return full;
+		};
+
+		test('Windows-раскладка: <версия>/bin/ibsrv.exe', () => {
+			const expected = touch('8.3.27.1936', 'bin', 'ibsrv.exe');
+			touch('8.3.23.2040', 'bin', 'ibsrv.exe');
+			assert.strictEqual(
+				resolvePlatformBinary(baseDir, 'ibsrv', { platform: 'win32' }),
+				expected
+			);
+		});
+
+		test('Linux .deb-раскладка: <версия>/ibsrv без bin', () => {
+			touch('8.3.27.1936', 'ibsrv');
+			const expected = touch('8.5.1.1343', 'ibsrv');
+			assert.strictEqual(
+				resolvePlatformBinary(baseDir, 'ibsrv', { platform: 'linux' }),
+				expected
+			);
+		});
+
+		test('Linux .run-раскладка: ibsrv прямо в базе без каталога версии', () => {
+			const expected = touch('ibsrv');
+			assert.strictEqual(
+				resolvePlatformBinary(baseDir, 'ibsrv', { platform: 'linux' }),
+				expected
+			);
+		});
+
+		test('запрошенная версия выбирается среди каталогов без bin', () => {
+			const expected = touch('8.3.27.1936', 'ibsrv');
+			touch('8.5.1.1343', 'ibsrv');
+			assert.strictEqual(
+				resolvePlatformBinary(baseDir, 'ibsrv', {
+					platform: 'linux',
+					requestedVersion: '8.3.27',
+				}),
+				expected
+			);
+		});
+
+		test('каталог версии без бинаря игнорируется', () => {
+			fs.mkdirSync(path.join(baseDir, '8.5.1.1343'), { recursive: true });
+			const expected = touch('8.3.27.1936', 'ibsrv');
+			assert.strictEqual(
+				resolvePlatformBinary(baseDir, 'ibsrv', { platform: 'linux' }),
+				expected
+			);
+		});
+
+		test('нет бинаря → undefined', () => {
+			fs.mkdirSync(path.join(baseDir, '8.5.1.1343'), { recursive: true });
+			assert.strictEqual(
+				resolvePlatformBinary(baseDir, 'ibsrv', { platform: 'linux' }),
+				undefined
+			);
+		});
+
+		test('несуществующая база → undefined', () => {
+			assert.strictEqual(
+				resolvePlatformBinary(path.join(baseDir, 'нет'), 'ibsrv', { platform: 'linux' }),
+				undefined
+			);
+		});
 	});
 });


### PR DESCRIPTION
## Проблема

На Linux расширение не видело установленную платформу 1С и не запускало автономный сервер («не удалось найти ibsrv»). Резолвер бинарей искал только Windows-раскладку `<база>/<версия>/bin/<имя>`, а на Linux каталога `bin` обычно нет.

Раскладки на Linux (сверено с flow из `yellow-hammer/namespace-forest`, где бинарь ищут через `find /opt/1cv8 /opt/1C -name 'ibsrv'`):

- **`.deb`-пакеты:** `/opt/1cv8/x86_64/<версия>/ibsrv` — версия подкаталогом, без `bin`;
- **`.run`-инсталлятор:** `/opt/1C/v8.3/x86_64/ibsrv` — бинарь прямо в базе, без каталога версии.

## Решение

- `resolvePlatformBinary` для каждого каталога версии проверяет и `bin/<имя>`, и `<имя>`; если каталогов версий нет — ищет бинарь прямо в базе.
- Новый `defaultPlatformBasePaths()` на Linux перебирает `/opt/1cv8/x86_64` и `/opt/1C/v8.3/x86_64`; `PlatformServerManager` пробует базы-кандидаты по порядку. В сообщении об ошибке перечисляются все проверенные каталоги.
- Windows-раскладка `<версия>/bin/<имя>.exe` сохранена без изменений.
- Обновлены описание настройки `server.platformPath` и `docs/autonomous-server.md`.

## Тесты

Добавлены кейсы в `platformBinary.test.ts` на все три раскладки, выбор версии среди каталогов без `bin`, игнор пустых каталогов и несуществующей базы. Локально `tsc --noEmit` и `eslint` чисто, тесты пакета проходят.

Закрывает #173
