### PR TITLE
feat(metadata): поиск по дереву метаданных

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,12 @@
       ],
       "1c-platform-tools-metadata": [
         {
+          "type": "webview",
+          "id": "1c-platform-tools-metadata-search",
+          "name": "Поиск",
+          "when": "1c-platform-tools.is1CProject == true"
+        },
+        {
           "id": "1c-platform-tools-metadata-tree",
           "name": "Дерево метаданных",
           "contextualTitle": "Метаданные выгрузки",

--- a/package.json
+++ b/package.json
@@ -153,13 +153,15 @@
           "type": "webview",
           "id": "1c-platform-tools-metadata-search",
           "name": "Поиск",
-          "when": "1c-platform-tools.is1CProject == true"
+          "when": "1c-platform-tools.is1CProject == true",
+          "initialSize": 1
         },
         {
           "id": "1c-platform-tools-metadata-tree",
           "name": "Дерево метаданных",
           "contextualTitle": "Метаданные выгрузки",
-          "when": "1c-platform-tools.is1CProject == true"
+          "when": "1c-platform-tools.is1CProject == true",
+          "initialSize": 30
         },
         {
           "id": "1c-platform-tools-metadata-help",

--- a/src/features/metadata/metadataSearchView.ts
+++ b/src/features/metadata/metadataSearchView.ts
@@ -45,11 +45,13 @@ export class MetadataSearchViewProvider implements vscode.WebviewViewProvider {
 <head>
 <meta charset="UTF-8" />
 <style>
+	/* Секция занимает минимум места: только строка ввода. */
 	body {
 		margin: 0;
-		padding: 6px 8px;
+		padding: 2px 8px 3px 8px;
 		font-family: var(--vscode-font-family);
 		font-size: var(--vscode-font-size);
+		overflow: hidden;
 	}
 	.wrap {
 		position: relative;

--- a/src/features/metadata/metadataSearchView.ts
+++ b/src/features/metadata/metadataSearchView.ts
@@ -1,0 +1,136 @@
+/**
+ * Поле поиска над деревом метаданных: отдельный webview-view, потому что у TreeView
+ * своего поля ввода нет.
+ * @module metadataSearchView
+ */
+import * as vscode from 'vscode';
+
+export const METADATA_SEARCH_VIEW_ID = '1c-platform-tools-metadata-search';
+
+/** Задержка перед перестроением дерева: дерево не дёргается на каждый символ. */
+const INPUT_DEBOUNCE_MS = 250;
+
+export class MetadataSearchViewProvider implements vscode.WebviewViewProvider {
+	private _view: vscode.WebviewView | undefined;
+
+	constructor(
+		private readonly _extensionUri: vscode.Uri,
+		private readonly _onQueryChanged: (query: string) => void
+	) {}
+
+	resolveWebviewView(view: vscode.WebviewView): void {
+		this._view = view;
+		view.webview.options = { enableScripts: true, localResourceRoots: [this._extensionUri] };
+		view.webview.html = this.html();
+		view.webview.onDidReceiveMessage((msg: unknown) => {
+			if (typeof msg === 'object' && msg !== null && (msg as { type?: string }).type === 'search') {
+				const query = (msg as { query?: unknown }).query;
+				this._onQueryChanged(typeof query === 'string' ? query : '');
+			}
+		});
+		view.onDidDispose(() => {
+			this._view = undefined;
+		});
+	}
+
+	/** Сбрасывает поле извне (например, командой очистки). */
+	clear(): void {
+		this._view?.webview.postMessage({ type: 'clear' });
+		this._onQueryChanged('');
+	}
+
+	private html(): string {
+		return `<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8" />
+<style>
+	body {
+		margin: 0;
+		padding: 6px 8px;
+		font-family: var(--vscode-font-family);
+		font-size: var(--vscode-font-size);
+	}
+	.wrap {
+		position: relative;
+		display: block;
+	}
+	input {
+		width: 100%;
+		box-sizing: border-box;
+		padding: 3px 22px 3px 6px;
+		border-radius: 2px;
+		border: 1px solid var(--vscode-input-border, transparent);
+		background: var(--vscode-input-background);
+		color: var(--vscode-input-foreground);
+		font-family: inherit;
+		font-size: inherit;
+	}
+	input:focus {
+		outline: 1px solid var(--vscode-focusBorder);
+		outline-offset: -1px;
+	}
+	input::placeholder {
+		color: var(--vscode-input-placeholderForeground);
+	}
+	.clear {
+		position: absolute;
+		top: 50%;
+		right: 4px;
+		transform: translateY(-50%);
+		border: none;
+		background: transparent;
+		color: var(--vscode-descriptionForeground);
+		cursor: pointer;
+		padding: 0 2px;
+		font-size: 13px;
+		line-height: 1;
+	}
+	.clear:hover {
+		color: var(--vscode-foreground);
+	}
+	.clear.hidden {
+		display: none;
+	}
+</style>
+</head>
+<body>
+	<label class="wrap">
+		<input id="q" type="text" placeholder="Поиск по метаданным…" autocomplete="off" />
+		<button id="clear" class="clear hidden" type="button" title="Очистить">×</button>
+	</label>
+	<script>
+		const vscodeApi = acquireVsCodeApi();
+		const input = document.getElementById('q');
+		const clearBtn = document.getElementById('clear');
+		let timer;
+		function send() {
+			clearBtn.classList.toggle('hidden', input.value.length === 0);
+			clearTimeout(timer);
+			timer = setTimeout(function () {
+				vscodeApi.postMessage({ type: 'search', query: input.value });
+			}, ${INPUT_DEBOUNCE_MS});
+		}
+		input.addEventListener('input', send);
+		input.addEventListener('keydown', function (e) {
+			if (e.key === 'Escape' && input.value.length > 0) {
+				input.value = '';
+				send();
+			}
+		});
+		clearBtn.addEventListener('click', function () {
+			input.value = '';
+			input.focus();
+			send();
+		});
+		window.addEventListener('message', function (event) {
+			if (event.data && event.data.type === 'clear') {
+				input.value = '';
+				clearBtn.classList.add('hidden');
+			}
+		});
+	</script>
+</body>
+</html>`;
+	}
+}

--- a/src/features/metadata/metadataTreeView.ts
+++ b/src/features/metadata/metadataTreeView.ts
@@ -1055,6 +1055,8 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 				readonly allowedSubsystemNames?: ReadonlySet<string>;
 		  }
 		| undefined;
+	/** Поиск по дереву: строка в нижнем регистре либо undefined. */
+	private _textFilter: string | undefined;
 
 	/** Кэш последнего успешного дерева (для API). */
 	private _sourceItems: MetadataSourceTreeItem[] = [];
@@ -1143,6 +1145,21 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 	): void {
 		this._subsystemFilter = { subsystemName, allowedObjectNames, allowedObjectKeys, allowedSubsystemNames };
 		this._onDidChange.fire(undefined);
+	}
+
+	/** Поиск по имени объекта: пустая строка снимает фильтр. */
+	setTextFilter(query: string): void {
+		const normalized = query.trim().toLowerCase();
+		const next = normalized.length > 0 ? normalized : undefined;
+		if (next === this._textFilter) {
+			return;
+		}
+		this._textFilter = next;
+		this._onDidChange.fire(undefined);
+	}
+
+	getTextFilter(): string | undefined {
+		return this._textFilter;
 	}
 
 	clearSubsystemFilter(): void {
@@ -1345,6 +1362,14 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 			return [errItem];
 		}
 		if (!element) {
+			if (this._textFilter && !this.anySourceHasMatches()) {
+				const empty = new vscode.TreeItem(
+					`Ничего не найдено: «${this._textFilter}»`,
+					vscode.TreeItemCollapsibleState.None
+				);
+				empty.iconPath = new vscode.ThemeIcon('search');
+				return [empty];
+			}
 			return [...this._sourceItems];
 		}
 		if (element instanceof MetadataSourceTreeItem) {
@@ -1387,7 +1412,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 	}
 
 	private filterGroups(groups: MetadataMdGroupTreeItem[]): MetadataMdGroupTreeItem[] {
-		if (!this._subsystemFilter) {
+		if (!this._subsystemFilter && !this._textFilter) {
 			return groups;
 		}
 		const filtered: MetadataMdGroupTreeItem[] = [];
@@ -1396,6 +1421,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 			const leaves = this.filterLeaves(this._leavesByGroup.get(key) ?? []);
 			const subgroups = this.filterSubgroups(this._subgroupsByGroup.get(key) ?? []);
 			if (leaves.length > 0 || subgroups.length > 0) {
+				this.expandWhenSearching(group);
 				filtered.push(group);
 			}
 		}
@@ -1403,7 +1429,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 	}
 
 	private filterSubgroups(subgroups: MetadataMdSubgroupTreeItem[]): MetadataMdSubgroupTreeItem[] {
-		if (!this._subsystemFilter) {
+		if (!this._subsystemFilter && !this._textFilter) {
 			return subgroups;
 		}
 		const filtered: MetadataMdSubgroupTreeItem[] = [];
@@ -1414,17 +1440,50 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 				) ?? []
 			);
 			if (leaves.length > 0) {
+				this.expandWhenSearching(subgroup);
 				filtered.push(subgroup);
 			}
 		}
 		return filtered;
 	}
 
