### PR TITLE
feat(metadata): редактирование свойств документа в панели

### DIFF
--- a/resources/webview/metadata-object.css
+++ b/resources/webview/metadata-object.css
@@ -8,7 +8,7 @@ body {
 }
 
 .page {
-	max-width: 1240px;
+	max-width: 1600px;
 	margin: 0 auto;
 	padding: 16px 16px 56px 16px;
 	box-sizing: border-box;
@@ -339,10 +339,9 @@ body {
 
 /* Группы полей текут в колонки последовательно (первая заполняется сверху вниз, хвост уходит во вторую). */
 .edit-columns {
-	column-width: 430px;
+	column-width: 520px;
 	column-count: 2;
 	column-gap: 40px;
-	max-width: 960px;
 }
 
 .edit-group {
@@ -517,9 +516,13 @@ body {
 .edit-ref-item-label {
 	min-width: 0;
 	flex: 1 1 auto;
-	overflow: hidden;
+	overflow-wrap: anywhere;
+}
+
+.edit-ref-item-hint {
+	color: var(--vscode-descriptionForeground);
+	font-size: 11px;
 	white-space: nowrap;
-	text-overflow: ellipsis;
 }
 
 .edit-ref-remove {

--- a/resources/webview/metadata-object.css
+++ b/resources/webview/metadata-object.css
@@ -358,10 +358,15 @@ body {
 
 .edit-row {
 	display: grid;
-	grid-template-columns: minmax(160px, 220px) 1fr;
+	grid-template-columns: minmax(160px, 220px) minmax(0, 1fr);
 	align-items: center;
 	gap: 8px;
 	min-height: 28px;
+}
+
+/* Без min-width колонка растягивалась под самую длинную опцию select. */
+.edit-control {
+	min-width: 0;
 }
 
 .edit-row:has(.edit-ref-list) {
@@ -510,8 +515,11 @@ body {
 }
 
 .edit-ref-item-label {
-	overflow-wrap: anywhere;
 	min-width: 0;
+	flex: 1 1 auto;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 }
 
 .edit-ref-remove {

--- a/resources/webview/metadata-object.js
+++ b/resources/webview/metadata-object.js
@@ -502,7 +502,7 @@
 				const rows = selected
 					.map(
 						(item, itemIdx) => `<div class="edit-ref-item">
-							<span class="edit-ref-item-label">${escapeHtml(labelByValue[item] || toDisplayText(item))}</span>
+							<span class="edit-ref-item-label" title="${escapeHtml(toDisplayText(item))}">${escapeHtml(labelByValue[item] || toDisplayText(item))}</span>
 							<span class="edit-ref-item-actions">
 								<button type="button" class="edit-ref-move" data-ref-move-path="${escapeHtml(field.path)}" data-ref-move-index="${itemIdx}" data-ref-move-dir="-1" title="Вверх"${itemIdx === 0 ? ' disabled' : disabled}>↑</button>
 								<button type="button" class="edit-ref-move" data-ref-move-path="${escapeHtml(field.path)}" data-ref-move-index="${itemIdx}" data-ref-move-dir="1" title="Вниз"${itemIdx === selected.length - 1 ? ' disabled' : disabled}>↓</button>

--- a/resources/webview/metadata-object.js
+++ b/resources/webview/metadata-object.js
@@ -460,6 +460,38 @@
 				.join('')}</div>`;
 	}
 
+	/** Вид объекта приглушённым текстом после имени: имя всегда читается первым. */
+	function refItemHintHtml(option) {
+		if (!option || !option.hint) {
+			return '';
+		}
+		return ` <span class="edit-ref-item-hint">${escapeHtml(option.hint)}</span>`;
+	}
+
+	/** Подбор группируем по виду объекта, если он задан. */
+	function refAddOptionsHtml(options) {
+		const flat = options.filter((option) => !option.hint);
+		const groups = [];
+		for (const option of options) {
+			if (!option.hint) {
+				continue;
+			}
+			let group = groups.find((item) => item.hint === option.hint);
+			if (!group) {
+				group = { hint: option.hint, options: [] };
+				groups.push(group);
+			}
+			group.options.push(option);
+		}
+		const optionHtml = (option) => `<option value="${escapeHtml(option.value)}">${escapeHtml(option.label)}</option>`;
+		return [
+			...flat.map(optionHtml),
+			...groups.map(
+				(group) => `<optgroup label="${escapeHtml(group.hint)}">${group.options.map(optionHtml).join('')}</optgroup>`
+			),
+		].join('');
+	}
+
 	function editControlHtml(field, index) {
 		const value = field.path ? getPath(editedProps, field.path) : undefined;
 		const disabled = field.readonly || !fieldEnabled(field) ? ' disabled' : '';
@@ -495,14 +527,16 @@
 			case 'refList': {
 				const selected = Array.isArray(value) ? value : [];
 				const options = Array.isArray(field.options) ? field.options : [];
-				const labelByValue = {};
+				const optionByValue = {};
 				for (const option of options) {
-					labelByValue[option.value] = option.label;
+					optionByValue[option.value] = option;
 				}
 				const rows = selected
 					.map(
 						(item, itemIdx) => `<div class="edit-ref-item">
-							<span class="edit-ref-item-label" title="${escapeHtml(toDisplayText(item))}">${escapeHtml(labelByValue[item] || toDisplayText(item))}</span>
+							<span class="edit-ref-item-label" title="${escapeHtml(toDisplayText(item))}">${escapeHtml(
+								(optionByValue[item] && optionByValue[item].label) || toDisplayText(item)
+							)}${refItemHintHtml(optionByValue[item])}</span>
 							<span class="edit-ref-item-actions">
 								<button type="button" class="edit-ref-move" data-ref-move-path="${escapeHtml(field.path)}" data-ref-move-index="${itemIdx}" data-ref-move-dir="-1" title="Вверх"${itemIdx === 0 ? ' disabled' : disabled}>↑</button>
 								<button type="button" class="edit-ref-move" data-ref-move-path="${escapeHtml(field.path)}" data-ref-move-index="${itemIdx}" data-ref-move-dir="1" title="Вниз"${itemIdx === selected.length - 1 ? ' disabled' : disabled}>↓</button>
@@ -515,9 +549,7 @@
 				const addControl = available.length > 0
 					? `<select class="edit-ref-add-select" data-ref-add-select="${escapeHtml(field.path)}"${disabled}>
 							<option value="" selected>+ Добавить…</option>
-							${available
-								.map((option) => `<option value="${escapeHtml(option.value)}">${escapeHtml(option.label)}</option>`)
-								.join('')}
+							${refAddOptionsHtml(available)}
 						</select>`
 					: '';
 				return `<div class="edit-ref-list">

--- a/src/features/metadata/metadataObjectEditSpec.ts
+++ b/src/features/metadata/metadataObjectEditSpec.ts
@@ -461,6 +461,347 @@ export function buildCatalogEditTabs(input: CatalogEditSpecInput): MetadataEditT
 	];
 }
 
+export interface DocumentEditSpecInput {
+	internalName: string;
+	formNames: readonly string[];
+	commandNames: readonly string[];
+	/** Имена справочников — кандидаты в основания. */
+	catalogNames?: readonly string[];
+	/** Имена документов — кандидаты в основания. */
+	documentNames?: readonly string[];
+	/** Имена реквизитов объекта — кандидаты для ввода по строке и полей блокировки. */
+	attributeNames?: readonly string[];
+	/** Имена нумераторов. */
+	numeratorNames?: readonly string[];
+	/** Кандидаты состава движений: полные ссылки на регистры с подписями. */
+	registerOptions?: readonly MetadataEditOption[];
+}
+
+function documentFormOptions(internalName: string, formNames: readonly string[]): MetadataEditOption[] {
+	return [
+		{ value: '', label: '(не задана)' },
+		...formNames.map((name) => ({ value: `Document.${internalName}.Form.${name}`, label: name })),
+	];
+}
+
+function documentInputByStringOptions(internalName: string, attributeNames: readonly string[]): MetadataEditOption[] {
+	const base = `Document.${internalName}`;
+	return [
+		{ value: `${base}.StandardAttribute.Number`, label: 'Номер' },
+		...attributeNames.map((name) => ({ value: `${base}.Attribute.${name}`, label: name })),
+	];
+}
+
+function documentDataLockFieldsOptions(input: DocumentEditSpecInput): MetadataEditOption[] {
+	const base = `Document.${input.internalName}`;
+	return [
+		{ value: `${base}.StandardAttribute.Number`, label: 'Номер' },
+		{ value: `${base}.StandardAttribute.Date`, label: 'Дата' },
+		...(input.attributeNames ?? []).map((name) => ({ value: `${base}.Attribute.${name}`, label: name })),
+	];
+}
+
+/**
+ * Вкладки редактирования документа: раскладка повторяет редактор EDT
+ * (Основные, Данные, Движения, Формы, Команды, Ввод на основании).
+ */
+export function buildDocumentEditTabs(input: DocumentEditSpecInput): MetadataEditTabSpec[] {
+	const forms = documentFormOptions(input.internalName, input.formNames);
+	const inputByString = documentInputByStringOptions(input.internalName, input.attributeNames ?? []);
+	const dataLockFields = documentDataLockFieldsOptions(input);
+	const basedOn = basedOnOptions({
+		internalName: input.internalName,
+		formNames: [],
+		commandNames: [],
+		catalogNames: input.catalogNames,
+		documentNames: input.documentNames,
+	});
+	const numerators: MetadataEditOption[] = [
+		{ value: '', label: '(не задан)' },
+		...(input.numeratorNames ?? []).map((name) => ({ value: `DocumentNumerator.${name}`, label: name })),
+	];
+	return [
+		{
+			id: 'edit_main',
+			title: 'Основные',
+			groups: [
+				{
+					title: 'Основные',
+					fields: [
+						{ path: 'internalName', label: 'Имя', control: 'text', readonly: true },
+						{ path: 'synonymRu', label: 'Синоним', control: 'text' },
+						{ path: 'comment', label: 'Комментарий', control: 'text' },
+						{ path: 'object', label: 'Модуль объекта', control: 'moduleLink' },
+						{ path: 'manager', label: 'Модуль менеджера', control: 'moduleLink' },
+					],
+				},
+				{
+					title: 'Представление',
+					fields: [
+						{ path: 'document.objectPresentationRu', label: 'Представление объекта', control: 'text' },
+						{
+							path: 'document.extendedObjectPresentationRu',
+							label: 'Расширенное представление объекта',
+							control: 'text',
+						},
+						{ path: 'document.listPresentationRu', label: 'Представление списка', control: 'text' },
+						{
+							path: 'document.extendedListPresentationRu',
+							label: 'Расширенное представление списка',
+							control: 'text',
+						},
+						{ path: 'document.explanationRu', label: 'Пояснение', control: 'textarea' },
+					],
+				},
+				{
+					title: 'Нумерация',
+					fields: [
+						{
+							path: 'document.numberType',
+							label: 'Тип номера',
+							control: 'select',
+							options: opts(['STRING', 'Строка'], ['NUMBER', 'Число']),
+						},
+						{ path: 'document.numberLength', label: 'Длина номера', control: 'number' },
+						{
+							path: 'document.numberAllowedLength',
+							label: 'Допустимая длина номера',
+							control: 'select',
+							options: opts(['VARIABLE', 'Переменная'], ['FIXED', 'Фиксированная']),
+						},
+						{ path: 'document.autonumbering', label: 'Автонумерация', control: 'check' },
+						{ path: 'document.checkUnique', label: 'Контроль уникальности', control: 'check' },
+						{
+							path: 'document.numberPeriodicity',
+							label: 'Периодичность',
+							control: 'select',
+							options: opts(
+								['NONPERIODICAL', 'Непериодический'],
+								['YEAR', 'В пределах года'],
+								['QUARTER', 'В пределах квартала'],
+								['MONTH', 'В пределах месяца'],
+								['DAY', 'В пределах дня']
+							),
+						},
+						{ path: 'document.numerator', label: 'Нумератор', control: 'select', options: numerators, clearable: true },
+					],
+				},
+				{
+					title: 'Поле ввода',
+					fields: [
+						{
+							path: 'document.createOnInput',
+							label: 'Создание при вводе',
+							control: 'select',
+							options: opts(['AUTO', 'Авто'], ['USE', 'Использовать'], ['DONT_USE', 'Не использовать']),
+						},
+						{ path: 'document.inputByString', label: 'Ввод по строке', control: 'refList', options: inputByString },
+						{
+							path: 'document.searchStringModeOnInputByString',
+							label: 'Способ поиска строки при вводе',
+							control: 'select',
+							options: opts(['BEGIN', 'Начало'], ['ANY_PART', 'Любая часть']),
+						},
+						{
+							path: 'document.fullTextSearchOnInputByString',
+							label: 'Полнотекстовый поиск при вводе',
+							control: 'select',
+							options: USE_DONT_USE,
+						},
+						{
+							path: 'document.choiceDataGetModeOnInputByString',
+							label: 'Режим получения данных выбора',
+							control: 'select',
+							options: opts(['DIRECTLY', 'Непосредственно'], ['BACKGROUND', 'Фоновым заданием']),
+						},
+						{
+							path: 'document.choiceHistoryOnInput',
+							label: 'История выбора при вводе',
+							control: 'select',
+							options: opts(['AUTO', 'Авто'], ['DONT_USE', 'Не использовать']),
+						},
+					],
+				},
+				{
+					title: 'Прочее',
+					fields: [
+						{
+							path: 'document.dataLockFields',
+							label: 'Поля блокировки данных',
+							control: 'refList',
+							options: dataLockFields,
+						},
+						{
+							path: 'document.dataLockControlMode',
+							label: 'Режим управления блокировкой данных',
+							control: 'select',
+							options: opts(
+								['AUTOMATIC', 'Автоматический'],
+								['MANAGED', 'Управляемый'],
+								['AUTOMATIC_AND_MANAGED', 'Автоматический и управляемый']
+							),
+						},
+						{
+							path: 'document.fullTextSearch',
+							label: 'Полнотекстовый поиск',
+							control: 'select',
+							options: USE_DONT_USE,
+						},
+						{
+							path: 'document.dataHistory',
+							label: 'История данных',
+							control: 'select',
+							options: USE_DONT_USE,
+						},
+						{
+							path: 'document.updateDataHistoryImmediatelyAfterWrite',
+							label: 'Обновлять историю данных сразу после записи',
+							control: 'check',
+							enabledWhen: [{ path: 'document.dataHistory', equals: 'USE' }],
+						},
+						{
+							path: 'document.executeAfterWriteDataHistoryVersionProcessing',
+							label: 'Выполнять обработку версий истории данных после записи',
+							control: 'check',
+							enabledWhen: [{ path: 'document.dataHistory', equals: 'USE' }],
+						},
+						{ path: 'document.includeHelpInContents', label: 'Включать в содержание справки', control: 'check' },
+					],
+				},
+			],
+		},
+		{
+			id: 'edit_data',
+			title: 'Данные',
+			groups: [],
+		},
+		{
+			id: 'edit_movements',
+			title: 'Движения',
+			groups: [
+				{
+					title: 'Проведение',
+					fields: [
+						{
+							path: 'document.posting',
+							label: 'Проведение',
+							control: 'select',
+							options: opts(['ALLOW', 'Разрешить'], ['DENY', 'Запретить']),
+						},
+						{
+							path: 'document.realTimePosting',
+							label: 'Оперативное проведение',
+							control: 'select',
+							options: opts(['ALLOW', 'Разрешить'], ['DENY', 'Запретить']),
+						},
+						{
+							path: 'document.registerRecordsDeletion',
+							label: 'Удаление движений',
+							control: 'select',
+							options: opts(
+								['AUTO_DELETE_ON_UNPOST', 'Удалять автоматически при отмене проведения'],
+								['AUTO_DELETE', 'Удалять автоматически'],
+								['AUTO_DELETE_OFF', 'Не удалять автоматически']
+							),
+						},
+						{
+							path: 'document.registerRecordsWritingOnPost',
+							label: 'Запись движений при проведении',
+							control: 'select',
+							options: opts(
+								['WRITE_SELECTED', 'Записывать выбранные'],
+								['WRITE_MODIFIED', 'Записывать модифицированные']
+							),
+						},
+						{
+							path: 'document.sequenceFilling',
+							label: 'Заполнение последовательностей',
+							control: 'select',
+							options: opts(['AUTO_FILL', 'Заполнять автоматически'], ['AUTO_FILL_OFF', 'Не заполнять автоматически']),
+						},
+						{ path: 'document.postInPrivilegedMode', label: 'Проведение в привилегированном режиме', control: 'check' },
+						{
+							path: 'document.unpostInPrivilegedMode',
+							label: 'Отмена проведения в привилегированном режиме',
+							control: 'check',
+						},
+					],
+				},
+				{
+					title: 'Движения',
+					fields: [
+						{
+							path: 'document.registerRecords',
+							label: 'Регистры',
+							control: 'refList',
+							options: input.registerOptions ?? [],
+						},
+					],
+				},
+			],
+		},
+		{
+			id: 'edit_forms',
+			title: 'Формы',
+			groups: [
+				{
+					title: 'Основные формы',
+					fields: [
+						{
+							path: 'document.defaultObjectForm',
+							label: 'Основная форма объекта',
+							control: 'select',
+							options: forms,
+							clearable: true,
+						},
+						{
+							path: 'document.defaultListForm',
+							label: 'Основная форма списка',
+							control: 'select',
+							options: forms,
+							clearable: true,
+						},
+						{
+							path: 'document.defaultChoiceForm',
+							label: 'Основная форма выбора',
+							control: 'select',
+							options: forms,
+							clearable: true,
+						},
+					],
+				},
+				{
+					title: 'Формы',
+					fields: [{ path: '', label: 'Формы объекта', control: 'staticList', items: input.formNames }],
+				},
+			],
+		},
+		{
+			id: 'edit_commands',
+			title: 'Команды',
+			groups: [
+				{
+					title: 'Команды',
+					fields: [
+						{ path: 'document.useStandardCommands', label: 'Использовать стандартные команды', control: 'check' },
+						{ path: '', label: 'Команды объекта', control: 'staticList', items: input.commandNames },
+					],
+				},
+			],
+		},
+		{
+			id: 'edit_basedon',
+			title: 'Ввод на основании',
+			groups: [
+				{
+					title: 'Ввод на основании',
+					fields: [{ path: 'document.basedOn', label: 'Вводится на основании', control: 'refList', options: basedOn }],
+				},
+			],
+		},
+	];
+}
+
 function isEditableField(field: MetadataEditField): boolean {
 	return !field.readonly && field.control !== 'staticList' && field.control !== 'moduleLink' && field.path.length > 0;
 }

--- a/src/features/metadata/metadataObjectEditSpec.ts
+++ b/src/features/metadata/metadataObjectEditSpec.ts
@@ -19,6 +19,8 @@ export type MetadataEditControl =
 export interface MetadataEditOption {
 	readonly value: string;
 	readonly label: string;
+	/** Уточнение вида объекта: в списке идёт приглушённым текстом, в подборе — заголовком группы. */
+	readonly hint?: string;
 }
 
 /** Поле активно, только если значение по path равно equals (все условия одновременно). */

--- a/src/features/metadata/metadataObjectPropertiesPanel.ts
+++ b/src/features/metadata/metadataObjectPropertiesPanel.ts
@@ -1228,7 +1228,7 @@ async function loadEditCandidates(
 	if (wantsRegisters) {
 		Object.keys(REGISTER_TAG_LABEL).forEach((tag, index) => {
 			for (const name of registers[index] ?? []) {
-				registerOptions.push({ value: `${tag}.${name}`, label: `${REGISTER_TAG_LABEL[tag]}: ${name}` });
+				registerOptions.push({ value: `${tag}.${name}`, label: name, hint: REGISTER_TAG_LABEL[tag] });
 			}
 		});
 	}

--- a/src/features/metadata/metadataObjectPropertiesPanel.ts
+++ b/src/features/metadata/metadataObjectPropertiesPanel.ts
@@ -10,7 +10,13 @@ import { ensureMdSparrowRuntime } from './mdSparrowBootstrap';
 import { logger } from '../../shared/logger';
 import { mdSparrowSchemaFlagFromConfigurationXml } from './mdSparrowSchemaVersion';
 import { runMdSparrowParamsMutation, runMdSparrowParamsRead, type MdSparrowParams } from './mdSparrowParams';
-import { applyEditedScalars, buildCatalogEditTabs, type MetadataEditTabSpec } from './metadataObjectEditSpec';
+import {
+	applyEditedScalars,
+	buildCatalogEditTabs,
+	buildDocumentEditTabs,
+	type MetadataEditOption,
+	type MetadataEditTabSpec,
+} from './metadataObjectEditSpec';
 import {
 	metadataObjectPropertyProfileByType,
 	type MetadataObjectPropertyProfile,
@@ -32,6 +38,7 @@ interface MdObjectPropertiesDto {
 	nestedSubsystems?: string[];
 	contentRefs?: string[];
 	catalog?: Record<string, unknown>;
+	document?: Record<string, unknown>;
 }
 
 interface MdObjectStructureDto {
@@ -1004,34 +1011,70 @@ function rawNameList(value: unknown): string[] {
 	return Array.from(new Set(out));
 }
 
+/** Кандидаты для подбора в редактируемых списках (читаются из конфигурации). */
+export interface MetadataEditCandidates {
+	catalogNames: readonly string[];
+	documentNames: readonly string[];
+	numeratorNames: readonly string[];
+	registerOptions: readonly MetadataEditOption[];
+}
+
+const EMPTY_CANDIDATES: MetadataEditCandidates = {
+	catalogNames: [],
+	documentNames: [],
+	numeratorNames: [],
+	registerOptions: [],
+};
+
 function buildEditableModel(
 	props: MdObjectPropertiesDto | null,
 	structure: MdObjectStructureDto | null,
 	internalName: string,
-	catalogNames: readonly string[] = [],
-	documentNames: readonly string[] = []
+	candidates: MetadataEditCandidates = EMPTY_CANDIDATES
 ): MetadataPanelEditableModel | undefined {
-	if (!props || props.kind !== 'catalog' || !isRecord(props.catalog)) {
+	if (!props) {
 		return undefined;
 	}
-	const catalog = props.catalog as Record<string, unknown>;
-	if (catalog.objectBelonging === 'ADOPTED') {
-		// Заимствованные объекты расширений: свои правила состава XML, редактирование пока не включаем.
-		return undefined;
+	if (props.kind === 'catalog' && isRecord(props.catalog)) {
+		const catalog = props.catalog as Record<string, unknown>;
+		if (catalog.objectBelonging === 'ADOPTED') {
+			// Заимствованные объекты расширений: свои правила состава XML, редактирование пока не включаем.
+			return undefined;
+		}
+		return {
+			props,
+			tabs: buildCatalogEditTabs({
+				internalName,
+				formNames: rawNameList(structure?.forms),
+				commandNames: rawNameList(structure?.commands),
+				catalogNames: candidates.catalogNames,
+				documentNames: candidates.documentNames,
+				attributeNames: rawNameList(props.attributes),
+				hasOwners: Array.isArray(catalog.owners) && catalog.owners.length > 0,
+				hierarchical: catalog.hierarchical === true,
+			}),
+		};
 	}
-	return {
-		props,
-		tabs: buildCatalogEditTabs({
-			internalName,
-			formNames: rawNameList(structure?.forms),
-			commandNames: rawNameList(structure?.commands),
-			catalogNames,
-			documentNames,
-			attributeNames: rawNameList(props.attributes),
-			hasOwners: Array.isArray(catalog.owners) && catalog.owners.length > 0,
-			hierarchical: catalog.hierarchical === true,
-		}),
-	};
+	if (props.kind === 'document' && isRecord(props.document)) {
+		const document = props.document as Record<string, unknown>;
+		if (document.objectBelonging === 'ADOPTED') {
+			return undefined;
+		}
+		return {
+			props,
+			tabs: buildDocumentEditTabs({
+				internalName,
+				formNames: rawNameList(structure?.forms),
+				commandNames: rawNameList(structure?.commands),
+				catalogNames: candidates.catalogNames,
+				documentNames: candidates.documentNames,
+				attributeNames: rawNameList(props.attributes),
+				numeratorNames: candidates.numeratorNames,
+				registerOptions: candidates.registerOptions,
+			}),
+		};
+	}
+	return undefined;
 }
 
 /**
@@ -1054,8 +1097,7 @@ function buildViewModel(
 	props: MdObjectPropertiesDto | null,
 	structure: MdObjectStructureDto | null,
 	warnings: string[],
-	catalogNames: readonly string[] = [],
-	documentNames: readonly string[] = []
+	candidates: MetadataEditCandidates = EMPTY_CANDIDATES
 ): MetadataPanelViewModel {
 	const declaredObjectType = normalizeObjectType(params.objectType ?? '');
 	const internalName = props?.internalName || structure?.internalName || path.parse(params.objectXmlFsPath).name;
@@ -1065,7 +1107,7 @@ function buildViewModel(
 		properties: props,
 		structure,
 	};
-	const editable = buildEditableModel(props, structure, internalName, catalogNames, documentNames);
+	const editable = buildEditableModel(props, structure, internalName, candidates);
 	const structureLists = editable
 		? {
 				attributes: props?.attributes ? asNamedRows(props.attributes) : asNamedRows(structure?.attributes),
@@ -1105,10 +1147,9 @@ export async function openMetadataObjectPropertiesEditor(
 	}
 
 	const runtime = await ensureMdSparrowRuntime(context);
-	const wantsCatalogCandidates =
-		Boolean(params.cfgPath) && normalizeObjectType(params.objectType ?? '') === 'Catalog';
-	const noCandidates = Promise.resolve({ ok: false as const, error: '' });
-	const [propsResult, structureResult, catalogNamesResult, documentNamesResult] = await Promise.all([
+	const editableType = normalizeObjectType(params.objectType ?? '');
+	const wantsCandidates = Boolean(params.cfgPath) && (editableType === 'Catalog' || editableType === 'Document');
+	const [propsResult, structureResult, candidates] = await Promise.all([
 		runMdSparrowJson<MdObjectPropertiesDto>(
 			runtime,
 			{ op: 'cf-md-object-get', objectXml: params.objectXmlFsPath, schemaVersion: schema },
@@ -1119,20 +1160,9 @@ export async function openMetadataObjectPropertiesEditor(
 			{ op: 'cf-md-object-structure-get', objectXml: params.objectXmlFsPath, schemaVersion: schema },
 			params.cwd
 		),
-		wantsCatalogCandidates
-			? runMdSparrowJson<string[]>(
-					runtime,
-					{ op: 'cf-list-catalogs', configurationXml: params.cfgPath, schemaVersion: schema },
-					params.cwd
-				)
-			: noCandidates,
-		wantsCatalogCandidates
-			? runMdSparrowJson<string[]>(
-					runtime,
-					{ op: 'cf-list-child-objects', configurationXml: params.cfgPath, tag: 'Document', schemaVersion: schema },
-					params.cwd
-				)
-			: noCandidates,
+		wantsCandidates
+			? loadEditCandidates(runtime, params, schema, editableType)
+			: Promise.resolve(EMPTY_CANDIDATES),
 	]);
 
 	const { propsDto, structureDto, warnings, fatalReason } = collectMetadataReadState(propsResult, structureResult);
@@ -1143,10 +1173,7 @@ export async function openMetadataObjectPropertiesEditor(
 		return;
 	}
 
-	const catalogNames = catalogNamesResult.ok && Array.isArray(catalogNamesResult.value) ? catalogNamesResult.value : [];
-	const documentNames =
-		documentNamesResult.ok && Array.isArray(documentNamesResult.value) ? documentNamesResult.value : [];
-	const viewModel = buildViewModel(params, propsDto, structureDto, warnings, catalogNames, documentNames);
+	const viewModel = buildViewModel(params, propsDto, structureDto, warnings, candidates);
 	const title = panelTitleForKind(viewModel.objectKind, viewModel.internalName);
 	const webviewRoot = vscode.Uri.joinPath(context.extensionUri, 'resources', 'webview');
 	const panel = vscode.window.createWebviewPanel('1cMetadataObjectProperties', title, vscode.ViewColumn.Active, {
@@ -1156,7 +1183,7 @@ export async function openMetadataObjectPropertiesEditor(
 	});
 
 	if (viewModel.editable) {
-		registerEditableSaveHandler(context, panel, params, runtime, schema, viewModel.editable, catalogNames, documentNames);
+		registerEditableSaveHandler(context, panel, params, runtime, schema, viewModel.editable, candidates);
 	}
 
 	try {
@@ -1166,6 +1193,46 @@ export async function openMetadataObjectPropertiesEditor(
 		void vscode.window.showErrorMessage('Не удалось загрузить панель свойств.');
 		panel.dispose();
 	}
+}
+
+const REGISTER_TAG_LABEL: Record<string, string> = {
+	InformationRegister: 'Регистр сведений',
+	AccumulationRegister: 'Регистр накопления',
+	AccountingRegister: 'Регистр бухгалтерии',
+	CalculationRegister: 'Регистр расчета',
+};
+
+/** Читает списки конфигурации для подбора в редактируемых полях панели. */
+async function loadEditCandidates(
+	runtime: Awaited<ReturnType<typeof ensureMdSparrowRuntime>>,
+	params: OpenMetadataObjectPropertiesParams,
+	schema: string,
+	editableType: string
+): Promise<MetadataEditCandidates> {
+	const listByTag = async (tag: string): Promise<string[]> => {
+		const res = await runMdSparrowJson<string[]>(
+			runtime,
+			{ op: 'cf-list-child-objects', configurationXml: params.cfgPath, tag, schemaVersion: schema },
+			params.cwd
+		);
+		return res.ok && Array.isArray(res.value) ? res.value : [];
+	};
+	const wantsRegisters = editableType === 'Document';
+	const [catalogNames, documentNames, numeratorNames, ...registers] = await Promise.all([
+		listByTag('Catalog'),
+		listByTag('Document'),
+		wantsRegisters ? listByTag('DocumentNumerator') : Promise.resolve([]),
+		...(wantsRegisters ? Object.keys(REGISTER_TAG_LABEL).map((tag) => listByTag(tag)) : []),
+	]);
+	const registerOptions: MetadataEditOption[] = [];
+	if (wantsRegisters) {
+		Object.keys(REGISTER_TAG_LABEL).forEach((tag, index) => {
+			for (const name of registers[index] ?? []) {
+				registerOptions.push({ value: `${tag}.${name}`, label: `${REGISTER_TAG_LABEL[tag]}: ${name}` });
+			}
+		});
+	}
+	return { catalogNames, documentNames, numeratorNames, registerOptions };
 }
 
 interface MetadataPanelSaveMessage {
@@ -1433,8 +1500,7 @@ function registerEditableSaveHandler(
 	runtime: Awaited<ReturnType<typeof ensureMdSparrowRuntime>>,
 	schema: string,
 	editable: MetadataPanelEditableModel,
-	catalogNames: readonly string[],
-	documentNames: readonly string[]
+	candidates: MetadataEditCandidates
 ): void {
 	const enqueue = params.enqueueMutation ?? (<T,>(fn: () => Promise<T>): Promise<T> => fn());
 	let saving = false;
@@ -1460,8 +1526,7 @@ function registerEditableSaveHandler(
 			propsResult.value,
 			structureResult.ok ? structureResult.value : null,
 			[],
-			catalogNames,
-			documentNames
+			candidates
 		);
 		if (vm.editable) {
 			editable.props = vm.editable.props;

--- a/src/test/metadata/metadataObjectEditSpec.test.ts
+++ b/src/test/metadata/metadataObjectEditSpec.test.ts
@@ -300,7 +300,7 @@ suite('metadataObjectEditSpec: документ', () => {
 			formNames: ['ФормаДокумента'],
 			commandNames: [],
 			numeratorNames: ['ОбщийНумератор'],
-			registerOptions: [{ value: 'AccumulationRegister.Остатки', label: 'Регистр накопления: Остатки' }],
+			registerOptions: [{ value: 'AccumulationRegister.Остатки', label: 'Остатки', hint: 'Регистр накопления' }],
 		});
 		assert.deepStrictEqual(
 			tabs.map((tab: { title: string }) => tab.title),

--- a/src/test/metadata/metadataObjectEditSpec.test.ts
+++ b/src/test/metadata/metadataObjectEditSpec.test.ts
@@ -271,3 +271,59 @@ suite('metadataObjectPropertiesPanel structure edits', () => {
 		assert.strictEqual((dto.tabularSections as Array<Record<string, unknown>>)[0].synonymRu, 'Позиции заказа');
 	});
 });
+
+suite('metadataObjectEditSpec: документ', () => {
+	const { buildDocumentEditTabs } = require('../../features/metadata/metadataObjectEditSpec');
+
+	function documentProps(): Record<string, unknown> {
+		return {
+			kind: 'document',
+			internalName: 'ЗаказПокупателя',
+			synonymRu: 'Заказ покупателя',
+			comment: '',
+			attributes: [{ name: 'Контрагент', synonymRu: 'Контрагент', comment: '' }],
+			tabularSections: [],
+			document: {
+				posting: 'ALLOW',
+				numberType: 'STRING',
+				numberLength: '11',
+				registerRecords: ['AccumulationRegister.Остатки'],
+				autonumbering: true,
+				checkUnique: true,
+			},
+		};
+	}
+
+	test('вкладки документа в раскладке EDT', () => {
+		const tabs = buildDocumentEditTabs({
+			internalName: 'ЗаказПокупателя',
+			formNames: ['ФормаДокумента'],
+			commandNames: [],
+			numeratorNames: ['ОбщийНумератор'],
+			registerOptions: [{ value: 'AccumulationRegister.Остатки', label: 'Регистр накопления: Остатки' }],
+		});
+		assert.deepStrictEqual(
+			tabs.map((tab: { title: string }) => tab.title),
+			['Основные', 'Данные', 'Движения', 'Формы', 'Команды', 'Ввод на основании']
+		);
+		const movements = tabs.find((tab: { id: string }) => tab.id === 'edit_movements');
+		const rr = movements?.groups
+			.flatMap((g: { fields: unknown[] }) => g.fields)
+			.find((f: { path: string }) => f.path === 'document.registerRecords');
+		assert.strictEqual(rr?.control, 'refList');
+		assert.ok(rr?.options?.some((o: { value: string }) => o.value === 'AccumulationRegister.Остатки'));
+		const numerator = tabs
+			.flatMap((tab: { groups: Array<{ fields: unknown[] }> }) => tab.groups)
+			.flatMap((g: { fields: Array<{ path: string }> }) => g.fields)
+			.find((f: { path: string }) => f.path === 'document.numerator');
+		assert.ok(numerator?.options?.some((o: { value: string }) => o.value === 'DocumentNumerator.ОбщийНумератор'));
+	});
+
+	test('панель документа начинается с редактируемых вкладок', () => {
+		const structure = { kind: 'document', internalName: 'ЗаказПокупателя', forms: ['ФормаДокумента'], commands: [] };
+		const tabs = buildMetadataObjectPropertiesTabsForTest('Document', documentProps(), structure);
+		assert.strictEqual(tabs[0]?.id, 'edit_main');
+		assert.strictEqual(tabs[0]?.render, 'edit');
+		assert.ok(!tabs.some((tab) => tab.id === 'overview'));
+	});
+});


### PR DESCRIPTION
## Что сделано

Первый этап #195 — редактирование свойств **документа** в панели метаданных:

- вкладки в раскладке EDT: Основные (Основные, Представление, Нумерация с выбором нумератора, Поле ввода, Прочее), Данные (реквизиты и ТЧ — общая механика со справочником), **Движения** (проведение, оперативное проведение, удаление/запись движений, последовательности, привилегированные режимы + состав регистров с подбором по четырём видам), Формы (основные формы), Команды, Ввод на основании;
- кандидаты подбора (справочники, документы, нумераторы, регистры) читаются из конфигурации параллельным блоком;
- сохранение, инлайн-редактирование структуры, валидация, автосиноним — общие со справочником; заимствованные объекты расширений не редактируются (до #210).

## Требования
Нужен md-sparrow с yellow-hammer/md-sparrow#4 (`dto.document` + теги регистров в `cf-list-child-objects`); релиз jar — в конце, по договорённости.

## Проверка
- 415 тестов, tsc, eslint — зелёные (тесты на вкладки документа, кандидатов движений и нумератора).
- md-sparrow: сквозной тест гранулярной записи документа (синоним + длина номера + проведение + состав движений) зелёный.
