### PR TITLE
feat(metadata): редактирование свойств справочника и настройки путей исходников

### DIFF
--- a/resources/webview/metadata-object.css
+++ b/resources/webview/metadata-object.css
@@ -10,7 +10,7 @@ body {
 .page {
 	max-width: 1240px;
 	margin: 0 auto;
-	padding: 16px;
+	padding: 16px 16px 56px 16px;
 	box-sizing: border-box;
 }
 
@@ -335,4 +335,564 @@ body {
 
 .hidden {
 	display: none;
+}
+
+/* Группы полей текут в колонки последовательно (первая заполняется сверху вниз, хвост уходит во вторую). */
+.edit-columns {
+	column-width: 430px;
+	column-count: 2;
+	column-gap: 40px;
+	max-width: 960px;
+}
+
+.edit-group {
+	break-inside: avoid;
+	margin-bottom: 16px;
+}
+
+.edit-fields {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.edit-row {
+	display: grid;
+	grid-template-columns: minmax(160px, 220px) 1fr;
+	align-items: center;
+	gap: 8px;
+	min-height: 28px;
+}
+
+.edit-row:has(.edit-ref-list) {
+	align-items: start;
+}
+
+.edit-row:has(.edit-ref-list) .edit-label {
+	padding-top: 6px;
+}
+
+.edit-label {
+	color: var(--vscode-descriptionForeground);
+	font-size: 12px;
+	line-height: 1.3;
+}
+
+.edit-input {
+	width: 100%;
+	box-sizing: border-box;
+	padding: 4px 8px;
+	border-radius: 4px;
+	border: 1px solid var(--vscode-input-border, var(--vscode-panel-border));
+	background: var(--vscode-input-background);
+	color: var(--vscode-input-foreground);
+	font-family: inherit;
+	font-size: inherit;
+}
+
+.edit-input:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+
+.edit-input:disabled {
+	opacity: 0.5;
+}
+
+.edit-textarea {
+	resize: vertical;
+}
+
+.edit-check {
+	width: 16px;
+	height: 16px;
+	accent-color: var(--vscode-focusBorder);
+}
+
+.edit-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+}
+
+.edit-chip {
+	padding: 2px 8px;
+	border-radius: 999px;
+	font-size: 11px;
+	background: var(--vscode-badge-background);
+	color: var(--vscode-badge-foreground);
+}
+
+.edit-static-empty {
+	color: var(--vscode-descriptionForeground);
+	font-size: 12px;
+}
+
+.save-bar {
+	position: fixed;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 10px;
+	padding: 8px 16px;
+	background: var(--vscode-editor-background);
+	border-top: 1px solid var(--vscode-panel-border);
+	z-index: 10;
+}
+
+.save-status {
+	margin-right: auto;
+	color: var(--vscode-descriptionForeground);
+	font-size: 12px;
+}
+
+.save-status-error {
+	color: var(--vscode-errorForeground);
+}
+
+.primary-btn {
+	flex: 0 0 auto;
+	padding: 6px 14px;
+	border-radius: 8px;
+	border: 1px solid transparent;
+	background: var(--vscode-button-background);
+	color: var(--vscode-button-foreground);
+	cursor: pointer;
+	font-weight: 600;
+}
+
+.primary-btn:hover:not(:disabled) {
+	background: var(--vscode-button-hoverBackground);
+}
+
+.primary-btn:disabled,
+.ghost-btn:disabled {
+	opacity: 0.5;
+	cursor: default;
+}
+
+/* .save-bar объявлен позже .hidden — без этого правила каскад оставляет панель видимой. */
+.save-bar.hidden {
+	display: none;
+}
+
+.edit-ref-list {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	min-width: 0;
+}
+
+.edit-ref-items {
+	border: 1px solid var(--vscode-input-border, var(--vscode-panel-border));
+	border-radius: 4px;
+	background: var(--vscode-input-background);
+	overflow: hidden;
+}
+
+.edit-ref-item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 4px 8px;
+}
+
+.edit-ref-item + .edit-ref-item {
+	border-top: 1px solid var(--vscode-panel-border);
+}
+
+.edit-ref-item:hover {
+	background: color-mix(in srgb, var(--vscode-focusBorder) 10%, transparent);
+}
+
+.edit-ref-item-label {
+	overflow-wrap: anywhere;
+	min-width: 0;
+}
+
+.edit-ref-remove {
+	flex: 0 0 auto;
+	border: none;
+	background: transparent;
+	color: var(--vscode-descriptionForeground);
+	cursor: pointer;
+	padding: 0 4px;
+	font-size: 14px;
+	line-height: 1;
+	opacity: 0;
+}
+
+.edit-ref-item:hover .edit-ref-remove {
+	opacity: 1;
+}
+
+.edit-ref-remove:hover {
+	color: var(--vscode-errorForeground);
+}
+
+.edit-ref-empty {
+	padding: 4px 8px;
+	color: var(--vscode-descriptionForeground);
+	font-size: 12px;
+}
+
+.edit-ref-add-select {
+	align-self: flex-start;
+	max-width: 100%;
+	padding: 3px 6px;
+	border-radius: 4px;
+	border: 1px dashed var(--vscode-input-border, var(--vscode-panel-border));
+	background: transparent;
+	color: var(--vscode-descriptionForeground);
+	font-family: inherit;
+	font-size: 12px;
+	cursor: pointer;
+}
+
+.edit-ref-add-select:hover,
+.edit-ref-add-select:focus {
+	border-color: var(--vscode-focusBorder);
+	color: var(--vscode-foreground);
+	outline: none;
+}
+
+.edit-chips {
+	overflow-wrap: anywhere;
+}
+
+/* Нативные списки select в тёмной теме (иначе белые). */
+body.vscode-dark {
+	color-scheme: dark;
+}
+
+body.vscode-light {
+	color-scheme: light;
+}
+
+.edit-input option,
+.edit-ref-add-select option {
+	background: var(--vscode-dropdown-background);
+	color: var(--vscode-dropdown-foreground);
+}
+
+select.edit-input {
+	background: var(--vscode-dropdown-background, var(--vscode-input-background));
+	color: var(--vscode-dropdown-foreground, var(--vscode-input-foreground));
+}
+
+.edit-ref-item-actions {
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+}
+
+.edit-ref-move {
+	border: none;
+	background: transparent;
+	color: var(--vscode-descriptionForeground);
+	cursor: pointer;
+	padding: 0 3px;
+	font-size: 12px;
+	line-height: 1;
+	opacity: 0;
+}
+
+.edit-ref-item:hover .edit-ref-move {
+	opacity: 1;
+}
+
+.edit-ref-move:disabled {
+	opacity: 0;
+	cursor: default;
+}
+
+.edit-ref-move:hover:not(:disabled) {
+	color: var(--vscode-foreground);
+}
+
+.edit-module-link {
+	border: none;
+	background: transparent;
+	color: var(--vscode-textLink-foreground);
+	cursor: pointer;
+	padding: 0;
+	font-family: inherit;
+	font-size: inherit;
+	text-align: left;
+}
+
+.edit-module-link:hover {
+	text-decoration: underline;
+}
+
+/* Списки структуры (реквизиты, ТЧ) — тот же рамочный стиль, что у редактируемых списков ссылок. */
+.struct-list {
+	border: 1px solid var(--vscode-input-border, var(--vscode-panel-border));
+	border-radius: 4px;
+	background: var(--vscode-input-background);
+	overflow: hidden;
+}
+
+.struct-list .struct-list {
+	border: none;
+	border-radius: 0;
+	background: transparent;
+}
+
+.struct-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 3px 8px;
+	min-height: 22px;
+}
+
+.struct-item + .struct-item,
+.struct-ts + .struct-ts,
+.struct-item + .struct-ts,
+.struct-ts + .struct-item {
+	border-top: 1px solid var(--vscode-panel-border);
+}
+
+.struct-item:hover {
+	background: color-mix(in srgb, var(--vscode-focusBorder) 10%, transparent);
+}
+
+.struct-item-name {
+	flex: 0 1 auto;
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+
+.struct-item-syn {
+	flex: 1 1 auto;
+	min-width: 0;
+	color: var(--vscode-descriptionForeground);
+	font-size: 12px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.struct-actions {
+	flex: 0 0 auto;
+	display: inline-flex;
+	gap: 2px;
+	opacity: 0;
+}
+
+.struct-item:hover > .struct-actions {
+	opacity: 1;
+}
+
+.struct-btn {
+	border: none;
+	background: transparent;
+	color: var(--vscode-descriptionForeground);
+	cursor: pointer;
+	padding: 1px 4px;
+	font-size: 12px;
+	line-height: 1;
+	border-radius: 3px;
+}
+
+.struct-btn:hover:not(:disabled) {
+	color: var(--vscode-foreground);
+	background: color-mix(in srgb, var(--vscode-focusBorder) 16%, transparent);
+}
+
+.struct-btn-danger:hover:not(:disabled) {
+	color: var(--vscode-errorForeground);
+}
+
+.struct-btn:disabled,
+.struct-add-btn:disabled {
+	opacity: 0.4;
+	cursor: default;
+}
+
+.struct-ts > summary.struct-item {
+	cursor: pointer;
+	list-style: none;
+}
+
+.struct-ts > summary.struct-item::before {
+	content: '›';
+	flex: 0 0 auto;
+	width: 10px;
+	color: var(--vscode-descriptionForeground);
+	transition: transform 0.1s;
+}
+
+.struct-ts[open] > summary.struct-item::before {
+	transform: rotate(90deg);
+}
+
+.struct-ts-body {
+	padding: 4px 8px 8px 20px;
+	border-top: 1px solid var(--vscode-panel-border);
+}
+
+.struct-add-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-top: 6px;
+}
+
+.struct-add-btn {
+	padding: 3px 6px;
+	border-radius: 4px;
+	border: 1px dashed var(--vscode-input-border, var(--vscode-panel-border));
+	background: transparent;
+	color: var(--vscode-descriptionForeground);
+	font-family: inherit;
+	font-size: 12px;
+	cursor: pointer;
+}
+
+.struct-add-btn:hover:not(:disabled) {
+	border-color: var(--vscode-focusBorder);
+	color: var(--vscode-foreground);
+}
+
+.struct-hint {
+	color: var(--vscode-descriptionForeground);
+	font-size: 11px;
+}
+
+.edit-data-layout {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+	gap: 16px 32px;
+	align-items: start;
+}
+
+.edit-data-structure {
+	min-width: 0;
+}
+
+.edit-data-props {
+	min-width: 0;
+	max-width: 520px;
+}
+
+/* Инлайн-редактирование структуры на «Данных». */
+.struct-input {
+	padding: 2px 6px;
+	font-size: 12px;
+	background: transparent;
+	border-color: transparent;
+}
+
+.struct-input:hover,
+.struct-input:focus {
+	background: var(--vscode-input-background);
+	border-color: var(--vscode-input-border, var(--vscode-panel-border));
+}
+
+.struct-input-name {
+	flex: 0 0 44%;
+	min-width: 0;
+	font-weight: 500;
+}
+
+.struct-input:not(.struct-input-name) {
+	flex: 1 1 auto;
+	min-width: 0;
+	color: var(--vscode-descriptionForeground);
+}
+
+.struct-input-invalid,
+.struct-input-invalid:hover,
+.struct-input-invalid:focus {
+	border-color: var(--vscode-errorForeground) !important;
+}
+
+.struct-item-deleted {
+	opacity: 0.55;
+}
+
+.struct-item-deleted .struct-input {
+	text-decoration: line-through;
+}
+
+.struct-item .struct-btn {
+	opacity: 0;
+}
+
+.struct-item:hover .struct-btn,
+.struct-item .struct-btn:focus {
+	opacity: 1;
+}
+
+.struct-item-deleted .struct-btn {
+	opacity: 1;
+}
+
+.struct-ts-block {
+	border: 1px solid var(--vscode-input-border, var(--vscode-panel-border));
+	border-radius: 4px;
+	background: var(--vscode-input-background);
+	margin-bottom: 6px;
+}
+
+.struct-ts-block > .struct-item {
+	border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.struct-ts-block .struct-ts-body {
+	border-top: none;
+	padding: 4px 8px 8px 20px;
+}
+
+.struct-ts-block .struct-ts-body .struct-add-row {
+	margin-top: 4px;
+}
+
+.edit-filter-row {
+	margin-bottom: 12px;
+}
+
+.edit-filter {
+	max-width: 320px;
+}
+
+.edit-filter-wrap {
+	position: relative;
+	display: inline-block;
+}
+
+.edit-filter {
+	padding-right: 24px;
+}
+
+.edit-filter-clear {
+	position: absolute;
+	right: 4px;
+	top: 50%;
+	transform: translateY(-50%);
+	border: none;
+	background: transparent;
+	color: var(--vscode-descriptionForeground);
+	cursor: pointer;
+	padding: 0 4px;
+	font-size: 13px;
+	line-height: 1;
+}
+
+.edit-filter-clear:hover {
+	color: var(--vscode-foreground);
+}
+
+.struct-actions-inline {
+	flex: 0 0 auto;
+	display: inline-flex;
+	gap: 2px;
+	align-items: center;
 }

--- a/resources/webview/metadata-object.html
+++ b/resources/webview/metadata-object.html
@@ -30,6 +30,12 @@
 		</section>
 	</div>
 
+	<footer id="saveBar" class="save-bar hidden">
+		<span id="saveStatus" class="save-status"></span>
+		<button id="resetBtn" class="ghost-btn" type="button">Отменить</button>
+		<button id="saveBtn" class="primary-btn" type="button">Сохранить</button>
+	</footer>
+
 	<script type="application/json" id="metadata-object-initial">{{INITIAL_JSON}}</script>
 	<script src="{{JS_URI}}"></script>
 </body>

--- a/resources/webview/metadata-object.js
+++ b/resources/webview/metadata-object.js
@@ -28,6 +28,266 @@
 	const tabs = Array.isArray(model.tabs) ? model.tabs : [];
 	let activeTabId = tabs[0] ? tabs[0].id : '';
 	let technicalVisible = false;
+
+	const vscodeApi = typeof acquireVsCodeApi === 'function' ? acquireVsCodeApi() : null;
+	const editable = model.editable && typeof model.editable === 'object' ? model.editable : null;
+	let editedProps = editable ? deepClone(editable.props) : null;
+	let editedStructure = model.structureLists ? structureEditsFromLists(model.structureLists) : null;
+	let editFilter = '';
+
+	/** Синоним из имени по правилу 1С: «ВалютаБанка» → «Валюта банка», «БИКБанка» → «БИК банка». */
+	function synonymFromName(name) {
+		const text = String(name || '').trim();
+		if (!text) {
+			return '';
+		}
+		const words = [];
+		let current = '';
+		const isUpper = (ch) => ch !== ch.toLowerCase() && ch === ch.toUpperCase();
+		const isLower = (ch) => ch !== ch.toUpperCase() && ch === ch.toLowerCase();
+		const isDigit = (ch) => ch >= '0' && ch <= '9';
+		for (let i = 0; i < text.length; i++) {
+			const ch = text[i];
+			if (ch === '_') {
+				if (current) {
+					words.push(current);
+					current = '';
+				}
+				continue;
+			}
+			if (current) {
+				const prev = current[current.length - 1];
+				const next = i + 1 < text.length ? text[i + 1] : '';
+				const boundary =
+					(isUpper(ch) && isLower(prev)) ||
+					(isDigit(ch) !== isDigit(prev)) ||
+					(isUpper(ch) && isUpper(prev) && next && isLower(next));
+				if (boundary) {
+					words.push(current);
+					current = '';
+				}
+			}
+			current += ch;
+		}
+		if (current) {
+			words.push(current);
+		}
+		return words
+			.map((word, idx) => {
+				if (idx === 0) {
+					return word;
+				}
+				const isAbbrev = word.length > 1 && word === word.toUpperCase() && !isDigit(word[0]);
+				return isAbbrev ? word : word.toLowerCase();
+			})
+			.join(' ');
+	}
+
+	function structureEditsFromLists(lists) {
+		const rowFrom = function (r) {
+			const item = typeof r === 'object' && r !== null ? r : {};
+			return {
+				originalName: typeof item.name === 'string' ? item.name : '',
+				name: typeof item.name === 'string' ? item.name : '',
+				synonymRu: typeof item.synonymRu === 'string' ? item.synonymRu : '',
+				baselineSynonymRu: typeof item.synonymRu === 'string' ? item.synonymRu : '',
+				comment: typeof item.comment === 'string' ? item.comment : '',
+				deleted: false,
+			};
+		};
+		return {
+			attributes: (Array.isArray(lists.attributes) ? lists.attributes : []).map(rowFrom),
+			tabularSections: (Array.isArray(lists.tabularSections) ? lists.tabularSections : []).map(function (t) {
+				const row = rowFrom(t);
+				row.attributes = (Array.isArray(t.attributes) ? t.attributes : []).map(rowFrom);
+				return row;
+			}),
+		};
+	}
+
+	function eachStructRow(fn) {
+		if (!editedStructure) {
+			return;
+		}
+		for (const row of editedStructure.attributes) {
+			fn(row, null);
+		}
+		for (const ts of editedStructure.tabularSections) {
+			fn(ts, null);
+			for (const row of ts.attributes) {
+				fn(row, ts);
+			}
+		}
+	}
+
+	function structRowDirty(row) {
+		return row.deleted || !row.originalName || row.name !== row.originalName || row.synonymRu !== row.baselineSynonymRu;
+	}
+
+	function structOrderKey(structure) {
+		if (!structure) {
+			return '';
+		}
+		const attr = structure.attributes.map((row) => row.originalName || '+').join('|');
+		const ts = structure.tabularSections
+			.map((t) => (t.originalName || '+') + ':' + t.attributes.map((row) => row.originalName || '+').join(','))
+			.join('|');
+		return attr + '#' + ts;
+	}
+
+	let structBaselineOrderKey = structOrderKey(editedStructure);
+
+	function isStructDirty() {
+		let dirty = false;
+		eachStructRow(function (row) {
+			if (structRowDirty(row)) {
+				dirty = true;
+			}
+		});
+		return dirty || structOrderKey(editedStructure) !== structBaselineOrderKey;
+	}
+
+	const STRUCT_NAME_RE = /^[A-Za-zА-ЯЁа-яё_][A-Za-zА-ЯЁа-яё0-9_]*$/;
+
+	function structNameValid(name) {
+		return STRUCT_NAME_RE.test(String(name || '').trim());
+	}
+
+	/** Первая ошибка имён структуры или пустая строка. */
+	function structValidationError() {
+		if (!editedStructure) {
+			return '';
+		}
+		const topSeen = new Set();
+		for (const row of [...editedStructure.attributes, ...editedStructure.tabularSections]) {
+			if (row.deleted) {
+				continue;
+			}
+			if (!structNameValid(row.name)) {
+				return 'Исправьте некорректные имена';
+			}
+			const key = row.name.trim().toLowerCase();
+			if (topSeen.has(key)) {
+				return `Дублируется имя «${row.name.trim()}»`;
+			}
+			topSeen.add(key);
+		}
+		for (const ts of editedStructure.tabularSections) {
+			if (ts.deleted) {
+				continue;
+			}
+			const nestedSeen = new Set();
+			for (const row of ts.attributes) {
+				if (row.deleted) {
+					continue;
+				}
+				if (!structNameValid(row.name)) {
+					return 'Исправьте некорректные имена';
+				}
+				const key = row.name.trim().toLowerCase();
+				if (nestedSeen.has(key)) {
+					return `Дублируется имя «${row.name.trim()}» в ТЧ «${ts.name}»`;
+				}
+				nestedSeen.add(key);
+			}
+		}
+		return '';
+	}
+
+	function serializeStructureEdits() {
+		if (!editedStructure || !isStructDirty()) {
+			return null;
+		}
+		const rowOut = function (row) {
+			return {
+				originalName: row.originalName || undefined,
+				name: String(row.name || '').trim(),
+				synonymRu: row.synonymRu,
+				deleted: Boolean(row.deleted),
+			};
+		};
+		return {
+			attributes: editedStructure.attributes.map(rowOut),
+			tabularSections: editedStructure.tabularSections.map(function (ts) {
+				const out = rowOut(ts);
+				out.attributes = ts.attributes.map(rowOut);
+				return out;
+			}),
+		};
+	}
+	let saving = false;
+	let saveError = '';
+	let savedFlash = false;
+
+	function deepClone(value) {
+		return JSON.parse(JSON.stringify(value ?? null));
+	}
+
+	function getPath(source, path) {
+		let current = source;
+		for (const part of String(path).split('.')) {
+			if (typeof current !== 'object' || current === null) {
+				return undefined;
+			}
+			current = current[part];
+		}
+		return current;
+	}
+
+	function setPath(target, path, value) {
+		const parts = String(path).split('.');
+		let current = target;
+		for (const part of parts.slice(0, -1)) {
+			if (typeof current[part] !== 'object' || current[part] === null) {
+				return;
+			}
+			current = current[part];
+		}
+		current[parts[parts.length - 1]] = value;
+	}
+
+	function editableFields() {
+		const out = [];
+		if (!editable || !Array.isArray(editable.tabs)) {
+			return out;
+		}
+		for (const tab of editable.tabs) {
+			for (const group of tab.groups || []) {
+				for (const field of group.fields || []) {
+					if (!field.readonly && field.control !== 'staticList' && field.path) {
+						out.push(field);
+					}
+				}
+			}
+		}
+		return out;
+	}
+
+	function normalizeForCompare(value) {
+		if (Array.isArray(value)) {
+			return JSON.stringify(value);
+		}
+		return value === undefined || value === '' ? null : value;
+	}
+
+	function isDirty() {
+		if (!editable || !editedProps) {
+			return false;
+		}
+		for (const field of editableFields()) {
+			if (normalizeForCompare(getPath(editedProps, field.path)) !== normalizeForCompare(getPath(editable.props, field.path))) {
+				return true;
+			}
+		}
+		return isStructDirty();
+	}
+
+	function fieldEnabled(field) {
+		if (!Array.isArray(field.enabledWhen)) {
+			return true;
+		}
+		return field.enabledWhen.every((cond) => getPath(editedProps, cond.path) === cond.equals);
+	}
 	const genericValueLabels = {
 		Use: 'Использовать',
 		DontUse: 'Не использовать',
@@ -142,11 +402,14 @@
 			case 'overview':
 				renderOverview();
 				return;
+			case 'edit':
+				renderEditTab(tab.id);
+				return;
 			case 'named':
-				renderNamed(tab.data);
+				renderNamed(tab);
 				return;
 			case 'tabular':
-				renderTabular(tab.data);
+				renderTabular(tab);
 				return;
 			case 'list':
 				renderList(tab.data);
@@ -197,103 +460,628 @@
 				.join('')}</div>`;
 	}
 
-	function renderNamed(data) {
-		if (!contentRoot) {
-			return;
-		}
-		const items = Array.isArray(data) ? data : [];
-		if (items.length === 0) {
-			contentRoot.innerHTML = '<div class="empty">Нет данных.</div>';
-			return;
-		}
-		contentRoot.innerHTML = `<div class="named-list">${items
-			.map((raw) => {
-				const item = asObject(raw);
-				const name = toDisplayText(item.name);
-				const synonym = toDisplayText(item.synonymRu);
-				const comment = toDisplayText(item.comment);
-				return `<div class="named-item">
-						<div class="item-title">${escapeHtml(name)}</div>
-						<div class="item-grid">
-							<div>
-								<div class="field-label">Синоним</div>
-								<div class="field-value">${escapeHtml(synonym)}</div>
-							</div>
-							<div>
-								<div class="field-label">Комментарий</div>
-								<div class="field-value">${escapeHtml(comment)}</div>
-							</div>
-						</div>
+	function editControlHtml(field, index) {
+		const value = field.path ? getPath(editedProps, field.path) : undefined;
+		const disabled = field.readonly || !fieldEnabled(field) ? ' disabled' : '';
+		const id = `editField_${index}`;
+		switch (field.control) {
+			case 'check': {
+				const checked = value === true ? ' checked' : '';
+				return `<input id="${id}" class="edit-check" type="checkbox" data-path="${escapeHtml(field.path)}" data-control="check"${checked}${disabled} />`;
+			}
+			case 'number':
+				return `<input id="${id}" class="edit-input" type="number" min="0" data-path="${escapeHtml(field.path)}" data-control="number" value="${escapeHtml(value === null || value === undefined ? '' : String(value))}"${disabled} />`;
+			case 'textarea':
+				return `<textarea id="${id}" class="edit-input edit-textarea" data-path="${escapeHtml(field.path)}" data-control="textarea" rows="3"${disabled}>${escapeHtml(typeof value === 'string' ? value : '')}</textarea>`;
+			case 'select': {
+				const current = value === null || value === undefined ? '' : String(value);
+				const options = Array.isArray(field.options) ? field.options.slice() : [];
+				if (current && !options.some((option) => option.value === current)) {
+					options.push({ value: current, label: current });
+				}
+				if (!current && !options.some((option) => option.value === '')) {
+					options.unshift({ value: '', label: '(по умолчанию)' });
+				}
+				const optionsHtml = options
+					.map(
+						(option) =>
+							`<option value="${escapeHtml(option.value)}"${option.value === current ? ' selected' : ''}>${escapeHtml(option.label)}</option>`
+					)
+					.join('');
+				return `<select id="${id}" class="edit-input" data-path="${escapeHtml(field.path)}" data-control="select"${disabled}>${optionsHtml}</select>`;
+			}
+			case 'moduleLink':
+				return `<button type="button" class="edit-module-link" data-module-kind="${escapeHtml(field.path)}">Открыть</button>`;
+			case 'refList': {
+				const selected = Array.isArray(value) ? value : [];
+				const options = Array.isArray(field.options) ? field.options : [];
+				const labelByValue = {};
+				for (const option of options) {
+					labelByValue[option.value] = option.label;
+				}
+				const rows = selected
+					.map(
+						(item, itemIdx) => `<div class="edit-ref-item">
+							<span class="edit-ref-item-label">${escapeHtml(labelByValue[item] || toDisplayText(item))}</span>
+							<span class="edit-ref-item-actions">
+								<button type="button" class="edit-ref-move" data-ref-move-path="${escapeHtml(field.path)}" data-ref-move-index="${itemIdx}" data-ref-move-dir="-1" title="Вверх"${itemIdx === 0 ? ' disabled' : disabled}>↑</button>
+								<button type="button" class="edit-ref-move" data-ref-move-path="${escapeHtml(field.path)}" data-ref-move-index="${itemIdx}" data-ref-move-dir="1" title="Вниз"${itemIdx === selected.length - 1 ? ' disabled' : disabled}>↓</button>
+								<button type="button" class="edit-ref-remove" data-ref-path="${escapeHtml(field.path)}" data-ref-index="${itemIdx}" title="Убрать"${disabled}>×</button>
+							</span>
+						</div>`
+					)
+					.join('');
+				const available = options.filter((option) => !selected.includes(option.value));
+				const addControl = available.length > 0
+					? `<select class="edit-ref-add-select" data-ref-add-select="${escapeHtml(field.path)}"${disabled}>
+							<option value="" selected>+ Добавить…</option>
+							${available
+								.map((option) => `<option value="${escapeHtml(option.value)}">${escapeHtml(option.label)}</option>`)
+								.join('')}
+						</select>`
+					: '';
+				return `<div class="edit-ref-list">
+						<div class="edit-ref-items">${rows || '<div class="edit-ref-empty">(пусто)</div>'}</div>
+						${addControl}
 					</div>`;
-			})
-			.join('')}</div>`;
+			}
+			case 'staticList': {
+				const items = Array.isArray(field.items) && field.items.length > 0
+					? field.items
+					: (Array.isArray(value) ? value : []);
+				if (items.length === 0) {
+					return '<div class="edit-static-empty">(пусто)</div>';
+				}
+				return `<div class="edit-chips">${items
+					.map((item) => `<span class="edit-chip">${escapeHtml(toDisplayText(item))}</span>`)
+					.join('')}</div>`;
+			}
+			default:
+				return `<input id="${id}" class="edit-input" type="text" data-path="${escapeHtml(field.path)}" data-control="text" value="${escapeHtml(typeof value === 'string' ? value : '')}"${disabled} />`;
+		}
 	}
 
-	function renderTabular(data) {
-		if (!contentRoot) {
+	function renderEditTab(tabId) {
+		if (!contentRoot || !editable || !editedProps) {
 			return;
 		}
-		const items = Array.isArray(data) ? data : [];
-		if (items.length === 0) {
+		const spec = (editable.tabs || []).find((tab) => tab.id === tabId);
+		if (!spec) {
 			contentRoot.innerHTML = '<div class="empty">Нет данных.</div>';
 			return;
 		}
-		contentRoot.innerHTML = `<div class="tabular-list">${items
-			.map((raw) => {
-				const item = asObject(raw);
-				const name = toDisplayText(item.name);
-				const synonym = toDisplayText(item.synonymRu);
-				const comment = toDisplayText(item.comment);
-				const attrs = Array.isArray(item.attributes) ? item.attributes.map((x) => asObject(x)).filter(Boolean) : [];
-				const attrsHtml =
-					attrs.length > 0
-						? `<div class="nested-list">${attrs
-								.map((attr) => {
-									const attrName = toDisplayText(attr.name);
-									const attrSynonym = toDisplayText(attr.synonymRu);
-									const attrComment = toDisplayText(attr.comment);
-									return `<div class="nested-item">
-										<div class="nested-title">${escapeHtml(attrName)}</div>
-										<div class="item-grid">
-											<div>
-												<div class="field-label">Синоним</div>
-												<div class="field-value">${escapeHtml(attrSynonym)}</div>
-											</div>
-											<div>
-												<div class="field-label">Комментарий</div>
-												<div class="field-value">${escapeHtml(attrComment)}</div>
-											</div>
-										</div>
-									</div>`;
-								})
-								.join('')}</div>`
-						: '<div class="empty">Реквизитов нет.</div>';
-				return `<div class="tabular-item">
-						<details class="tabular-details">
-							<summary class="tabular-summary">
-								<span class="item-title">${escapeHtml(name)}</span>
-								<span class="tabular-meta">${escapeHtml(synonym)}</span>
-							</summary>
-							<div class="tabular-details-content">
-						<div class="item-grid">
-							<div>
-								<div class="field-label">Синоним</div>
-								<div class="field-value">${escapeHtml(synonym)}</div>
-							</div>
-							<div>
-								<div class="field-label">Комментарий</div>
-								<div class="field-value">${escapeHtml(comment)}</div>
-							</div>
-							<div>
-								<div class="field-label">Реквизиты табличной части</div>
-								${attrsHtml}
-							</div>
-						</div>
-							</div>
-						</details>
+		let fieldIndex = 0;
+		const groupsHtml = (spec.groups || [])
+			.map((group) => {
+				const rows = (group.fields || [])
+					.map((field) => {
+						const control = editControlHtml(field, fieldIndex);
+						fieldIndex += 1;
+						return `<div class="edit-row">
+							<label class="edit-label">${escapeHtml(field.label)}</label>
+							<div class="edit-control">${control}</div>
+						</div>`;
+					})
+					.join('');
+				return `<div class="edit-group">
+						<div class="section-title">${escapeHtml(group.title)}</div>
+						<div class="edit-fields">${rows}</div>
 					</div>`;
 			})
-			.join('')}</div>`;
+			.join('');
+		const filterHtml = tabId === 'edit_main'
+			? `<div class="edit-filter-row">
+				<span class="edit-filter-wrap">
+					<input id="editFilterInput" class="edit-input edit-filter" type="text" placeholder="Поиск свойства..." value="${escapeHtml(editFilter)}" />
+					<button id="editFilterClear" class="edit-filter-clear${editFilter ? '' : ' hidden'}" type="button" title="Очистить">×</button>
+				</span>
+			</div>`
+			: '';
+		if (tabId === 'edit_data') {
+			// Раскладка EDT: слева редактируемые реквизиты и табличные части, справа группы свойств.
+			contentRoot.innerHTML = `${filterHtml}<div class="edit-data-layout">
+					<div class="edit-data-structure">
+						<div class="section-title">Реквизиты</div>
+						${structEditListHtml()}
+						<div class="section-title section-title-spaced">Табличные части</div>
+						${structEditTsHtml()}
+					</div>
+					<div class="edit-data-props">${groupsHtml}</div>
+				</div>`;
+			bindEditInputs(spec);
+			bindStructEditInputs(spec);
+			bindEditFilter();
+			return;
+		}
+		contentRoot.innerHTML = `${filterHtml}<div class="edit-columns">${groupsHtml}</div>`;
+		bindEditInputs(spec);
+		bindEditFilter();
+	}
+
+	function bindEditFilter() {
+		const input = /** @type {HTMLInputElement | null} */ (document.getElementById('editFilterInput'));
+		if (!input) {
+			return;
+		}
+		const clearBtn = document.getElementById('editFilterClear');
+		const sync = function () {
+			editFilter = input.value;
+			if (clearBtn) {
+				clearBtn.classList.toggle('hidden', editFilter.length === 0);
+			}
+			applyEditFilter();
+		};
+		input.addEventListener('input', sync);
+		if (clearBtn) {
+			clearBtn.addEventListener('click', function () {
+				input.value = '';
+				sync();
+				input.focus();
+			});
+		}
+		applyEditFilter();
+	}
+
+	function applyEditFilter() {
+		if (!contentRoot) {
+			return;
+		}
+		const query = editFilter.trim().toLowerCase();
+		for (const group of contentRoot.querySelectorAll('.edit-group')) {
+			let visibleRows = 0;
+			for (const row of group.querySelectorAll('.edit-row')) {
+				const label = row.querySelector('.edit-label');
+				const text = label && label.textContent ? label.textContent.toLowerCase() : '';
+				const show = query.length === 0 || text.includes(query);
+				row.classList.toggle('hidden', !show);
+				if (show) {
+					visibleRows++;
+				}
+			}
+			group.classList.toggle('hidden', visibleRows === 0);
+		}
+	}
+
+	function fieldByPath(spec, path) {
+		for (const group of spec.groups || []) {
+			for (const field of group.fields || []) {
+				if (field.path === path) {
+					return field;
+				}
+			}
+		}
+		return null;
+	}
+
+	function bindEditInputs(spec) {
+		if (!contentRoot) {
+			return;
+		}
+		const inputs = contentRoot.querySelectorAll('[data-path]');
+		for (const input of inputs) {
+			const path = input.getAttribute('data-path');
+			const control = input.getAttribute('data-control');
+			if (!path || !control) {
+				continue;
+			}
+			const handler = function () {
+				if (!editedProps) {
+					return;
+				}
+				if (control === 'check') {
+					setPath(editedProps, path, Boolean(input.checked));
+				} else if (control === 'select') {
+					setPath(editedProps, path, input.value === '' ? null : input.value);
+				} else {
+					setPath(editedProps, path, input.value);
+				}
+				const field = fieldByPath(spec, path);
+				if (control === 'check' || control === 'select') {
+					// Возможна смена доступности зависимых полей.
+					renderEditTab(spec.id);
+				}
+				void field;
+				renderSaveBar();
+			};
+			input.addEventListener(control === 'check' || control === 'select' ? 'change' : 'input', handler);
+		}
+		bindRefListButtons(spec);
+	}
+
+	function bindRefListButtons(spec) {
+		if (!contentRoot || !editedProps) {
+			return;
+		}
+		for (const btn of contentRoot.querySelectorAll('[data-ref-index]')) {
+			btn.addEventListener('click', function () {
+				const path = btn.getAttribute('data-ref-path');
+				const index = Number(btn.getAttribute('data-ref-index'));
+				const list = getPath(editedProps, path);
+				if (!Array.isArray(list) || Number.isNaN(index)) {
+					return;
+				}
+				list.splice(index, 1);
+				renderEditTab(spec.id);
+				renderSaveBar();
+			});
+		}
+		for (const select of contentRoot.querySelectorAll('[data-ref-add-select]')) {
+			select.addEventListener('change', function () {
+				const path = select.getAttribute('data-ref-add-select');
+				if (!select.value) {
+					return;
+				}
+				const list = getPath(editedProps, path);
+				if (!Array.isArray(list) || list.includes(select.value)) {
+					select.value = '';
+					return;
+				}
+				list.push(select.value);
+				renderEditTab(spec.id);
+				renderSaveBar();
+			});
+		}
+		for (const btn of contentRoot.querySelectorAll('[data-ref-move-path]')) {
+			btn.addEventListener('click', function () {
+				const path = btn.getAttribute('data-ref-move-path');
+				const index = Number(btn.getAttribute('data-ref-move-index'));
+				const dir = Number(btn.getAttribute('data-ref-move-dir'));
+				const list = getPath(editedProps, path);
+				const target = index + dir;
+				if (!Array.isArray(list) || Number.isNaN(index) || target < 0 || target >= list.length) {
+					return;
+				}
+				const moved = list.splice(index, 1)[0];
+				list.splice(target, 0, moved);
+				renderEditTab(spec.id);
+				renderSaveBar();
+			});
+		}
+		for (const btn of contentRoot.querySelectorAll('[data-module-kind]')) {
+			btn.addEventListener('click', function () {
+				if (vscodeApi) {
+					vscodeApi.postMessage({ type: 'openModule', module: btn.getAttribute('data-module-kind') });
+				}
+			});
+		}
+	}
+
+	function renderSaveBar() {
+		const bar = document.getElementById('saveBar');
+		const status = document.getElementById('saveStatus');
+		const saveBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('saveBtn'));
+		const resetBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('resetBtn'));
+		if (!bar || !status || !saveBtn || !resetBtn) {
+			return;
+		}
+		const dirty = isDirty();
+		const structError = structValidationError();
+		const visible = Boolean(editable) && (dirty || saving || Boolean(saveError) || savedFlash);
+		bar.classList.toggle('hidden', !visible);
+		if (!visible) {
+			return;
+		}
+		saveBtn.disabled = saving || !dirty || Boolean(structError);
+		resetBtn.disabled = saving || !dirty;
+		status.classList.toggle('save-status-error', Boolean(saveError) || Boolean(structError));
+		if (saving) {
+			status.textContent = 'Сохранение...';
+		} else if (dirty && structError) {
+			status.textContent = structError;
+		} else if (saveError) {
+			status.textContent = saveError;
+		} else if (dirty) {
+			status.textContent = 'Есть несохраненные изменения';
+		} else if (savedFlash) {
+			status.textContent = 'Сохранено';
+		} else {
+			status.textContent = '';
+		}
+	}
+
+	function currentTabIsEdit() {
+		const tab = tabs.find((item) => item.id === activeTabId);
+		return Boolean(tab && tab.render === 'edit');
+	}
+
+	function initSaveBar() {
+		const saveBtn = document.getElementById('saveBtn');
+		const resetBtn = document.getElementById('resetBtn');
+		if (!editable || !vscodeApi || !saveBtn || !resetBtn) {
+			return;
+		}
+		saveBtn.addEventListener('click', function () {
+			if (saving || !isDirty() || structValidationError()) {
+				return;
+			}
+			saving = true;
+			saveError = '';
+			savedFlash = false;
+			renderSaveBar();
+			vscodeApi.postMessage({ type: 'save', payload: editedProps, structure: serializeStructureEdits() });
+		});
+		resetBtn.addEventListener('click', function () {
+			if (saving || !editable) {
+				return;
+			}
+			editedProps = deepClone(editable.props);
+			editedStructure = model.structureLists ? structureEditsFromLists(model.structureLists) : null;
+			structBaselineOrderKey = structOrderKey(editedStructure);
+			saveError = '';
+			savedFlash = false;
+			if (currentTabIsEdit()) {
+				renderContent();
+			}
+			renderSaveBar();
+		});
+		window.addEventListener('message', function (event) {
+			const msg = event.data;
+			if (msg && msg.type === 'modelUpdated') {
+				if (msg.structureLists && typeof msg.structureLists === 'object') {
+					model.structureLists = msg.structureLists;
+				}
+				editedStructure = model.structureLists ? structureEditsFromLists(model.structureLists) : null;
+				structBaselineOrderKey = structOrderKey(editedStructure);
+				if (Array.isArray(msg.tabs)) {
+					tabs.length = 0;
+					for (const tab of msg.tabs) {
+						tabs.push(tab);
+					}
+					if (!tabs.some((tab) => tab.id === activeTabId)) {
+						activeTabId = tabs[0] ? tabs[0].id : '';
+					}
+				}
+				if (editable && msg.props && typeof msg.props === 'object') {
+					editable.props = msg.props;
+					if (Array.isArray(msg.editableTabs)) {
+						editable.tabs = msg.editableTabs;
+					}
+					editedProps = deepClone(editable.props);
+				}
+				renderTabs();
+				renderContent();
+				renderSaveBar();
+				return;
+			}
+			if (!msg || msg.type !== 'saved') {
+				return;
+			}
+			saving = false;
+			if (msg.ok) {
+				if (msg.props && typeof msg.props === 'object') {
+					editable.props = msg.props;
+					editedProps = deepClone(editable.props);
+				}
+				saveError = '';
+				savedFlash = true;
+				setTimeout(function () {
+					savedFlash = false;
+					renderSaveBar();
+				}, 4000);
+				if (currentTabIsEdit()) {
+					renderContent();
+				}
+			} else {
+				saveError = String(msg.error || 'Не удалось сохранить изменения.');
+			}
+			renderSaveBar();
+		});
+	}
+
+	function structRowByPath(spath) {
+		if (!editedStructure) {
+			return null;
+		}
+		const parts = String(spath).split('.');
+		if (parts[0] === 'a') {
+			return editedStructure.attributes[Number(parts[1])] || null;
+		}
+		const ts = editedStructure.tabularSections[Number(parts[1])] || null;
+		if (!ts) {
+			return null;
+		}
+		if (parts[2] === 'a') {
+			return ts.attributes[Number(parts[3])] || null;
+		}
+		return ts;
+	}
+
+	function structEditRowHtml(row, spath) {
+		const deleted = row.deleted;
+		const invalid = !deleted && !structNameValid(row.name) ? ' struct-input-invalid' : '';
+		const dis = deleted ? ' disabled' : '';
+		return `<div class="struct-item${deleted ? ' struct-item-deleted' : ''}"${row.comment ? ` title="${escapeHtml(row.comment)}"` : ''}>
+			<input class="edit-input struct-input struct-input-name${invalid}" data-spath="${spath}" data-sfield="name" value="${escapeHtml(row.name)}" placeholder="Имя" spellcheck="false"${dis} />
+			<input class="edit-input struct-input" data-spath="${spath}" data-sfield="synonymRu" value="${escapeHtml(row.synonymRu)}" placeholder="Синоним"${dis} />
+			<span class="struct-actions-inline">
+				<button type="button" class="struct-btn" data-smove="${spath}" data-smove-dir="-1" title="Вверх"${dis}>↑</button>
+				<button type="button" class="struct-btn" data-smove="${spath}" data-smove-dir="1" title="Вниз"${dis}>↓</button>
+				<button type="button" class="struct-btn${deleted ? '' : ' struct-btn-danger'}" data-sdel="${spath}" title="${deleted ? 'Вернуть' : 'Удалить'}">${deleted ? '↩' : '×'}</button>
+			</span>
+		</div>`;
+	}
+
+	function structEditListHtml() {
+		if (!editedStructure) {
+			return '<div class="edit-ref-empty">(нет данных)</div>';
+		}
+		const rows = editedStructure.attributes.map((row, idx) => structEditRowHtml(row, `a.${idx}`)).join('');
+		return `<div class="struct-list">${rows || '<div class="edit-ref-empty">(пусто)</div>'}</div>
+			<div class="struct-add-row"><button type="button" class="struct-add-btn" data-sadd="a">+ Реквизит…</button></div>`;
+	}
+
+	function structEditTsHtml() {
+		if (!editedStructure) {
+			return '<div class="edit-ref-empty">(нет данных)</div>';
+		}
+		const blocks = editedStructure.tabularSections
+			.map((ts, idx) => {
+				const nested = ts.attributes.map((row, j) => structEditRowHtml(row, `t.${idx}.a.${j}`)).join('');
+				const body = ts.deleted
+					? ''
+					: `<div class="struct-ts-body">
+						<div class="struct-list">${nested || '<div class="edit-ref-empty">(пусто)</div>'}</div>
+						<div class="struct-add-row"><button type="button" class="struct-add-btn" data-sadd="t.${idx}">+ Реквизит…</button></div>
+					</div>`;
+				return `<div class="struct-ts-block">${structEditRowHtml(ts, `t.${idx}`)}${body}</div>`;
+			})
+			.join('');
+		return `${blocks || '<div class="struct-list"><div class="edit-ref-empty">(пусто)</div></div>'}
+			<div class="struct-add-row"><button type="button" class="struct-add-btn" data-sadd="t">+ Табличная часть…</button></div>`;
+	}
+
+	function bindStructEditInputs(spec) {
+		if (!contentRoot || !editedStructure) {
+			return;
+		}
+		for (const input of contentRoot.querySelectorAll('[data-spath]')) {
+			input.addEventListener('input', function () {
+				const spath = input.getAttribute('data-spath');
+				const row = structRowByPath(spath);
+				const field = input.getAttribute('data-sfield');
+				if (!row || !field) {
+					return;
+				}
+				if (field === 'name') {
+					// Синоним следует за именем, пока пользователь не задал его вручную.
+					const followsName = row.synonymRu === '' || row.synonymRu === synonymFromName(row.name);
+					row.name = input.value;
+					input.classList.toggle('struct-input-invalid', !row.deleted && !structNameValid(input.value));
+					if (followsName) {
+						row.synonymRu = synonymFromName(input.value);
+						const synInput = contentRoot.querySelector(
+							`[data-spath="${CSS.escape(spath)}"][data-sfield="synonymRu"]`
+						);
+						if (synInput) {
+							synInput.value = row.synonymRu;
+						}
+					}
+				} else {
+					row[field] = input.value;
+				}
+				renderSaveBar();
+			});
+		}
+		for (const btn of contentRoot.querySelectorAll('[data-sdel]')) {
+			btn.addEventListener('click', function () {
+				const spath = btn.getAttribute('data-sdel');
+				const row = structRowByPath(spath);
+				if (!row) {
+					return;
+				}
+				if (!row.originalName && !row.deleted) {
+					// Новая строка: удаляем совсем.
+					const parts = spath.split('.');
+					if (parts[0] === 'a') {
+						editedStructure.attributes.splice(Number(parts[1]), 1);
+					} else if (parts[2] === 'a') {
+						editedStructure.tabularSections[Number(parts[1])].attributes.splice(Number(parts[3]), 1);
+					} else {
+						editedStructure.tabularSections.splice(Number(parts[1]), 1);
+					}
+				} else {
+					row.deleted = !row.deleted;
+				}
+				renderEditTab(spec.id);
+				renderSaveBar();
+			});
+		}
+		for (const btn of contentRoot.querySelectorAll('[data-smove]')) {
+			btn.addEventListener('click', function () {
+				const spath = btn.getAttribute('data-smove');
+				const dir = Number(btn.getAttribute('data-smove-dir'));
+				const parts = String(spath).split('.');
+				let list = null;
+				let index = -1;
+				if (parts[0] === 'a') {
+					list = editedStructure.attributes;
+					index = Number(parts[1]);
+				} else if (parts[2] === 'a') {
+					list = editedStructure.tabularSections[Number(parts[1])]
+						? editedStructure.tabularSections[Number(parts[1])].attributes
+						: null;
+					index = Number(parts[3]);
+				} else {
+					list = editedStructure.tabularSections;
+					index = Number(parts[1]);
+				}
+				const target = index + dir;
+				if (!list || Number.isNaN(index) || target < 0 || target >= list.length) {
+					return;
+				}
+				const moved = list.splice(index, 1)[0];
+				list.splice(target, 0, moved);
+				renderEditTab(spec.id);
+				renderSaveBar();
+			});
+		}
+		for (const btn of contentRoot.querySelectorAll('[data-sadd]')) {
+			btn.addEventListener('click', function () {
+				const target = btn.getAttribute('data-sadd');
+				const emptyRow = { originalName: '', name: '', synonymRu: '', baselineSynonymRu: '', comment: '', deleted: false };
+				let newSpath = '';
+				if (target === 'a') {
+					editedStructure.attributes.push({ ...emptyRow });
+					newSpath = `a.${editedStructure.attributes.length - 1}`;
+				} else if (target === 't') {
+					editedStructure.tabularSections.push({ ...emptyRow, attributes: [] });
+					newSpath = `t.${editedStructure.tabularSections.length - 1}`;
+				} else {
+					const idx = Number(target.split('.')[1]);
+					if (editedStructure.tabularSections[idx]) {
+						editedStructure.tabularSections[idx].attributes.push({ ...emptyRow });
+						newSpath = `t.${idx}.a.${editedStructure.tabularSections[idx].attributes.length - 1}`;
+					}
+				}
+				renderEditTab(spec.id);
+				if (newSpath) {
+					const added = contentRoot.querySelector(
+						`[data-spath="${CSS.escape(newSpath)}"][data-sfield="name"]`
+					);
+					if (added) {
+						added.focus();
+					}
+				}
+				renderSaveBar();
+			});
+		}
+	}
+
+	function readonlyStructRowHtml(item) {
+		const name = toDisplayText(item.name);
+		const synonymRaw = typeof item.synonymRu === 'string' ? item.synonymRu.trim() : '';
+		const synonym = synonymRaw && synonymRaw !== item.name ? synonymRaw : '';
+		const comment = typeof item.comment === 'string' ? item.comment.trim() : '';
+		return `<div class="struct-item"${comment ? ` title="${escapeHtml(comment)}"` : ''}>
+			<span class="struct-item-name">${escapeHtml(name)}</span>
+			<span class="struct-item-syn">${escapeHtml(synonym)}</span>
+		</div>`;
+	}
+
+	function renderNamed(tab) {
+		if (!contentRoot) {
+			return;
+		}
+		const items = Array.isArray(tab.data) ? tab.data.map((x) => asObject(x)).filter((x) => x.name) : [];
+		const rows = items.map((item) => readonlyStructRowHtml(item)).join('');
+		contentRoot.innerHTML = `<div class="struct-list">${rows || '<div class="edit-ref-empty">(пусто)</div>'}</div>`;
+	}
+
+	function renderTabular(tab) {
+		if (!contentRoot) {
+			return;
+		}
+		const items = Array.isArray(tab.data) ? tab.data.map((x) => asObject(x)).filter((x) => x.name) : [];
+		const blocks = items
+			.map((item) => {
+				const attrs = Array.isArray(item.attributes) ? item.attributes.map((x) => asObject(x)).filter((x) => x.name) : [];
+				const nested = attrs.map((attr) => readonlyStructRowHtml(attr)).join('');
+				return `<div class="struct-ts-block">${readonlyStructRowHtml(item)}
+					<div class="struct-ts-body"><div class="struct-list">${nested || '<div class="edit-ref-empty">(пусто)</div>'}</div></div>
+				</div>`;
+			})
+			.join('');
+		contentRoot.innerHTML = blocks || '<div class="empty">Нет данных.</div>';
 	}
 
 	function renderSubsystemContent(data) {
@@ -489,4 +1277,6 @@
 	renderTabs();
 	renderContent();
 	renderTechnical();
+	initSaveBar();
+	renderSaveBar();
 })();

--- a/resources/webview/metadata-object.js
+++ b/resources/webview/metadata-object.js
@@ -110,12 +110,12 @@
 			return;
 		}
 		for (const row of editedStructure.attributes) {
-			fn(row, null);
+			fn(row);
 		}
 		for (const ts of editedStructure.tabularSections) {
-			fn(ts, null);
+			fn(ts);
 			for (const row of ts.attributes) {
-				fn(row, ts);
+				fn(row);
 			}
 		}
 	}

--- a/src/features/metadata/er/erGraphService.ts
+++ b/src/features/metadata/er/erGraphService.ts
@@ -14,6 +14,7 @@ import * as fssync from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { logger } from '../../../shared/logger';
+import { configuredSourceDirs } from '../../../shared/sourcePaths';
 import { ensureMdSparrowRuntime } from '../mdSparrowBootstrap';
 import { isMdSparrowUnknownCommandError, MdSparrowOutdatedError } from '../mdSparrowErrors';
 import { runMdSparrowParamsRead } from '../mdSparrowParams';
@@ -47,16 +48,17 @@ function resolveCacheFile(context: vscode.ExtensionContext): string {
 	return path.join(storageUri.fsPath, 'er-cache', 'er-graph.json');
 }
 
-/** Список «интересных» каталогов: src/cf, src/cfe/*, src/erf/*, src/epf/*. */
+/** Список «интересных» каталогов по настройкам paths.*: cf, cfe/*, erf/*, epf/*. */
 async function collectGraphRoots(workspaceRoot: string): Promise<string[]> {
+	const dirs = configuredSourceDirs();
 	const roots: string[] = [];
-	const cfRoot = path.join(workspaceRoot, 'src', 'cf');
+	const cfRoot = path.join(workspaceRoot, ...dirs.cf.split('/'));
 	if (fssync.existsSync(cfRoot)) {
 		roots.push(cfRoot);
 	}
-	const subRoots = ['cfe', 'erf', 'epf'];
+	const subRoots = [dirs.cfe, dirs.erf, dirs.epf];
 	for (const seg of subRoots) {
-		const dir = path.join(workspaceRoot, 'src', seg);
+		const dir = path.join(workspaceRoot, ...seg.split('/'));
 		if (!fssync.existsSync(dir)) {
 			continue;
 		}
@@ -220,9 +222,17 @@ export async function loadErGraph(
 		return { graph: cached, fromCache: true, fingerprint };
 	}
 	options.progress?.report({ message: 'ER: построение графа (md-sparrow cf-md-graph)' });
+	const graphDirs = configuredSourceDirs();
 	const res = await runMdSparrowParamsRead(
 		runtime,
-		{ op: 'cf-md-graph', projectRoot: workspaceRoot },
+		{
+			op: 'cf-md-graph',
+			projectRoot: workspaceRoot,
+			cfDir: graphDirs.cf,
+			cfeDir: graphDirs.cfe,
+			epfDir: graphDirs.epf,
+			erfDir: graphDirs.erf,
+		},
 		{ cwd: workspaceRoot, token: options.token }
 	);
 	if (res.exitCode !== 0) {

--- a/src/features/metadata/mdSparrowParams.ts
+++ b/src/features/metadata/mdSparrowParams.ts
@@ -39,11 +39,15 @@ export type MdSparrowOp =
 	| 'cf-md-tabular-attribute-rename'
 	| 'cf-md-tabular-attribute-delete'
 	| 'cf-md-tabular-attribute-duplicate'
+	| 'cf-md-attribute-reorder'
+	| 'cf-md-tabular-section-reorder'
+	| 'cf-md-tabular-attribute-reorder'
 	| 'external-artifact-rename'
 	| 'external-artifact-delete'
 	| 'external-artifact-duplicate'
 	| 'external-artifact-add'
 	| 'external-artifact-properties-set'
+	| 'cf-md-object-set'
 	| 'cf-configuration-properties-set'
 	| 'init-empty-cf'
 	| 'add-md-object'
@@ -53,6 +57,7 @@ export type MdSparrowOp =
 	| 'external-artifact-properties-get'
 	| 'cf-configuration-properties-get'
 	| 'cf-list-child-objects'
+	| 'cf-list-catalogs'
 	| 'project-metadata-tree'
 	| 'cf-md-graph';
 
@@ -64,6 +69,11 @@ export interface MdSparrowParams {
 	artifactsRoot?: string;
 	targetCfRoot?: string;
 	projectRoot?: string;
+	/** Каталоги исходников относительно projectRoot; пусто — стандартные src/cf, src/cfe, src/epf, src/erf. */
+	cfDir?: string;
+	cfeDir?: string;
+	epfDir?: string;
+	erfDir?: string;
 	tag?: string;
 	name?: string;
 	oldName?: string;
@@ -81,6 +91,9 @@ export interface MdSparrowParams {
 	payloadJson?: string;
 }
 
+/** Сквозной счётчик имён params-файлов: параллельные вызовы в одну миллисекунду не должны делить файл. */
+let paramsFileSeq = 0;
+
 async function writeParamsAndRun(
 	runtime: MdSparrowRuntime,
 	command: 'apply-mutation' | 'read-json',
@@ -90,7 +103,8 @@ async function writeParamsAndRun(
 		token?: vscode.CancellationToken;
 	}
 ): Promise<MdSparrowRunResult> {
-	const tmpPath = path.join(os.tmpdir(), `md-sparrow-${command}-${Date.now()}-${process.pid}.json`);
+	paramsFileSeq += 1;
+	const tmpPath = path.join(os.tmpdir(), `md-sparrow-${command}-${Date.now()}-${process.pid}-${paramsFileSeq}.json`);
 	await fs.writeFile(tmpPath, JSON.stringify(params), 'utf8');
 	try {
 		return await runMdSparrow(runtime, [command, '--params', tmpPath], options);

--- a/src/features/metadata/metadataObjectEditSpec.ts
+++ b/src/features/metadata/metadataObjectEditSpec.ts
@@ -1,0 +1,589 @@
+/**
+ * Спецификация редактируемых вкладок панели свойств объекта метаданных.
+ * Спека — единственный источник правды о том, какие поля DTO можно менять из webview:
+ * по ней строится форма и по ней же фильтруются значения при сохранении.
+ * Значения enum-свойств — имена Java-констант md-sparrow (`BOTH_WAYS`, `QUICK_CHOICE`).
+ * @module metadataObjectEditSpec
+ */
+
+export type MetadataEditControl =
+	| 'text'
+	| 'textarea'
+	| 'check'
+	| 'number'
+	| 'select'
+	| 'staticList'
+	| 'refList'
+	| 'moduleLink';
+
+export interface MetadataEditOption {
+	readonly value: string;
+	readonly label: string;
+}
+
+/** Поле активно, только если значение по path равно equals (все условия одновременно). */
+export interface MetadataEditCondition {
+	readonly path: string;
+	readonly equals: string | boolean;
+}
+
+export interface MetadataEditField {
+	/** Путь в DTO свойств: `synonymRu` или `catalog.choiceMode`. */
+	readonly path: string;
+	readonly label: string;
+	readonly control: MetadataEditControl;
+	/** Для select — значения; для refList — кандидаты на добавление. */
+	readonly options?: readonly MetadataEditOption[];
+	readonly readonly?: boolean;
+	/** select: пустой выбор — это очистка значения (пишется пустым), а не «оставить как есть». */
+	readonly clearable?: boolean;
+	readonly enabledWhen?: readonly MetadataEditCondition[];
+	/** Элементы staticList, когда они берутся не из DTO (формы, команды из структуры). */
+	readonly items?: readonly string[];
+}
+
+export interface MetadataEditGroup {
+	readonly title: string;
+	readonly fields: readonly MetadataEditField[];
+}
+
+export interface MetadataEditTabSpec {
+	readonly id: string;
+	readonly title: string;
+	readonly groups: readonly MetadataEditGroup[];
+}
+
+function opts(...pairs: Array<[string, string]>): MetadataEditOption[] {
+	return pairs.map(([value, label]) => ({ value, label }));
+}
+
+const USE_DONT_USE = opts(['USE', 'Использовать'], ['DONT_USE', 'Не использовать']);
+
+interface CatalogEditSpecInput {
+	internalName: string;
+	formNames: readonly string[];
+	commandNames: readonly string[];
+	/** Имена всех справочников конфигурации — кандидаты во владельцы и в основания. */
+	catalogNames?: readonly string[];
+	/** Имена документов конфигурации — кандидаты в основания. */
+	documentNames?: readonly string[];
+	/** Имена реквизитов объекта — кандидаты для ввода по строке и полей блокировки. */
+	attributeNames?: readonly string[];
+	/** Есть ли владельцы на момент открытия — влияет на кандидатов полей блокировки. */
+	hasOwners?: boolean;
+	/** Иерархический ли на момент открытия — влияет на кандидатов полей блокировки. */
+	hierarchical?: boolean;
+}
+
+function formOptions(internalName: string, formNames: readonly string[]): MetadataEditOption[] {
+	return [
+		{ value: '', label: '(не задана)' },
+		...formNames.map((name) => ({ value: `Catalog.${internalName}.Form.${name}`, label: name })),
+	];
+}
+
+function ownerOptions(internalName: string, catalogNames: readonly string[]): MetadataEditOption[] {
+	return catalogNames
+		.filter((name) => name !== internalName)
+		.map((name) => ({ value: `Catalog.${name}`, label: name }));
+}
+
+function inputByStringOptions(internalName: string, attributeNames: readonly string[]): MetadataEditOption[] {
+	const base = `Catalog.${internalName}`;
+	return [
+		{ value: `${base}.StandardAttribute.Description`, label: 'Наименование' },
+		{ value: `${base}.StandardAttribute.Code`, label: 'Код' },
+		...attributeNames.map((name) => ({ value: `${base}.Attribute.${name}`, label: name })),
+	];
+}
+
+function dataLockFieldsOptions(input: CatalogEditSpecInput): MetadataEditOption[] {
+	const base = `Catalog.${input.internalName}`;
+	const out: MetadataEditOption[] = [
+		{ value: `${base}.StandardAttribute.Code`, label: 'Код' },
+		{ value: `${base}.StandardAttribute.Description`, label: 'Наименование' },
+	];
+	if (input.hasOwners) {
+		out.push({ value: `${base}.StandardAttribute.Owner`, label: 'Владелец' });
+	}
+	if (input.hierarchical) {
+		out.push({ value: `${base}.StandardAttribute.Parent`, label: 'Родитель' });
+	}
+	for (const name of input.attributeNames ?? []) {
+		out.push({ value: `${base}.Attribute.${name}`, label: name });
+	}
+	return out;
+}
+
+function basedOnOptions(input: CatalogEditSpecInput): MetadataEditOption[] {
+	return [
+		...(input.catalogNames ?? []).map((name) => ({ value: `Catalog.${name}`, label: `Справочник: ${name}` })),
+		...(input.documentNames ?? []).map((name) => ({ value: `Document.${name}`, label: `Документ: ${name}` })),
+	];
+}
+
+const HIERARCHICAL_ON: readonly MetadataEditCondition[] = [{ path: 'catalog.hierarchical', equals: true }];
+
+/**
+ * Вкладки редактирования справочника: раскладка повторяет редактор EDT
+ * (Основные, Данные, Владельцы, Формы, Команды).
+ */
+export function buildCatalogEditTabs(input: CatalogEditSpecInput): MetadataEditTabSpec[] {
+	const forms = formOptions(input.internalName, input.formNames);
+	const owners = ownerOptions(input.internalName, input.catalogNames ?? []);
+	const inputByString = inputByStringOptions(input.internalName, input.attributeNames ?? []);
+	const dataLockFields = dataLockFieldsOptions(input);
+	const basedOn = basedOnOptions(input);
+	return [
+		{
+			id: 'edit_main',
+			title: 'Основные',
+			groups: [
+				{
+					title: 'Основные',
+					fields: [
+						{ path: 'internalName', label: 'Имя', control: 'text', readonly: true },
+						{ path: 'synonymRu', label: 'Синоним', control: 'text' },
+						{ path: 'comment', label: 'Комментарий', control: 'text' },
+						{ path: 'object', label: 'Модуль объекта', control: 'moduleLink' },
+						{ path: 'manager', label: 'Модуль менеджера', control: 'moduleLink' },
+					],
+				},
+				{
+					title: 'Представление',
+					fields: [
+						{ path: 'catalog.objectPresentationRu', label: 'Представление объекта', control: 'text' },
+						{
+							path: 'catalog.extendedObjectPresentationRu',
+							label: 'Расширенное представление объекта',
+							control: 'text',
+						},
+						{ path: 'catalog.listPresentationRu', label: 'Представление списка', control: 'text' },
+						{
+							path: 'catalog.extendedListPresentationRu',
+							label: 'Расширенное представление списка',
+							control: 'text',
+						},
+						{ path: 'catalog.explanationRu', label: 'Пояснение', control: 'textarea' },
+					],
+				},
+				{
+					title: 'Иерархия',
+					fields: [
+						{ path: 'catalog.hierarchical', label: 'Иерархический', control: 'check' },
+						{
+							path: 'catalog.hierarchyType',
+							label: 'Вид иерархии',
+							control: 'select',
+							options: opts(
+								['HIERARCHY_FOLDERS_AND_ITEMS', 'Иерархия групп и элементов'],
+								['HIERARCHY_OF_ITEMS', 'Иерархия элементов']
+							),
+							enabledWhen: HIERARCHICAL_ON,
+						},
+						{
+							path: 'catalog.foldersOnTop',
+							label: 'Размещать группы сверху',
+							control: 'check',
+							enabledWhen: HIERARCHICAL_ON,
+						},
+						{
+							path: 'catalog.limitLevelCount',
+							label: 'Ограничивать количество уровней',
+							control: 'check',
+							enabledWhen: HIERARCHICAL_ON,
+						},
+						{
+							path: 'catalog.levelCount',
+							label: 'Количество уровней',
+							control: 'number',
+							enabledWhen: [...HIERARCHICAL_ON, { path: 'catalog.limitLevelCount', equals: true }],
+						},
+					],
+				},
+				{
+					title: 'Нумерация',
+					fields: [
+						{ path: 'catalog.autonumbering', label: 'Автонумерация', control: 'check' },
+						{ path: 'catalog.checkUnique', label: 'Контроль уникальности', control: 'check' },
+						{
+							path: 'catalog.codeSeries',
+							label: 'Серии кодов',
+							control: 'select',
+							options: opts(
+								['WHOLE_CATALOG', 'Во всем справочнике'],
+								['WITHIN_SUBORDINATION', 'В пределах подчинения'],
+								['WITHIN_OWNER_SUBORDINATION', 'В пределах подчинения владельцу']
+							),
+						},
+					],
+				},
+				{
+					title: 'Поле ввода',
+					fields: [
+						{ path: 'catalog.quickChoice', label: 'Быстрый выбор', control: 'check' },
+						{
+							path: 'catalog.choiceMode',
+							label: 'Способ выбора',
+							control: 'select',
+							options: opts(
+								['FROM_FORM', 'Из формы'],
+								['QUICK_CHOICE', 'Быстрый выбор'],
+								['BOTH_WAYS', 'Обоими способами']
+							),
+						},
+						{
+							path: 'catalog.createOnInput',
+							label: 'Создание при вводе',
+							control: 'select',
+							options: opts(['AUTO', 'Авто'], ['USE', 'Использовать'], ['DONT_USE', 'Не использовать']),
+						},
+						{ path: 'catalog.inputByString', label: 'Ввод по строке', control: 'refList', options: inputByString },
+						{
+							path: 'catalog.searchStringModeOnInputByString',
+							label: 'Способ поиска строки при вводе',
+							control: 'select',
+							options: opts(['BEGIN', 'Начало'], ['ANY_PART', 'Любая часть']),
+						},
+						{
+							path: 'catalog.fullTextSearchOnInputByString',
+							label: 'Полнотекстовый поиск при вводе',
+							control: 'select',
+							options: USE_DONT_USE,
+						},
+						{
+							path: 'catalog.choiceDataGetModeOnInputByString',
+							label: 'Режим получения данных выбора',
+							control: 'select',
+							options: opts(['DIRECTLY', 'Непосредственно'], ['BACKGROUND', 'Фоновым заданием']),
+						},
+						{
+							path: 'catalog.choiceHistoryOnInput',
+							label: 'История выбора при вводе',
+							control: 'select',
+							options: opts(['AUTO', 'Авто'], ['DONT_USE', 'Не использовать']),
+						},
+					],
+				},
+				{
+					title: 'Прочее',
+					fields: [
+						{
+							path: 'catalog.editType',
+							label: 'Способ редактирования',
+							control: 'select',
+							options: opts(['IN_DIALOG', 'В диалоге'], ['IN_LIST', 'В списке'], ['BOTH_WAYS', 'Обоими способами']),
+						},
+						{
+							path: 'catalog.predefinedDataUpdate',
+							label: 'Обновление предопределенных данных',
+							control: 'select',
+							options: opts(
+								['AUTO', 'Авто'],
+								['AUTO_UPDATE', 'Обновлять автоматически'],
+								['DONT_AUTO_UPDATE', 'Не обновлять автоматически']
+							),
+						},
+						{ path: 'catalog.dataLockFields', label: 'Поля блокировки данных', control: 'refList', options: dataLockFields },
+						{
+							path: 'catalog.dataLockControlMode',
+							label: 'Режим управления блокировкой данных',
+							control: 'select',
+							options: opts(
+								['AUTOMATIC', 'Автоматический'],
+								['MANAGED', 'Управляемый'],
+								['AUTOMATIC_AND_MANAGED', 'Автоматический и управляемый']
+							),
+						},
+						{
+							path: 'catalog.fullTextSearch',
+							label: 'Полнотекстовый поиск',
+							control: 'select',
+							options: USE_DONT_USE,
+						},
+						{
+							path: 'catalog.dataHistory',
+							label: 'История данных',
+							control: 'select',
+							options: USE_DONT_USE,
+						},
+						{
+							path: 'catalog.updateDataHistoryImmediatelyAfterWrite',
+							label: 'Обновлять историю данных сразу после записи',
+							control: 'check',
+							enabledWhen: [{ path: 'catalog.dataHistory', equals: 'USE' }],
+						},
+						{
+							path: 'catalog.executeAfterWriteDataHistoryVersionProcessing',
+							label: 'Выполнять обработку версий истории данных после записи',
+							control: 'check',
+							enabledWhen: [{ path: 'catalog.dataHistory', equals: 'USE' }],
+						},
+						{ path: 'catalog.includeHelpInContents', label: 'Включать в содержание справки', control: 'check' },
+					],
+				},
+			],
+		},
+		{
+			id: 'edit_data',
+			title: 'Данные',
+			groups: [
+				{
+					title: 'Код',
+					fields: [
+						{ path: 'catalog.codeLength', label: 'Длина кода', control: 'number' },
+						{ path: 'catalog.descriptionLength', label: 'Длина наименования', control: 'number' },
+						{
+							path: 'catalog.codeType',
+							label: 'Тип кода',
+							control: 'select',
+							options: opts(['STRING', 'Строка'], ['NUMBER', 'Число']),
+						},
+						{
+							path: 'catalog.codeAllowedLength',
+							label: 'Допустимая длина кода',
+							control: 'select',
+							options: opts(['VARIABLE', 'Переменная'], ['FIXED', 'Фиксированная']),
+						},
+						{
+							path: 'catalog.defaultPresentation',
+							label: 'Основное представление',
+							control: 'select',
+							options: opts(['AS_DESCRIPTION', 'В виде наименования'], ['AS_CODE', 'В виде кода']),
+						},
+					],
+				},
+			],
+		},
+		{
+			id: 'edit_owners',
+			title: 'Владельцы',
+			groups: [
+				{
+					title: 'Владельцы',
+					fields: [
+						{ path: 'catalog.owners', label: 'Владельцы', control: 'refList', options: owners },
+						{
+							path: 'catalog.subordinationUse',
+							label: 'Использование подчинения',
+							control: 'select',
+							options: opts(
+								['TO_ITEMS', 'Элементам'],
+								['TO_FOLDERS', 'Группам'],
+								['TO_FOLDERS_AND_ITEMS', 'Группам и элементам']
+							),
+						},
+					],
+				},
+			],
+		},
+		{
+			id: 'edit_forms',
+			title: 'Формы',
+			groups: [
+				{
+					title: 'Основные формы',
+					fields: [
+						{
+							path: 'catalog.defaultObjectForm',
+							label: 'Основная форма объекта',
+							control: 'select',
+							options: forms,
+							clearable: true,
+						},
+						{
+							path: 'catalog.defaultFolderForm',
+							label: 'Основная форма группы',
+							control: 'select',
+							options: forms,
+							clearable: true,
+							enabledWhen: [
+								...HIERARCHICAL_ON,
+								{ path: 'catalog.hierarchyType', equals: 'HIERARCHY_FOLDERS_AND_ITEMS' },
+							],
+						},
+						{
+							path: 'catalog.defaultListForm',
+							label: 'Основная форма списка',
+							control: 'select',
+							options: forms,
+							clearable: true,
+						},
+						{
+							path: 'catalog.defaultChoiceForm',
+							label: 'Основная форма выбора',
+							control: 'select',
+							options: forms,
+							clearable: true,
+						},
+						{
+							path: 'catalog.defaultFolderChoiceForm',
+							label: 'Основная форма выбора группы',
+							control: 'select',
+							options: forms,
+							clearable: true,
+							enabledWhen: [
+								...HIERARCHICAL_ON,
+								{ path: 'catalog.hierarchyType', equals: 'HIERARCHY_FOLDERS_AND_ITEMS' },
+							],
+						},
+					],
+				},
+				{
+					title: 'Формы',
+					fields: [{ path: '', label: 'Формы объекта', control: 'staticList', items: input.formNames }],
+				},
+			],
+		},
+		{
+			id: 'edit_commands',
+			title: 'Команды',
+			groups: [
+				{
+					title: 'Команды',
+					fields: [
+						{ path: 'catalog.useStandardCommands', label: 'Использовать стандартные команды', control: 'check' },
+						{ path: '', label: 'Команды объекта', control: 'staticList', items: input.commandNames },
+					],
+				},
+			],
+		},
+		{
+			id: 'edit_basedon',
+			title: 'Ввод на основании',
+			groups: [
+				{
+					title: 'Ввод на основании',
+					fields: [{ path: 'catalog.basedOn', label: 'Вводится на основании', control: 'refList', options: basedOn }],
+				},
+			],
+		},
+	];
+}
+
+function isEditableField(field: MetadataEditField): boolean {
+	return !field.readonly && field.control !== 'staticList' && field.control !== 'moduleLink' && field.path.length > 0;
+}
+
+function readPath(source: unknown, dotPath: string): unknown {
+	let current: unknown = source;
+	for (const part of dotPath.split('.')) {
+		if (typeof current !== 'object' || current === null) {
+			return undefined;
+		}
+		current = (current as Record<string, unknown>)[part];
+	}
+	return current;
+}
+
+function writePath(target: Record<string, unknown>, dotPath: string, value: unknown): void {
+	const parts = dotPath.split('.');
+	let current: Record<string, unknown> = target;
+	for (const part of parts.slice(0, -1)) {
+		const next = current[part];
+		if (typeof next !== 'object' || next === null) {
+			return;
+		}
+		current = next as Record<string, unknown>;
+	}
+	current[parts.at(-1) as string] = value;
+}
+
+function normalizeRefList(
+	field: MetadataEditField,
+	value: unknown,
+	currentValue: unknown
+): { ok: boolean; value?: unknown } {
+	if (!Array.isArray(value)) {
+		return { ok: false };
+	}
+	const allowed = new Set<string>((field.options ?? []).map((option) => option.value));
+	if (Array.isArray(currentValue)) {
+		for (const item of currentValue) {
+			if (typeof item === 'string') {
+				allowed.add(item);
+			}
+		}
+	}
+	const out: string[] = [];
+	for (const item of value) {
+		if (typeof item === 'string' && allowed.has(item) && !out.includes(item)) {
+			out.push(item);
+		}
+	}
+	return { ok: true, value: out };
+}
+
+function normalizeFieldValue(
+	field: MetadataEditField,
+	value: unknown,
+	rawValue: unknown
+): { ok: boolean; value?: unknown } {
+	switch (field.control) {
+		case 'check':
+			return typeof value === 'boolean' ? { ok: true, value } : { ok: false };
+		case 'number': {
+			if (typeof value !== 'string' && typeof value !== 'number') {
+				return { ok: false };
+			}
+			const text = String(value).trim();
+			return /^\d+$/.test(text) ? { ok: true, value: text } : { ok: false };
+		}
+		case 'select': {
+			if (value === null || value === '') {
+				if (field.clearable) {
+					// Пустой выбор очищаемого поля: если на диске значение было — пишем пустым, иначе не трогаем.
+					const rawEmpty = rawValue === null || rawValue === undefined || rawValue === '';
+					return { ok: true, value: rawEmpty ? (rawValue ?? null) : '' };
+				}
+				return { ok: true, value: null };
+			}
+			if (typeof value !== 'string') {
+				return { ok: false };
+			}
+			const known = field.options?.some((option) => option.value === value) ?? false;
+			return known ? { ok: true, value } : { ok: false };
+		}
+		case 'text':
+		case 'textarea':
+			return typeof value === 'string' ? { ok: true, value } : { ok: false };
+		default:
+			return { ok: false };
+	}
+}
+
+/**
+ * Переносит в глубокую копию rawProps только значения полей, которые спека объявляет редактируемыми.
+ * Всё остальное (списки, структура, неизвестные поля) остаётся как на диске — webview им не доверяем.
+ */
+export function applyEditedScalars(
+	rawProps: Record<string, unknown>,
+	edited: unknown,
+	tabs: readonly MetadataEditTabSpec[]
+): Record<string, unknown> {
+	const result = structuredClone(rawProps);
+	if (typeof edited !== 'object' || edited === null) {
+		return result;
+	}
+	for (const tab of tabs) {
+		for (const group of tab.groups) {
+			for (const field of group.fields) {
+				if (!isEditableField(field)) {
+					continue;
+				}
+				const incoming = readPath(edited, field.path);
+				if (incoming === undefined) {
+					continue;
+				}
+				const normalized =
+					field.control === 'refList'
+						? normalizeRefList(field, incoming, readPath(rawProps, field.path))
+						: normalizeFieldValue(field, incoming, readPath(rawProps, field.path));
+				if (normalized.ok) {
+					writePath(result, field.path, normalized.value);
+				}
+			}
+		}
+	}
+	return result;
+}

--- a/src/features/metadata/metadataObjectPropertiesPanel.ts
+++ b/src/features/metadata/metadataObjectPropertiesPanel.ts
@@ -1,5 +1,6 @@
 /**
- * Панель свойств объекта метаданных (webview): только чтение через md-sparrow.
+ * Панель свойств объекта метаданных (webview): чтение через md-sparrow,
+ * для справочника — редактирование скалярных свойств с записью `cf-md-object-set`.
  * @module metadataObjectPropertiesPanel
  */
 
@@ -8,7 +9,8 @@ import * as vscode from 'vscode';
 import { ensureMdSparrowRuntime } from './mdSparrowBootstrap';
 import { logger } from '../../shared/logger';
 import { mdSparrowSchemaFlagFromConfigurationXml } from './mdSparrowSchemaVersion';
-import { runMdSparrowParamsRead, type MdSparrowParams } from './mdSparrowParams';
+import { runMdSparrowParamsMutation, runMdSparrowParamsRead, type MdSparrowParams } from './mdSparrowParams';
+import { applyEditedScalars, buildCatalogEditTabs, type MetadataEditTabSpec } from './metadataObjectEditSpec';
 import {
 	metadataObjectPropertyProfileByType,
 	type MetadataObjectPropertyProfile,
@@ -60,8 +62,19 @@ interface MetadataPanelTab {
 	id: string;
 	title: string;
 	count?: number;
-	render: 'overview' | 'named' | 'tabular' | 'list' | 'kv' | 'json' | 'subsystemContent';
+	render: 'overview' | 'named' | 'tabular' | 'list' | 'kv' | 'json' | 'subsystemContent' | 'edit';
 	data?: unknown;
+}
+
+interface MetadataPanelEditableModel {
+	props: MdObjectPropertiesDto;
+	tabs: MetadataEditTabSpec[];
+}
+
+/** Списки структуры для вкладки «Данные» (реквизиты и табличные части с операциями). */
+interface MetadataPanelStructureLists {
+	attributes: MetadataNamedRow[];
+	tabularSections: MetadataTabularSectionRow[];
 }
 
 interface MetadataNamedRow {
@@ -93,6 +106,8 @@ interface MetadataPanelViewModel {
 	warnings: string[];
 	tabs: MetadataPanelTab[];
 	technicalJson: string;
+	editable?: MetadataPanelEditableModel;
+	structureLists?: MetadataPanelStructureLists;
 }
 
 interface OpenMetadataObjectPropertiesParams {
@@ -101,6 +116,8 @@ interface OpenMetadataObjectPropertiesParams {
 	cfgPath?: string;
 	schemaFlag?: string;
 	objectType?: string;
+	/** Общая очередь мутаций md-sparrow; без неё сохранение выполняется вне очереди. */
+	enqueueMutation?: <T>(fn: () => Promise<T>) => Promise<T>;
 }
 
 const OBJECT_TYPE_ALIASES: Record<string, string> = {
@@ -945,12 +962,76 @@ function buildProfileTabs(
 	return tabs;
 }
 
+/** Вкладки профиля, замещённые редактируемыми (формы, команды, реквизиты и ТЧ уходят в edit-вкладки). */
+const TAB_IDS_REPLACED_BY_EDIT = new Set<string>([
+	'overview',
+	'section_forms',
+	'section_commands',
+	'attributes',
+	'tabularSections',
+]);
+
 function buildTabs(
 	props: MdObjectPropertiesDto | null,
 	structure: MdObjectStructureDto | null,
-	objectType: string
+	objectType: string,
+	editable?: MetadataPanelEditableModel
 ): MetadataPanelTab[] {
-	return buildProfileTabs(objectType, props, structure);
+	const profileTabs = buildProfileTabs(objectType, props, structure);
+	if (!editable) {
+		return profileTabs;
+	}
+	const editTabs: MetadataPanelTab[] = editable.tabs.map((tab) => ({
+		id: tab.id,
+		title: tab.title,
+		render: 'edit',
+	}));
+	return [...editTabs, ...profileTabs.filter((tab) => !TAB_IDS_REPLACED_BY_EDIT.has(tab.id))];
+}
+
+function rawNameList(value: unknown): string[] {
+	if (!Array.isArray(value)) {
+		return [];
+	}
+	const out: string[] = [];
+	for (const item of value) {
+		if (typeof item === 'string' && item.trim().length > 0) {
+			out.push(item.trim());
+		} else if (isRecord(item) && typeof item.name === 'string' && item.name.trim().length > 0) {
+			out.push(item.name.trim());
+		}
+	}
+	return Array.from(new Set(out));
+}
+
+function buildEditableModel(
+	props: MdObjectPropertiesDto | null,
+	structure: MdObjectStructureDto | null,
+	internalName: string,
+	catalogNames: readonly string[] = [],
+	documentNames: readonly string[] = []
+): MetadataPanelEditableModel | undefined {
+	if (!props || props.kind !== 'catalog' || !isRecord(props.catalog)) {
+		return undefined;
+	}
+	const catalog = props.catalog as Record<string, unknown>;
+	if (catalog.objectBelonging === 'ADOPTED') {
+		// Заимствованные объекты расширений: свои правила состава XML, редактирование пока не включаем.
+		return undefined;
+	}
+	return {
+		props,
+		tabs: buildCatalogEditTabs({
+			internalName,
+			formNames: rawNameList(structure?.forms),
+			commandNames: rawNameList(structure?.commands),
+			catalogNames,
+			documentNames,
+			attributeNames: rawNameList(props.attributes),
+			hasOwners: Array.isArray(catalog.owners) && catalog.owners.length > 0,
+			hierarchical: catalog.hierarchical === true,
+		}),
+	};
 }
 
 /**
@@ -962,18 +1043,19 @@ export function buildMetadataObjectPropertiesTabsForTest(
 	structure: unknown
 ): MetadataPanelTab[] {
 	const normalizedType = normalizeObjectType(objectType);
-	return buildTabs(
-		(isRecord(props) ? (props as unknown as MdObjectPropertiesDto) : null),
-		(isRecord(structure) ? (structure as unknown as MdObjectStructureDto) : null),
-		normalizedType
-	);
+	const propsDto = isRecord(props) ? (props as unknown as MdObjectPropertiesDto) : null;
+	const structureDto = isRecord(structure) ? (structure as unknown as MdObjectStructureDto) : null;
+	const editable = buildEditableModel(propsDto, structureDto, propsDto?.internalName ?? '');
+	return buildTabs(propsDto, structureDto, normalizedType, editable);
 }
 
 function buildViewModel(
 	params: OpenMetadataObjectPropertiesParams,
 	props: MdObjectPropertiesDto | null,
 	structure: MdObjectStructureDto | null,
-	warnings: string[]
+	warnings: string[],
+	catalogNames: readonly string[] = [],
+	documentNames: readonly string[] = []
 ): MetadataPanelViewModel {
 	const declaredObjectType = normalizeObjectType(params.objectType ?? '');
 	const internalName = props?.internalName || structure?.internalName || path.parse(params.objectXmlFsPath).name;
@@ -983,6 +1065,13 @@ function buildViewModel(
 		properties: props,
 		structure,
 	};
+	const editable = buildEditableModel(props, structure, internalName, catalogNames, documentNames);
+	const structureLists = editable
+		? {
+				attributes: props?.attributes ? asNamedRows(props.attributes) : asNamedRows(structure?.attributes),
+				tabularSections: mergeTabularSections(props?.tabularSections, structure?.tabularSections),
+			}
+		: undefined;
 	return {
 		objectKind,
 		objectKindLabel: kindLabel(objectKind, objectType),
@@ -992,8 +1081,10 @@ function buildViewModel(
 		comment: props?.comment ?? '',
 		objectXmlPath: params.objectXmlFsPath,
 		warnings,
-		tabs: buildTabs(props, structure, objectType),
+		tabs: buildTabs(props, structure, objectType, editable),
 		technicalJson: JSON.stringify(technicalPayload, null, 2),
+		editable,
+		structureLists,
 	};
 }
 
@@ -1014,7 +1105,10 @@ export async function openMetadataObjectPropertiesEditor(
 	}
 
 	const runtime = await ensureMdSparrowRuntime(context);
-	const [propsResult, structureResult] = await Promise.all([
+	const wantsCatalogCandidates =
+		Boolean(params.cfgPath) && normalizeObjectType(params.objectType ?? '') === 'Catalog';
+	const noCandidates = Promise.resolve({ ok: false as const, error: '' });
+	const [propsResult, structureResult, catalogNamesResult, documentNamesResult] = await Promise.all([
 		runMdSparrowJson<MdObjectPropertiesDto>(
 			runtime,
 			{ op: 'cf-md-object-get', objectXml: params.objectXmlFsPath, schemaVersion: schema },
@@ -1025,6 +1119,20 @@ export async function openMetadataObjectPropertiesEditor(
 			{ op: 'cf-md-object-structure-get', objectXml: params.objectXmlFsPath, schemaVersion: schema },
 			params.cwd
 		),
+		wantsCatalogCandidates
+			? runMdSparrowJson<string[]>(
+					runtime,
+					{ op: 'cf-list-catalogs', configurationXml: params.cfgPath, schemaVersion: schema },
+					params.cwd
+				)
+			: noCandidates,
+		wantsCatalogCandidates
+			? runMdSparrowJson<string[]>(
+					runtime,
+					{ op: 'cf-list-child-objects', configurationXml: params.cfgPath, tag: 'Document', schemaVersion: schema },
+					params.cwd
+				)
+			: noCandidates,
 	]);
 
 	const { propsDto, structureDto, warnings, fatalReason } = collectMetadataReadState(propsResult, structureResult);
@@ -1035,7 +1143,10 @@ export async function openMetadataObjectPropertiesEditor(
 		return;
 	}
 
-	const viewModel = buildViewModel(params, propsDto, structureDto, warnings);
+	const catalogNames = catalogNamesResult.ok && Array.isArray(catalogNamesResult.value) ? catalogNamesResult.value : [];
+	const documentNames =
+		documentNamesResult.ok && Array.isArray(documentNamesResult.value) ? documentNamesResult.value : [];
+	const viewModel = buildViewModel(params, propsDto, structureDto, warnings, catalogNames, documentNames);
 	const title = panelTitleForKind(viewModel.objectKind, viewModel.internalName);
 	const webviewRoot = vscode.Uri.joinPath(context.extensionUri, 'resources', 'webview');
 	const panel = vscode.window.createWebviewPanel('1cMetadataObjectProperties', title, vscode.ViewColumn.Active, {
@@ -1044,6 +1155,10 @@ export async function openMetadataObjectPropertiesEditor(
 		localResourceRoots: [webviewRoot],
 	});
 
+	if (viewModel.editable) {
+		registerEditableSaveHandler(context, panel, params, runtime, schema, viewModel.editable, catalogNames, documentNames);
+	}
+
 	try {
 		panel.webview.html = await loadMetadataObjectHtml(panel.webview, context.extensionUri, viewModel);
 	} catch (e) {
@@ -1051,6 +1166,411 @@ export async function openMetadataObjectPropertiesEditor(
 		void vscode.window.showErrorMessage('Не удалось загрузить панель свойств.');
 		panel.dispose();
 	}
+}
+
+interface MetadataPanelSaveMessage {
+	type?: string;
+	payload?: unknown;
+	structure?: unknown;
+	module?: string;
+}
+
+const IDENTIFIER_RE = /^[A-Za-zА-ЯЁа-яё_][A-Za-zА-ЯЁа-яё0-9_]*$/;
+
+/** Правка одной строки структуры из webview: originalName нет — строка новая. */
+interface MetadataStructRowEdit {
+	originalName?: string;
+	name: string;
+	synonymRu: string;
+	deleted: boolean;
+}
+
+interface MetadataTabularSectionEdit extends MetadataStructRowEdit {
+	attributes: MetadataStructRowEdit[];
+}
+
+interface MetadataStructureEdits {
+	attributes: MetadataStructRowEdit[];
+	tabularSections: MetadataTabularSectionEdit[];
+}
+
+function parseStructRow(value: unknown): MetadataStructRowEdit | null {
+	if (!isRecord(value)) {
+		return null;
+	}
+	const originalName =
+		typeof value.originalName === 'string' && value.originalName.length > 0 ? value.originalName : undefined;
+	return {
+		originalName,
+		name: typeof value.name === 'string' ? value.name.trim() : '',
+		synonymRu: typeof value.synonymRu === 'string' ? value.synonymRu : '',
+		deleted: value.deleted === true,
+	};
+}
+
+export function parseStructureEdits(value: unknown): MetadataStructureEdits | null {
+	if (!isRecord(value)) {
+		return null;
+	}
+	const attributes: MetadataStructRowEdit[] = [];
+	if (Array.isArray(value.attributes)) {
+		for (const raw of value.attributes) {
+			const row = parseStructRow(raw);
+			if (row) {
+				attributes.push(row);
+			}
+		}
+	}
+	const tabularSections: MetadataTabularSectionEdit[] = [];
+	if (Array.isArray(value.tabularSections)) {
+		for (const raw of value.tabularSections) {
+			const row = parseStructRow(raw);
+			if (!row) {
+				continue;
+			}
+			const nested: MetadataStructRowEdit[] = [];
+			if (isRecord(raw) && Array.isArray(raw.attributes)) {
+				for (const rawAttr of raw.attributes) {
+					const attr = parseStructRow(rawAttr);
+					if (attr) {
+						nested.push(attr);
+					}
+				}
+			}
+			tabularSections.push({ ...row, attributes: nested });
+		}
+	}
+	return { attributes, tabularSections };
+}
+
+/** @returns текст первой ошибки валидации имён; null — правки корректны. */
+export function validateStructureEdits(edits: MetadataStructureEdits): string | null {
+	const topSeen = new Set<string>();
+	for (const row of [...edits.attributes, ...edits.tabularSections]) {
+		if (row.deleted) {
+			continue;
+		}
+		if (!IDENTIFIER_RE.test(row.name)) {
+			return `Некорректное имя: «${row.name || '(пусто)'}»`;
+		}
+		const key = row.name.toLowerCase();
+		if (topSeen.has(key)) {
+			return `Дублируется имя «${row.name}»`;
+		}
+		topSeen.add(key);
+	}
+	for (const ts of edits.tabularSections) {
+		if (ts.deleted) {
+			continue;
+		}
+		const nestedSeen = new Set<string>();
+		for (const row of ts.attributes) {
+			if (row.deleted) {
+				continue;
+			}
+			if (!IDENTIFIER_RE.test(row.name)) {
+				return `Некорректное имя реквизита ТЧ «${ts.name}»: «${row.name || '(пусто)'}»`;
+			}
+			const key = row.name.toLowerCase();
+			if (nestedSeen.has(key)) {
+				return `Дублируется имя «${row.name}» в ТЧ «${ts.name}»`;
+			}
+			nestedSeen.add(key);
+		}
+	}
+	return null;
+}
+
+/** Операции структуры из правок: переименования, затем удаления, затем добавления. */
+export function structOpsFromEdits(edits: MetadataStructureEdits, objectXml: string, schema: string): MdSparrowParams[] {
+	const ops: MdSparrowParams[] = [];
+	const base = { objectXml, schemaVersion: schema };
+	for (const ts of edits.tabularSections) {
+		if (!ts.deleted && ts.originalName && ts.name !== ts.originalName) {
+			ops.push({ op: 'cf-md-tabular-section-rename', ...base, oldName: ts.originalName, newName: ts.name });
+		}
+	}
+	for (const row of edits.attributes) {
+		if (!row.deleted && row.originalName && row.name !== row.originalName) {
+			ops.push({ op: 'cf-md-attribute-rename', ...base, oldName: row.originalName, newName: row.name });
+		}
+	}
+	for (const ts of edits.tabularSections) {
+		if (ts.deleted) {
+			continue;
+		}
+		for (const row of ts.attributes) {
+			if (!row.deleted && row.originalName && row.name !== row.originalName) {
+				ops.push({
+					op: 'cf-md-tabular-attribute-rename',
+					...base,
+					tabularSection: ts.name,
+					oldName: row.originalName,
+					newName: row.name,
+				});
+			}
+		}
+	}
+	for (const row of edits.attributes) {
+		if (row.deleted && row.originalName) {
+			ops.push({ op: 'cf-md-attribute-delete', ...base, name: row.originalName });
+		}
+	}
+	for (const ts of edits.tabularSections) {
+		if (ts.deleted) {
+			if (ts.originalName) {
+				ops.push({ op: 'cf-md-tabular-section-delete', ...base, name: ts.originalName });
+			}
+			continue;
+		}
+		for (const row of ts.attributes) {
+			if (row.deleted && row.originalName) {
+				ops.push({ op: 'cf-md-tabular-attribute-delete', ...base, tabularSection: ts.name, name: row.originalName });
+			}
+		}
+	}
+	for (const row of edits.attributes) {
+		if (!row.deleted && !row.originalName) {
+			ops.push({ op: 'cf-md-attribute-add', ...base, name: row.name });
+		}
+	}
+	for (const ts of edits.tabularSections) {
+		if (ts.deleted) {
+			continue;
+		}
+		if (!ts.originalName) {
+			ops.push({ op: 'cf-md-tabular-section-add', ...base, name: ts.name });
+		}
+		for (const row of ts.attributes) {
+			if (!row.deleted && !row.originalName) {
+				ops.push({ op: 'cf-md-tabular-attribute-add', ...base, tabularSection: ts.name, name: row.name });
+			}
+		}
+	}
+	// Порядок: блоки переставляются между собой по финальным именам (после rename/add/delete).
+	const attrOrder = edits.attributes.filter((row) => !row.deleted).map((row) => row.name);
+	if (attrOrder.length > 1) {
+		ops.push({ op: 'cf-md-attribute-reorder', ...base, payloadJson: JSON.stringify(attrOrder) });
+	}
+	const tsOrder = edits.tabularSections.filter((ts) => !ts.deleted).map((ts) => ts.name);
+	if (tsOrder.length > 1) {
+		ops.push({ op: 'cf-md-tabular-section-reorder', ...base, payloadJson: JSON.stringify(tsOrder) });
+	}
+	for (const ts of edits.tabularSections) {
+		if (ts.deleted) {
+			continue;
+		}
+		const nestedOrder = ts.attributes.filter((row) => !row.deleted).map((row) => row.name);
+		if (nestedOrder.length > 1) {
+			ops.push({
+				op: 'cf-md-tabular-attribute-reorder',
+				...base,
+				tabularSection: ts.name,
+				payloadJson: JSON.stringify(nestedOrder),
+			});
+		}
+	}
+	return ops;
+}
+
+/** Переносит синонимы реквизитов и ТЧ из правок в DTO (перечитанный после операций структуры). */
+export function applySynonymEdits(dto: Record<string, unknown>, edits: MetadataStructureEdits): void {
+	const attrSyn = new Map<string, string>();
+	for (const row of edits.attributes) {
+		if (!row.deleted && row.name) {
+			attrSyn.set(row.name, row.synonymRu);
+		}
+	}
+	if (Array.isArray(dto.attributes)) {
+		for (const raw of dto.attributes) {
+			if (isRecord(raw) && typeof raw.name === 'string' && attrSyn.has(raw.name)) {
+				raw.synonymRu = attrSyn.get(raw.name);
+			}
+		}
+	}
+	const tsSyn = new Map<string, string>();
+	for (const ts of edits.tabularSections) {
+		if (!ts.deleted && ts.name) {
+			tsSyn.set(ts.name, ts.synonymRu);
+		}
+	}
+	if (Array.isArray(dto.tabularSections)) {
+		for (const raw of dto.tabularSections) {
+			if (isRecord(raw) && typeof raw.name === 'string' && tsSyn.has(raw.name)) {
+				raw.synonymRu = tsSyn.get(raw.name);
+			}
+		}
+	}
+}
+
+const MODULE_FILE_BY_KIND: Record<string, string> = {
+	object: 'ObjectModule.bsl',
+	manager: 'ManagerModule.bsl',
+};
+
+async function openObjectModuleFromPanel(objectXmlFsPath: string, internalName: string, moduleKind: string): Promise<void> {
+	const fileName = MODULE_FILE_BY_KIND[moduleKind];
+	if (!fileName) {
+		return;
+	}
+	const modulePath = path.join(path.dirname(objectXmlFsPath), internalName, 'Ext', fileName);
+	const uri = vscode.Uri.file(modulePath);
+	try {
+		await vscode.workspace.fs.stat(uri);
+	} catch {
+		await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.dirname(modulePath)));
+		await vscode.workspace.fs.writeFile(uri, new Uint8Array());
+		void vscode.window.showInformationMessage(`Создан пустой модуль: ${fileName}`);
+	}
+	const doc = await vscode.workspace.openTextDocument(uri);
+	await vscode.window.showTextDocument(doc, { preview: false });
+}
+
+function registerEditableSaveHandler(
+	context: vscode.ExtensionContext,
+	panel: vscode.WebviewPanel,
+	params: OpenMetadataObjectPropertiesParams,
+	runtime: Awaited<ReturnType<typeof ensureMdSparrowRuntime>>,
+	schema: string,
+	editable: MetadataPanelEditableModel,
+	catalogNames: readonly string[],
+	documentNames: readonly string[]
+): void {
+	const enqueue = params.enqueueMutation ?? (<T,>(fn: () => Promise<T>): Promise<T> => fn());
+	let saving = false;
+
+	async function rereadAndPushModel(): Promise<void> {
+		const [propsResult, structureResult] = await Promise.all([
+			runMdSparrowJson<MdObjectPropertiesDto>(
+				runtime,
+				{ op: 'cf-md-object-get', objectXml: params.objectXmlFsPath, schemaVersion: schema },
+				params.cwd
+			),
+			runMdSparrowJson<MdObjectStructureDto>(
+				runtime,
+				{ op: 'cf-md-object-structure-get', objectXml: params.objectXmlFsPath, schemaVersion: schema },
+				params.cwd
+			),
+		]);
+		if (!propsResult.ok) {
+			return;
+		}
+		const vm = buildViewModel(
+			params,
+			propsResult.value,
+			structureResult.ok ? structureResult.value : null,
+			[],
+			catalogNames,
+			documentNames
+		);
+		if (vm.editable) {
+			editable.props = vm.editable.props;
+			editable.tabs = vm.editable.tabs;
+		}
+		void panel.webview.postMessage({
+			type: 'modelUpdated',
+			tabs: vm.tabs,
+			props: editable.props,
+			editableTabs: editable.tabs,
+			structureLists: vm.structureLists,
+		});
+	}
+
+	async function runOneMutation(opParams: MdSparrowParams): Promise<string | null> {
+		const res = await enqueue(() => runMdSparrowParamsMutation(runtime, opParams, { cwd: params.cwd }));
+		if (res.exitCode !== 0) {
+			const errText = (res.stderr.trim() || res.stdout.trim() || `код ${res.exitCode}`).slice(0, ERR_PREVIEW);
+			log.error(`${opParams.op}: ${errText}`);
+			return errText;
+		}
+		return null;
+	}
+
+	async function handleSave(msg: MetadataPanelSaveMessage): Promise<void> {
+		const structureEdits = parseStructureEdits(msg.structure);
+		if (structureEdits) {
+			const validationError = validateStructureEdits(structureEdits);
+			if (validationError) {
+				void panel.webview.postMessage({ type: 'saved', ok: false, error: validationError });
+				return;
+			}
+		}
+		const ops = structureEdits ? structOpsFromEdits(structureEdits, params.objectXmlFsPath, schema) : [];
+		let structApplied = false;
+		for (const opParams of ops) {
+			const error = await runOneMutation(opParams);
+			if (error) {
+				void panel.webview.postMessage({ type: 'saved', ok: false, error: `${opParams.op}: ${error}` });
+				if (structApplied) {
+					await rereadAndPushModel();
+					void vscode.commands.executeCommand('1c-platform-tools.metadata.refresh');
+				}
+				return;
+			}
+			structApplied = true;
+		}
+
+		let baseProps = editable.props;
+		if (ops.length > 0) {
+			const reread = await runMdSparrowJson<MdObjectPropertiesDto>(
+				runtime,
+				{ op: 'cf-md-object-get', objectXml: params.objectXmlFsPath, schemaVersion: schema },
+				params.cwd
+			);
+			if (reread.ok) {
+				baseProps = reread.value;
+			}
+		}
+		const dto = applyEditedScalars(baseProps as unknown as Record<string, unknown>, msg.payload, editable.tabs);
+		if (structureEdits) {
+			applySynonymEdits(dto, structureEdits);
+		}
+		const error = await runOneMutation({
+			op: 'cf-md-object-set',
+			objectXml: params.objectXmlFsPath,
+			schemaVersion: schema,
+			payloadJson: JSON.stringify(dto),
+		});
+		if (error) {
+			void panel.webview.postMessage({ type: 'saved', ok: false, error });
+			if (structApplied) {
+				await rereadAndPushModel();
+				void vscode.commands.executeCommand('1c-platform-tools.metadata.refresh');
+			}
+			return;
+		}
+		void panel.webview.postMessage({ type: 'saved', ok: true });
+		await rereadAndPushModel();
+		void vscode.commands.executeCommand('1c-platform-tools.metadata.refresh');
+	}
+
+	panel.webview.onDidReceiveMessage(
+		async (msg: MetadataPanelSaveMessage) => {
+			if (!msg) {
+				return;
+			}
+			if (msg.type === 'openModule' && typeof msg.module === 'string') {
+				try {
+					await openObjectModuleFromPanel(params.objectXmlFsPath, editable.props.internalName, msg.module);
+				} catch (e) {
+					const errMsg = e instanceof Error ? e.message : String(e);
+					void vscode.window.showErrorMessage(`Не удалось открыть модуль: ${errMsg}`.slice(0, ERR_PREVIEW));
+				}
+				return;
+			}
+			if (msg.type !== 'save' || saving) {
+				return;
+			}
+			saving = true;
+			try {
+				await handleSave(msg);
+			} finally {
+				saving = false;
+			}
+		},
+		undefined,
+		context.subscriptions
+	);
 }
 
 async function loadMetadataObjectHtml(

--- a/src/features/metadata/metadataTreeService.ts
+++ b/src/features/metadata/metadataTreeService.ts
@@ -8,7 +8,8 @@ import * as vscode from 'vscode';
 import { clearMdSparrowJarCache, ensureMdSparrowRuntime } from './mdSparrowBootstrap';
 import { isMdSparrowUnknownCommandError, MdSparrowOutdatedError } from './mdSparrowErrors';
 import { logger } from '../../shared/logger';
-import { runMdSparrowParamsRead } from './mdSparrowParams';
+import { configuredSourceDirs } from '../../shared/sourcePaths';
+import { runMdSparrowParamsRead, type MdSparrowParams } from './mdSparrowParams';
 
 const log = logger.scope('metadata');
 
@@ -81,17 +82,30 @@ export async function loadProjectMetadataTree(
 	return parsed;
 }
 
+/** Параметры project-metadata-tree с каталогами исходников из настроек paths.*. */
+export function projectMetadataTreeParams(projectRootAbs: string): MdSparrowParams {
+	const dirs = configuredSourceDirs();
+	return {
+		op: 'project-metadata-tree',
+		projectRoot: projectRootAbs,
+		cfDir: dirs.cf,
+		cfeDir: dirs.cfe,
+		epfDir: dirs.epf,
+		erfDir: dirs.erf,
+	};
+}
+
 async function runProjectMetadataTreeWithRepair(context: vscode.ExtensionContext, abs: string) {
 	const initialRes = await runMdSparrowParamsRead(
 		await ensureMdSparrowRuntime(context),
-		{ op: 'project-metadata-tree', projectRoot: abs },
+		projectMetadataTreeParams(abs),
 		{ cwd: abs }
 	);
 	if (initialRes.exitCode !== 0 && shouldRepairJarAndRetry(initialRes.stderr, initialRes.stdout)) {
 		log.warn('ошибка загрузки классов md-sparrow — очищаем кэш JAR и повторяем запуск');
 		await clearMdSparrowJarCache(context);
 		const repairedRuntime = await ensureMdSparrowRuntime(context);
-		return runMdSparrowParamsRead(repairedRuntime, { op: 'project-metadata-tree', projectRoot: abs }, {
+		return runMdSparrowParamsRead(repairedRuntime, projectMetadataTreeParams(abs), {
 			cwd: abs,
 		});
 	}

--- a/src/features/metadata/registerMetadataFeature.ts
+++ b/src/features/metadata/registerMetadataFeature.ts
@@ -469,7 +469,9 @@ export function registerMetadataFeature(
 		for (;;) {
 			const candidate = `${prefix}${nextIndex}`;
 			if (!existingNames.includes(candidate)) {
-				const schema = await pickSchemaFlagInitEmptyCf(path.join(workspaceRoot, 'src', 'cf', 'Configuration.xml'));
+				const schema = await pickSchemaFlagInitEmptyCf(
+					metadataTreeProvider.configurationXml ?? path.join(workspaceRoot, 'src', 'cf', 'Configuration.xml')
+				);
 				if (!schema) {
 					return;
 				}
@@ -1837,6 +1839,7 @@ export function registerMetadataFeature(
 						schemaFlag: schemaFlagFallback,
 						cwd: node.metadataRootAbs ?? path.dirname(node.resourceUri.fsPath),
 						objectType: node.objectType,
+						enqueueMutation: runMdSparrowMutation,
 					}
 				);
 			}

--- a/src/shared/sourcePaths.ts
+++ b/src/shared/sourcePaths.ts
@@ -1,0 +1,40 @@
+/**
+ * Каталоги исходников из настроек 1c-platform-tools.paths.* (единая точка чтения).
+ * @module sourcePaths
+ */
+
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { DEFAULT_PATHS } from './pathDefaults';
+
+export interface SourceDirs {
+	/** paths.cf */
+	cf: string;
+	/** paths.cfe */
+	cfe: string;
+	/** paths.epf */
+	epf: string;
+	/** paths.erf */
+	erf: string;
+}
+
+function readPath(cfg: vscode.WorkspaceConfiguration, key: string, def: string): string {
+	const value = cfg.get<string>(key, def).trim().replaceAll('\\', '/');
+	return value.replace(/^\.\//, '').replace(/\/+$/, '') || def;
+}
+
+/** Настроенные каталоги исходников (относительно корня проекта). */
+export function configuredSourceDirs(): SourceDirs {
+	const cfg = vscode.workspace.getConfiguration('1c-platform-tools');
+	return {
+		cf: readPath(cfg, 'paths.cf', DEFAULT_PATHS.cf),
+		cfe: readPath(cfg, 'paths.cfe', DEFAULT_PATHS.cfe),
+		epf: readPath(cfg, 'paths.epf', DEFAULT_PATHS.epf),
+		erf: readPath(cfg, 'paths.erf', DEFAULT_PATHS.erf),
+	};
+}
+
+/** Абсолютный путь к корню исходников конфигурации (paths.cf) от корня workspace. */
+export function configuredCfRootAbs(workspaceRoot: string): string {
+	return path.join(workspaceRoot, ...configuredSourceDirs().cf.split('/'));
+}

--- a/src/test/metadata/metadataObjectEditSpec.test.ts
+++ b/src/test/metadata/metadataObjectEditSpec.test.ts
@@ -1,0 +1,273 @@
+import * as assert from 'node:assert';
+import { applyEditedScalars, buildCatalogEditTabs } from '../../features/metadata/metadataObjectEditSpec';
+import { buildMetadataObjectPropertiesTabsForTest } from '../../features/metadata/metadataObjectPropertiesPanel';
+
+function catalogProps(): Record<string, unknown> {
+	return {
+		kind: 'catalog',
+		internalName: 'Номенклатура',
+		synonymRu: 'Номенклатура',
+		comment: '',
+		attributes: [{ name: 'Артикул', synonymRu: 'Артикул', comment: '' }],
+		tabularSections: [],
+		catalog: {
+			hierarchical: false,
+			hierarchyType: 'HIERARCHY_FOLDERS_AND_ITEMS',
+			levelCount: '2',
+			autonumbering: true,
+			checkUnique: true,
+			codeSeries: 'WHOLE_CATALOG',
+			choiceMode: 'BOTH_WAYS',
+			codeLength: '9',
+			owners: ['Catalog.Организации'],
+			useStandardCommands: true,
+			defaultObjectForm: null,
+		},
+	};
+}
+
+suite('metadataObjectEditSpec', () => {
+	test('catalog edit tabs cover EDT layout', () => {
+		const tabs = buildCatalogEditTabs({ internalName: 'Номенклатура', formNames: ['ФормаСписка'], commandNames: [] });
+		assert.deepStrictEqual(
+			tabs.map((tab) => tab.title),
+			['Основные', 'Данные', 'Владельцы', 'Формы', 'Команды', 'Ввод на основании']
+		);
+		const forms = tabs.find((tab) => tab.id === 'edit_forms');
+		const objectForm = forms?.groups[0].fields.find((field) => field.path === 'catalog.defaultObjectForm');
+		assert.ok(
+			objectForm?.options?.some((option) => option.value === 'Catalog.Номенклатура.Form.ФормаСписка'),
+			'основная форма должна предлагать полную ссылку на форму'
+		);
+	});
+
+	test('basedOn and dataLockFields candidates depend on object state', () => {
+		const tabs = buildCatalogEditTabs({
+			internalName: 'Номенклатура',
+			formNames: [],
+			commandNames: [],
+			catalogNames: ['Организации'],
+			documentNames: ['ЗаказПокупателя'],
+			attributeNames: ['Артикул'],
+			hasOwners: true,
+			hierarchical: false,
+		});
+		const basedOn = tabs
+			.find((tab) => tab.id === 'edit_basedon')
+			?.groups[0].fields.find((field) => field.path === 'catalog.basedOn');
+		assert.ok(basedOn?.options?.some((option) => option.value === 'Document.ЗаказПокупателя'));
+		assert.ok(basedOn?.options?.some((option) => option.value === 'Catalog.Организации'));
+
+		const lock = tabs
+			.flatMap((tab) => tab.groups)
+			.flatMap((group) => group.fields)
+			.find((field) => field.path === 'catalog.dataLockFields');
+		assert.strictEqual(lock?.control, 'refList');
+		assert.ok(lock?.options?.some((option) => option.value === 'Catalog.Номенклатура.StandardAttribute.Owner'));
+		assert.ok(
+			!lock?.options?.some((option) => option.value === 'Catalog.Номенклатура.StandardAttribute.Parent'),
+			'Родитель не предлагается для неиерархического'
+		);
+		assert.ok(lock?.options?.some((option) => option.value === 'Catalog.Номенклатура.Attribute.Артикул'));
+	});
+
+	test('applyEditedScalars keeps structure and applies only whitelisted scalars', () => {
+		const raw = catalogProps();
+		const tabs = buildCatalogEditTabs({ internalName: 'Номенклатура', formNames: [], commandNames: [] });
+		const edited = catalogProps();
+		(edited.catalog as Record<string, unknown>).choiceMode = 'QUICK_CHOICE';
+		(edited.catalog as Record<string, unknown>).codeLength = '11';
+		edited.synonymRu = 'Товары';
+		// Попытки webview изменить нередактируемое должны игнорироваться.
+		edited.internalName = 'Взлом';
+		edited.attributes = [];
+
+		const dto = applyEditedScalars(raw, edited, tabs);
+		const cat = dto.catalog as Record<string, unknown>;
+		assert.strictEqual(dto.synonymRu, 'Товары');
+		assert.strictEqual(cat.choiceMode, 'QUICK_CHOICE');
+		assert.strictEqual(cat.codeLength, '11');
+		assert.strictEqual(dto.internalName, 'Номенклатура', 'имя не редактируется из панели');
+		assert.strictEqual((dto.attributes as unknown[]).length, 1, 'реквизиты не должны затираться');
+	});
+
+	test('refList: владельцы редактируются в пределах кандидатов', () => {
+		const raw = catalogProps();
+		const tabs = buildCatalogEditTabs({
+			internalName: 'Номенклатура',
+			formNames: [],
+			commandNames: [],
+			catalogNames: ['Организации', 'Контрагенты', 'Номенклатура'],
+			attributeNames: ['Артикул'],
+		});
+		const ownersField = tabs
+			.find((tab) => tab.id === 'edit_owners')
+			?.groups[0].fields.find((field) => field.path === 'catalog.owners');
+		assert.ok(ownersField?.options?.some((option) => option.value === 'Catalog.Контрагенты'));
+		assert.ok(
+			!ownersField?.options?.some((option) => option.value === 'Catalog.Номенклатура'),
+			'сам справочник не предлагается во владельцы'
+		);
+
+		const edited = catalogProps();
+		(edited.catalog as Record<string, unknown>).owners = [
+			'Catalog.Организации',
+			'Catalog.Контрагенты',
+			'Catalog.Чужой',
+			'Catalog.Контрагенты',
+		];
+		(edited.catalog as Record<string, unknown>).inputByString = [
+			'Catalog.Номенклатура.StandardAttribute.Code',
+			'Catalog.Номенклатура.Attribute.Артикул',
+		];
+		const dto = applyEditedScalars(raw, edited, tabs);
+		const cat = dto.catalog as Record<string, unknown>;
+		assert.deepStrictEqual(
+			cat.owners,
+			['Catalog.Организации', 'Catalog.Контрагенты'],
+			'неизвестные кандидаты и дубли отбрасываются'
+		);
+		assert.deepStrictEqual(cat.inputByString, [
+			'Catalog.Номенклатура.StandardAttribute.Code',
+			'Catalog.Номенклатура.Attribute.Артикул',
+		]);
+
+		const cleared = catalogProps();
+		(cleared.catalog as Record<string, unknown>).owners = [];
+		const dtoCleared = applyEditedScalars(raw, cleared, tabs);
+		assert.deepStrictEqual((dtoCleared.catalog as Record<string, unknown>).owners, [], 'очистка владельцев допустима');
+	});
+
+	test('clearable: очистка основной формы пишется пустым значением', () => {
+		const raw = catalogProps();
+		(raw.catalog as Record<string, unknown>).defaultObjectForm = 'Catalog.Номенклатура.Form.ФормаЭлемента';
+		const tabs = buildCatalogEditTabs({ internalName: 'Номенклатура', formNames: ['ФормаЭлемента'], commandNames: [] });
+		const edited = catalogProps();
+		(edited.catalog as Record<string, unknown>).defaultObjectForm = '';
+		const dto = applyEditedScalars(raw, edited, tabs);
+		assert.strictEqual((dto.catalog as Record<string, unknown>).defaultObjectForm, '', 'установленная форма очищается');
+
+		const rawEmpty = catalogProps();
+		const dtoEmpty = applyEditedScalars(rawEmpty, edited, tabs);
+		assert.strictEqual(
+			(dtoEmpty.catalog as Record<string, unknown>).defaultObjectForm,
+			null,
+			'незаданная форма остаётся незаданной'
+		);
+	});
+
+	test('applyEditedScalars normalizes values', () => {
+		const raw = catalogProps();
+		const tabs = buildCatalogEditTabs({ internalName: 'Номенклатура', formNames: [], commandNames: [] });
+		const edited = catalogProps();
+		(edited.catalog as Record<string, unknown>).defaultObjectForm = '';
+		(edited.catalog as Record<string, unknown>).codeLength = 'abc';
+		(edited.catalog as Record<string, unknown>).choiceMode = 'НЕИЗВЕСТНО';
+
+		const dto = applyEditedScalars(raw, edited, tabs);
+		const cat = dto.catalog as Record<string, unknown>;
+		assert.strictEqual(cat.defaultObjectForm, null, 'пустой выбор формы становится null');
+		assert.strictEqual(cat.codeLength, '9', 'нечисловая длина кода игнорируется');
+		assert.strictEqual(cat.choiceMode, 'BOTH_WAYS', 'неизвестное значение enum игнорируется');
+	});
+
+	test('catalog panel starts with editable tabs and drops replaced ones', () => {
+		const structure = {
+			kind: 'catalog',
+			internalName: 'Номенклатура',
+			forms: ['ФормаСписка'],
+			commands: ['Команда1'],
+		};
+		const tabs = buildMetadataObjectPropertiesTabsForTest('Catalog', catalogProps(), structure);
+		assert.strictEqual(tabs[0]?.id, 'edit_main');
+		assert.strictEqual(tabs[0]?.render, 'edit');
+		assert.ok(!tabs.some((tab) => tab.id === 'overview'), 'обзор замещается вкладкой «Основные»');
+		assert.ok(!tabs.some((tab) => tab.id === 'section_forms'), 'список форм уходит на вкладку «Формы»');
+		assert.ok(tabs.some((tab) => tab.id === 'edit_forms'));
+		assert.ok(!tabs.some((tab) => tab.id === 'attributes'), 'реквизиты уходят на вкладку «Данные»');
+		assert.ok(!tabs.some((tab) => tab.id === 'tabularSections'), 'табличные части уходят на вкладку «Данные»');
+	});
+});
+
+suite('metadataObjectPropertiesPanel structure edits', () => {
+	// Ленивая загрузка, чтобы не тянуть vscode-заглушки в чужие suite.
+	const panel = require('../../features/metadata/metadataObjectPropertiesPanel');
+
+	test('structOpsFromEdits: переименования, удаления, добавления в правильном порядке', () => {
+		const edits = panel.parseStructureEdits({
+			attributes: [
+				{ originalName: 'Старый', name: 'Новый', synonymRu: '', deleted: false },
+				{ originalName: 'Лишний', name: 'Лишний', synonymRu: '', deleted: true },
+				{ name: 'Добавленный', synonymRu: 'Синоним', deleted: false },
+			],
+			tabularSections: [
+				{
+					originalName: 'Товары',
+					name: 'Позиции',
+					synonymRu: '',
+					deleted: false,
+					attributes: [
+						{ originalName: 'Кол', name: 'Количество', synonymRu: '', deleted: false },
+						{ name: 'Цена', synonymRu: '', deleted: false },
+					],
+				},
+			],
+		});
+		assert.ok(edits);
+		assert.strictEqual(panel.validateStructureEdits(edits), null);
+		const allOps = panel.structOpsFromEdits(edits, 'obj.xml', 'V2_20');
+		const ops = allOps.map((op: { op: string }) => op.op);
+		assert.deepStrictEqual(ops, [
+			'cf-md-tabular-section-rename',
+			'cf-md-attribute-rename',
+			'cf-md-tabular-attribute-rename',
+			'cf-md-attribute-delete',
+			'cf-md-attribute-add',
+			'cf-md-tabular-attribute-add',
+			'cf-md-attribute-reorder',
+			'cf-md-tabular-attribute-reorder',
+		]);
+		const attrReorder = allOps.find((op: { op: string }) => op.op === 'cf-md-attribute-reorder');
+		assert.deepStrictEqual(JSON.parse(attrReorder.payloadJson), ['Новый', 'Добавленный'], 'порядок по финальным именам');
+		const renameTs = panel.structOpsFromEdits(edits, 'obj.xml', 'V2_20')[2];
+		assert.strictEqual(renameTs.tabularSection, 'Позиции', 'вложенные операции идут по новому имени ТЧ');
+	});
+
+	test('validateStructureEdits ловит дубли и мусорные имена', () => {
+		const bad = panel.parseStructureEdits({
+			attributes: [
+				{ name: '1Плохое', synonymRu: '', deleted: false },
+			],
+			tabularSections: [],
+		});
+		assert.ok(panel.validateStructureEdits(bad));
+		const dup = panel.parseStructureEdits({
+			attributes: [
+				{ originalName: 'А', name: 'Имя', synonymRu: '', deleted: false },
+				{ originalName: 'Б', name: 'имя', synonymRu: '', deleted: false },
+			],
+			tabularSections: [],
+		});
+		assert.ok(panel.validateStructureEdits(dup));
+	});
+
+	test('applySynonymEdits переносит синонимы по финальным именам', () => {
+		const dto: Record<string, unknown> = {
+			attributes: [
+				{ name: 'Новый', synonymRu: 'старый синоним', comment: 'к' },
+				{ name: 'Другой', synonymRu: 'х', comment: '' },
+			],
+			tabularSections: [{ name: 'Позиции', synonymRu: '', comment: '' }],
+		};
+		const edits = panel.parseStructureEdits({
+			attributes: [{ originalName: 'Старый', name: 'Новый', synonymRu: 'Свежий', deleted: false }],
+			tabularSections: [{ originalName: 'Товары', name: 'Позиции', synonymRu: 'Позиции заказа', deleted: false, attributes: [] }],
+		});
+		panel.applySynonymEdits(dto, edits);
+		const attrs = dto.attributes as Array<Record<string, unknown>>;
+		assert.strictEqual(attrs[0].synonymRu, 'Свежий');
+		assert.strictEqual(attrs[0].comment, 'к', 'комментарий сохраняется');
+		assert.strictEqual(attrs[1].synonymRu, 'х', 'нетронутые не меняются');
+		assert.strictEqual((dto.tabularSections as Array<Record<string, unknown>>)[0].synonymRu, 'Позиции заказа');
+	});
+});


### PR DESCRIPTION
## Что сделано

**Редактирование свойств справочника в панели метаданных** (первый тип по плану #182):
- вкладки в раскладке EDT: Основные, Данные, Владельцы, Формы, Команды, Ввод на основании;
- скалярные свойства с русскими подписями, зависимостями доступности (иерархия, история данных) и поиском по свойствам;
- редактируемые списки ссылок (владельцы, ввод по строке, поля блокировки, основания) с подбором кандидатов, удалением и порядком;
- очищаемые основные формы («(не задана)» реально очищает значение);
- реквизиты и табличные части на вкладке «Данные»: инлайн-редактирование имени и синонима, добавление, пометка на удаление с возвратом, порядок стрелками, автозаполнение синонима по правилу 1С («ВалютаБанка» → «Валюта банка»);
- всё применяется кнопкой «Сохранить» одной серией операций md-sparrow (переименования → удаления → добавления → порядок → свойства) с валидацией имён и перечитыванием модели; diff в XML точечный;
- ссылки «Открыть» для модуля объекта и модуля менеджера;
- редактирование отключено для заимствованных объектов расширений (ADOPTED) — до #210.

**Пути исходников из настроек**: дерево метаданных, ER-граф (включая отпечаток кэша) и выбор схемы читают `1c-platform-tools.paths.cf/cfe/epf/erf` через единый хелпер и передают их в md-sparrow — жёсткие `src/*` убраны.

Попутно исправлена гонка имён временных params-файлов при параллельных вызовах md-sparrow (панель случайно получала структуру вместо свойств).

## Требования
Нужен md-sparrow с yellow-hammer/md-sparrow#2 (операции `cf-md-object-set`, reorder, настраиваемые каталоги): после слияния того PR — выпустить релиз jar, иначе сохранение из панели даст «неизвестный op».

## Проверка
- 413 тестов расширения, tsc, eslint — зелёные; тесты md-sparrow зелёные.
- Приёмка на живой ssl_3_1: серия правок всех типов (скаляры, списки, структура, порядок, очистка форм), точечные diff, `vrunner infobase update --src src/cf` проходит.
- Хвосты вынесены: #206 (формы/команды/макеты), #210 (расширения), #213 (зачистка ссылок в формах при удалении/переименовании), #214 (синонимы реквизитов ТЧ).

Закрывает #194
Закрывает #207