+	/** При поиске ветки с совпадениями раскрыты: иначе результат надо разворачивать руками. */
+	private expandWhenSearching(item: vscode.TreeItem): void {
+		if (item.collapsibleState === vscode.TreeItemCollapsibleState.None) {
+			return;
+		}
+		item.collapsibleState = this._textFilter
+			? vscode.TreeItemCollapsibleState.Expanded
+			: vscode.TreeItemCollapsibleState.Collapsed;
+	}
+
 	private filterLeaves(leaves: MetadataLeafTreeItem[]): MetadataLeafTreeItem[] {
-		if (!this._subsystemFilter) {
+		if (!this._subsystemFilter && !this._textFilter) {
 			return leaves;
 		}
-		return leaves.filter((leaf) => this.isLeafAllowedBySubsystemFilter(leaf));
+		return leaves.filter(
+			(leaf) => this.isLeafAllowedBySubsystemFilter(leaf) && this.isLeafAllowedByTextFilter(leaf)
+		);
+	}
+
+	private isLeafAllowedByTextFilter(leaf: MetadataLeafTreeItem): boolean {
+		if (!this._textFilter) {
+			return true;
+		}
+		return leaf.name.toLowerCase().includes(this._textFilter);
+	}
+
+	private anySourceHasMatches(): boolean {
+		for (const source of this._sourceItems) {
+			const flat = this._flatLeavesBySource.get(source.sourceId);
+			if (flat && this.filterLeaves(flat).length > 0) {
+				return true;
+			}
+			if (this.filterGroups(this._groupsBySource.get(source.sourceId) ?? []).length > 0) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private isLeafAllowedBySubsystemFilter(leaf: MetadataLeafTreeItem): boolean {

--- a/src/features/metadata/metadataTreeView.ts
+++ b/src/features/metadata/metadataTreeView.ts
@@ -1055,8 +1055,8 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 				readonly allowedSubsystemNames?: ReadonlySet<string>;
 		  }
 		| undefined;
-	/** Поиск по дереву: строка в нижнем регистре либо undefined. */
-	private _textFilter: string | undefined;
+	/** Поиск по дереву: исходный запрос и его слова в нижнем регистре. */
+	private _textFilter: { readonly query: string; readonly terms: readonly string[] } | undefined;
 
 	/** Кэш последнего успешного дерева (для API). */
 	private _sourceItems: MetadataSourceTreeItem[] = [];
@@ -1147,11 +1147,18 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 		this._onDidChange.fire(undefined);
 	}
 
-	/** Поиск по имени объекта: пустая строка снимает фильтр. */
+	/**
+	 * Поиск по имени объекта: пустая строка снимает фильтр. Запрос из нескольких слов
+	 * ищет объекты, где встречается каждое слово («демо замет» находит «_ДемоЗаметки»).
+	 */
 	setTextFilter(query: string): void {
-		const normalized = query.trim().toLowerCase();
-		const next = normalized.length > 0 ? normalized : undefined;
-		if (next === this._textFilter) {
+		const terms = query
+			.trim()
+			.toLowerCase()
+			.split(/\s+/)
+			.filter((term) => term.length > 0);
+		const next = terms.length > 0 ? { query: query.trim(), terms } : undefined;
+		if (next?.query === this._textFilter?.query) {
 			return;
 		}
 		this._textFilter = next;
@@ -1159,7 +1166,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 	}
 
 	getTextFilter(): string | undefined {
-		return this._textFilter;
+		return this._textFilter?.query;
 	}
 
 	clearSubsystemFilter(): void {
@@ -1364,7 +1371,7 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 		if (!element) {
 			if (this._textFilter && !this.anySourceHasMatches()) {
 				const empty = new vscode.TreeItem(
-					`Ничего не найдено: «${this._textFilter}»`,
+					`Ничего не найдено: «${this._textFilter.query}»`,
 					vscode.TreeItemCollapsibleState.None
 				);
 				empty.iconPath = new vscode.ThemeIcon('search');
@@ -1470,7 +1477,8 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 		if (!this._textFilter) {
 			return true;
 		}
-		return leaf.name.toLowerCase().includes(this._textFilter);
+		const name = leaf.name.toLowerCase();
+		return this._textFilter.terms.every((term) => name.includes(term));
 	}
 
 	private anySourceHasMatches(): boolean {

--- a/src/features/metadata/registerMetadataView.ts
+++ b/src/features/metadata/registerMetadataView.ts
@@ -3,6 +3,7 @@ import {
 	MetadataLeafTreeItem,
 	MetadataTreeDataProvider,
 } from './metadataTreeView';
+import { METADATA_SEARCH_VIEW_ID, MetadataSearchViewProvider } from './metadataSearchView';
 
 export interface MetadataViewRegistration {
 	metadataTreeProvider: MetadataTreeDataProvider;
@@ -21,6 +22,13 @@ export function registerMetadataView(
 		showCollapseAll: true,
 	});
 	context.subscriptions.push(metadataTreeView);
+
+	const metadataSearchProvider = new MetadataSearchViewProvider(context.extensionUri, (query) => {
+		metadataTreeProvider.setTextFilter(query);
+	});
+	context.subscriptions.push(
+		vscode.window.registerWebviewViewProvider(METADATA_SEARCH_VIEW_ID, metadataSearchProvider)
+	);
 
 	const syncMetadataCatalogSelectionContext = (): void => {
 		const has = metadataTreeView.selection.some(

--- a/src/test/metadata/metadataTreeView.test.ts
+++ b/src/test/metadata/metadataTreeView.test.ts
@@ -192,6 +192,21 @@ suite('metadataTreeView поиск по имени', () => {
 		);
 	});
 
+	test('запрос из нескольких слов ищет объекты со всеми словами', async () => {
+		const { provider, group } = createProvider();
+		provider.setTextFilter('демо замет');
+		const leaves = await provider.getChildren(group);
+		assert.deepStrictEqual(
+			leaves.map((item) => (item as MetadataLeafTreeItem).name),
+			['_ДемоЗаметки'],
+			'«демо замет» находит «_ДемоЗаметки», но не «_ДемоЗаказыПокупателей»'
+		);
+
+		provider.setTextFilter('демо');
+		const demoLeaves = await provider.getChildren(group);
+		assert.strictEqual(demoLeaves.length, 2);
+	});
+
 	test('группа без совпадений скрывается, с совпадениями — раскрывается', async () => {
 		const { provider, root, group } = createProvider();
 		provider.setTextFilter('заметки');

--- a/src/test/metadata/metadataTreeView.test.ts
+++ b/src/test/metadata/metadataTreeView.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'node:assert';
+import * as vscode from 'vscode';
 import * as path from 'node:path';
 import {
 	MetadataLeafTreeItem,
@@ -123,6 +124,96 @@ suite('metadataTreeView subsystem filter', () => {
 		provider.clearSubsystemFilter();
 		const leaves = await provider.getChildren(group);
 		assert.strictEqual(leaves.length, 2);
+	});
+});
+
+suite('metadataTreeView поиск по имени', () => {
+	function createProvider(): {
+		provider: MetadataTreeDataProvider;
+		root: MetadataSourceTreeItem;
+		group: MetadataMdGroupTreeItem;
+	} {
+		const context = createMockExtensionContext();
+		const provider = new MetadataTreeDataProvider(context);
+		const root = new MetadataSourceTreeItem(
+			'main',
+			'Основная конфигурация',
+			'main',
+			'C:/ws/src/cf/Configuration.xml',
+			'C:/ws/src/cf'
+		);
+		const group = new MetadataMdGroupTreeItem(
+			'main',
+			'commonModules',
+			'Общие модули',
+			'symbol-namespace',
+			true,
+			false,
+			'C:/ws/src/cf/Configuration.xml',
+			'C:/ws/src/cf'
+		);
+		const leaf = (name: string): MetadataLeafTreeItem =>
+			new MetadataLeafTreeItem(
+				'main',
+				'commonModules',
+				undefined,
+				'CommonModule',
+				name,
+				undefined,
+				'C:/ws',
+				context.extensionUri,
+				'C:/ws/src/cf/Configuration.xml',
+				'C:/ws/src/cf'
+			);
+		const mutable = provider as unknown as {
+			_workspaceRoot: string;
+			_sourceItems: MetadataSourceTreeItem[];
+			_groupsBySource: Map<string, MetadataMdGroupTreeItem[]>;
+			_leavesByGroup: Map<string, MetadataLeafTreeItem[]>;
+		};
+		mutable._workspaceRoot = 'C:/ws';
+		mutable._sourceItems = [root];
+		mutable._groupsBySource.set('main', [group]);
+		mutable._leavesByGroup.set('main|commonModules', [
+			leaf('_ДемоЗаметки'),
+			leaf('_ДемоЗаказыПокупателей'),
+			leaf('ОбщегоНазначения'),
+		]);
+		return { provider, root, group };
+	}
+
+	test('ищет вхождением подстроки без учёта регистра', async () => {
+		const { provider, group } = createProvider();
+		provider.setTextFilter('демозамет');
+		const leaves = await provider.getChildren(group);
+		assert.deepStrictEqual(
+			leaves.map((item) => (item as MetadataLeafTreeItem).name),
+			['_ДемоЗаметки']
+		);
+	});
+
+	test('группа без совпадений скрывается, с совпадениями — раскрывается', async () => {
+		const { provider, root, group } = createProvider();
+		provider.setTextFilter('заметки');
+		const groups = await provider.getChildren(root);
+		assert.strictEqual(groups.length, 1);
+		assert.strictEqual(group.collapsibleState, vscode.TreeItemCollapsibleState.Expanded);
+
+		provider.setTextFilter('такогонет');
+		const hiddenGroups = await provider.getChildren(root);
+		assert.strictEqual(hiddenGroups.length, 0, 'группа без совпадений скрыта');
+		const rootLevel = await provider.getChildren();
+		assert.strictEqual(rootLevel.length, 1);
+		assert.ok(String(rootLevel[0].label).startsWith('Ничего не найдено'), 'видно, что ничего не нашлось');
+	});
+
+	test('пустая строка снимает фильтр', async () => {
+		const { provider, group } = createProvider();
+		provider.setTextFilter('заметки');
+		provider.setTextFilter('   ');
+		assert.strictEqual(provider.getTextFilter(), undefined);
+		const leaves = await provider.getChildren(group);
+		assert.strictEqual(leaves.length, 3);
 	});
 });
 


### PR DESCRIPTION
Закрывает #220.

Над деревом метаданных появилось поле поиска с кнопкой очистки. Вводим часть имени — в дереве остаются только подходящие объекты, ветки с совпадениями раскрываются, пустые скрываются. Пустое поле (или Esc) возвращает дерево в обычный вид; когда совпадений нет, в дереве видно «Ничего не найдено: «…»».

Поиск идёт по уже прочитанному дереву, без обращения к md-sparrow, с задержкой в 250 мс — дерево не перестраивается на каждый символ. Фильтр по подсистеме работает вместе с поиском: условия складываются.

## Как встроено
У `TreeView` своего поля ввода нет, поэтому поле — отдельный `WebviewViewProvider`, зарегистрированный в контейнере «Метаданные» перед деревом (тем же приёмом сделан выбор конфигурации над панелью отладки). Фильтрация легла на существующий механизм `filterGroups`/`filterSubgroups`/`filterLeaves`, которым уже пользуется фильтр по подсистеме.

## Проверка
Три теста на провайдере дерева: поиск вхождением подстроки без учёта регистра, скрытие групп без совпадений с раскрытием групп с совпадениями и сообщением о пустом результате, снятие фильтра пустой строкой. Всего 428 тестов, eslint и tsc зелёные.

Проверить руками на эталонной конфигурации: ввести «демо замет» — останутся общий модуль, подсистема, подписка, функциональная опция и регистр сведений; крестик возвращает полное дерево.