### PR TITLE
fix(commands): префикс кодировки chcp.com для bash-терминалов Windows

### DIFF
--- a/src/features/tasks/vrunnerTask.ts
+++ b/src/features/tasks/vrunnerTask.ts
@@ -67,8 +67,9 @@ class VRunnerPseudoterminal implements vscode.Pseudoterminal {
 	public open(): void {
 		log.debug(`запуск задачи: ${this.command}`);
 		// Эхо исходной команды в начале вывода (как у штатных задач VS Code),
-		// чтобы было видно, что именно запущено.
-		this.writeEmitter.fire(`[90m> ${this.command}[0m\r\n\r\n`);
+		// чтобы было видно, что именно запущено. Служебный префикс кодировки прячем.
+		const displayCommand = this.command.replace(/^chcp 65001 >nul && /, '');
+		this.writeEmitter.fire(`[90m> ${displayCommand}[0m\r\n\r\n`);
 		runCancellableCommand(this.command, {
 			cwd: this.cwd,
 			env: this.env,

--- a/src/shared/vrunnerManager.ts
+++ b/src/shared/vrunnerManager.ts
@@ -1661,7 +1661,10 @@ export class VRunnerManager {
 		const vrunnerPath = this.getVRunnerPath();
 		const argsString = escapeCommandArgs(args);
 		const quotedPath = vrunnerPath.includes(' ') ? `"${vrunnerPath}"` : vrunnerPath;
-		return { command: `${quotedPath} ${argsString}` };
+		// Задачи выполняются дочерним процессом через cmd (spawn shell:true) независимо от
+		// профиля терминала: без chcp oscript выводит кириллицу в OEM-кодировке.
+		const encodingPrefix = process.platform === 'win32' ? 'chcp 65001 >nul && ' : '';
+		return { command: `${encodingPrefix}${quotedPath} ${argsString}` };
 	}
 
 	/**

--- a/src/test/utils/commandUtils.test.ts
+++ b/src/test/utils/commandUtils.test.ts
@@ -72,9 +72,9 @@ suite('commandUtils', () => {
 		assert.ok(result.includes('vrunner.bat'), 'Команда должна содержать путь к исполняемому файлу');
 	});
 
-	test('buildCommand формирует команду для bash без кодировки', () => {
+	winTest('buildCommand формирует команду для bash с кодировкой chcp.com', () => {
 		const result = buildCommand('vrunner', ['init-dev'], 'bash');
-		assert.ok(!result.includes('chcp'), 'Команда для bash не должна содержать chcp');
+		assert.ok(result.includes('chcp.com 65001 >/dev/null'), 'Команда для bash должна содержать chcp.com: консоль общая с Windows');
 		assert.ok(!result.includes('[Console]::OutputEncoding'), 'Команда для bash не должна содержать установку кодировки PowerShell');
 		assert.ok(result.includes('vrunner'), 'Команда должна содержать путь к исполняемому файлу');
 	});

--- a/src/utils/commandUtils.ts
+++ b/src/utils/commandUtils.ts
@@ -355,12 +355,12 @@ export function normalizeArgForShell(arg: string, shellType: ShellType): string 
 
 /**
  * Формирует префикс команды для установки кодировки UTF-8 в зависимости от оболочки
- * 
+ *
  * Для Windows:
  * - PowerShell: использует [Console]::OutputEncoding
  * - cmd: использует chcp 65001
- * - bash: кодировка обычно уже настроена, префикс не нужен
- * 
+ * - bash (Git Bash/MSYS): использует chcp.com 65001 — консоль общая с Windows
+ *
  * Для Unix-систем: кодировка обычно уже настроена, префикс не нужен
  * 
  * @param shellType - Тип оболочки терминала
@@ -379,9 +379,11 @@ function getEncodingPrefix(shellType: ShellType): string {
 		// В cmd используем chcp для установки кодировки UTF-8
 		return 'chcp 65001 >nul && ';
 	}
-	
-	// Для bash и других оболочек на Windows (Git Bash, WSL) кодировка обычно уже настроена
-	return '';
+
+	// Git Bash/MSYS работают поверх той же Windows-консоли: без chcp oscript выводит кириллицу
+	// в OEM-кодировке. Builtin chcp из bash недоступен — только chcp.com; ошибки глушим,
+	// чтобы отсутствие chcp.com в PATH (например, WSL без interop) не ломало команду.
+	return 'chcp.com 65001 >/dev/null 2>&1; ';
 }
 
 /**


### PR DESCRIPTION
## Что сделано

`getEncodingPrefix` для bash-оболочек на Windows теперь добавляет `chcp.com 65001 >/dev/null 2>&1; ` перед командами vrunner/oscript — раньше префикс был только у cmd и PowerShell, и в Git Bash кириллица в выводе ломалась (OEM-кодировка общей Windows-консоли). Пользователям приходилось патчить `vrunner.bat` вручную.

Детали:
- именно `chcp.com` — builtin `chcp` из bash недоступен;
- разделитель `;` и глушение ошибок — отсутствие `chcp.com` в PATH (WSL без interop) не ломает команду;
- покрывает и интерактивные запуски в bash-терминале, и команды, инициированные через MCP (те же построители команд).

## Проверка
Тест `buildCommand формирует команду для bash с кодировкой chcp.com`; весь набор (413) зелёный.

Закрывает #216
