### PR TITLE
feat(metadata): панель «Фильтры» с поиском по подсистемам

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,14 @@
           "initialSize": 1
         },
         {
+          "id": "1c-platform-tools-metadata-filters",
+          "name": "Фильтры",
+          "contextualTitle": "Фильтры метаданных",
+          "when": "1c-platform-tools.is1CProject == true",
+          "visibility": "collapsed",
+          "initialSize": 8
+        },
+        {
           "id": "1c-platform-tools-metadata-tree",
           "name": "Дерево метаданных",
           "contextualTitle": "Метаданные выгрузки",
@@ -484,16 +492,22 @@
         "category": "1C: Метаданные"
       },
       {
+        "command": "1c-platform-tools.metadata.filters.apply",
+        "title": "Установить фильтр",
+        "category": "1C: Метаданные",
+        "icon": "$(check)"
+      },
+      {
+        "command": "1c-platform-tools.metadata.filters.reset",
+        "title": "Сбросить фильтр",
+        "category": "1C: Метаданные",
+        "icon": "$(clear-all)"
+      },
+      {
         "command": "1c-platform-tools.metadata.find",
         "title": "Поиск",
         "category": "1C: Метаданные",
         "icon": "$(search)"
-      },
-      {
-        "command": "1c-platform-tools.metadata.pickSubsystemFilter",
-        "title": "Фильтр по подсистемам",
-        "category": "1C: Метаданные",
-        "icon": "$(filter)"
       },
       {
         "command": "1c-platform-tools.metadata.addDocument",
@@ -1779,14 +1793,19 @@
           "group": "navigation@2"
         },
         {
-          "command": "1c-platform-tools.metadata.pickSubsystemFilter",
-          "when": "view == 1c-platform-tools-metadata-tree",
-          "group": "navigation@3"
-        },
-        {
           "submenu": "1c-platform-tools.metadata.overflowMenu",
           "when": "view == 1c-platform-tools-metadata-tree",
           "group": "navigation@6"
+        },
+        {
+          "command": "1c-platform-tools.metadata.filters.apply",
+          "when": "view == 1c-platform-tools-metadata-filters",
+          "group": "navigation@1"
+        },
+        {
+          "command": "1c-platform-tools.metadata.filters.reset",
+          "when": "view == 1c-platform-tools-metadata-filters",
+          "group": "navigation@2"
         }
       ],
       "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -499,6 +499,30 @@
         "icon": "$(collapse-all)"
       },
       {
+        "command": "1c-platform-tools.metadata.filters.includeNested.on",
+        "title": "Включать объекты из подчинённых подсистем",
+        "category": "1C: Метаданные",
+        "icon": "$(list-flat)"
+      },
+      {
+        "command": "1c-platform-tools.metadata.filters.includeNested.off",
+        "title": "Не включать объекты из подчинённых подсистем",
+        "category": "1C: Метаданные",
+        "icon": "$(list-tree)"
+      },
+      {
+        "command": "1c-platform-tools.metadata.filters.includeParents.on",
+        "title": "Включать объекты из родительских подсистем",
+        "category": "1C: Метаданные",
+        "icon": "$(type-hierarchy)"
+      },
+      {
+        "command": "1c-platform-tools.metadata.filters.includeParents.off",
+        "title": "Не включать объекты из родительских подсистем",
+        "category": "1C: Метаданные",
+        "icon": "$(type-hierarchy-super)"
+      },
+      {
         "command": "1c-platform-tools.metadata.filters.reset",
         "title": "Очистить фильтр",
         "category": "1C: Метаданные",
@@ -1788,14 +1812,34 @@
           "group": "navigation@6"
         },
         {
+          "command": "1c-platform-tools.metadata.filters.includeNested.on",
+          "when": "view == 1c-platform-tools-metadata-filters && !1c-platform-tools.metadata.filters.includeNested",
+          "group": "navigation@1"
+        },
+        {
+          "command": "1c-platform-tools.metadata.filters.includeNested.off",
+          "when": "view == 1c-platform-tools-metadata-filters && 1c-platform-tools.metadata.filters.includeNested",
+          "group": "navigation@1"
+        },
+        {
+          "command": "1c-platform-tools.metadata.filters.includeParents.on",
+          "when": "view == 1c-platform-tools-metadata-filters && !1c-platform-tools.metadata.filters.includeParents",
+          "group": "navigation@2"
+        },
+        {
+          "command": "1c-platform-tools.metadata.filters.includeParents.off",
+          "when": "view == 1c-platform-tools-metadata-filters && 1c-platform-tools.metadata.filters.includeParents",
+          "group": "navigation@2"
+        },
+        {
           "command": "1c-platform-tools.metadata.filters.reset",
           "when": "view == 1c-platform-tools-metadata-filters",
-          "group": "navigation@2"
+          "group": "navigation@3"
         },
         {
           "command": "1c-platform-tools.metadata.filters.collapseAll",
           "when": "view == 1c-platform-tools-metadata-filters",
-          "group": "navigation@1"
+          "group": "navigation@9"
         }
       ],
       "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -484,6 +484,18 @@
         "category": "1C: Метаданные"
       },
       {
+        "command": "1c-platform-tools.metadata.find",
+        "title": "Поиск",
+        "category": "1C: Метаданные",
+        "icon": "$(search)"
+      },
+      {
+        "command": "1c-platform-tools.metadata.pickSubsystemFilter",
+        "title": "Фильтр по подсистемам",
+        "category": "1C: Метаданные",
+        "icon": "$(filter)"
+      },
+      {
         "command": "1c-platform-tools.metadata.addDocument",
         "title": "Добавить документ",
         "category": "1C: Метаданные"
@@ -1754,17 +1766,27 @@
         {
           "command": "1c-platform-tools.metadata.er.openCanvas",
           "when": "view == 1c-platform-tools-metadata-tree",
-          "group": "navigation@2"
+          "group": "navigation@4"
         },
         {
           "command": "1c-platform-tools.metadata.clearSubsystemFilter",
           "when": "view == 1c-platform-tools-metadata-tree && 1c-platform-tools.metadata.subsystemFilterActive",
-          "group": "navigation@4"
+          "group": "navigation@5"
+        },
+        {
+          "command": "1c-platform-tools.metadata.find",
+          "when": "view == 1c-platform-tools-metadata-tree",
+          "group": "navigation@2"
+        },
+        {
+          "command": "1c-platform-tools.metadata.pickSubsystemFilter",
+          "when": "view == 1c-platform-tools-metadata-tree",
+          "group": "navigation@3"
         },
         {
           "submenu": "1c-platform-tools.metadata.overflowMenu",
           "when": "view == 1c-platform-tools-metadata-tree",
-          "group": "navigation@5"
+          "group": "navigation@6"
         }
       ],
       "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -154,7 +154,8 @@
           "id": "1c-platform-tools-metadata-search",
           "name": "Поиск",
           "when": "1c-platform-tools.is1CProject == true",
-          "initialSize": 1
+          "initialSize": 1,
+          "visibility": "collapsed"
         },
         {
           "id": "1c-platform-tools-metadata-filters",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,8 @@
           "contextualTitle": "Фильтры метаданных",
           "when": "1c-platform-tools.is1CProject == true",
           "visibility": "collapsed",
-          "initialSize": 8
+          "initialSize": 6,
+          "type": "webview"
         },
         {
           "id": "1c-platform-tools-metadata-tree",
@@ -492,22 +493,16 @@
         "category": "1C: Метаданные"
       },
       {
-        "command": "1c-platform-tools.metadata.filters.apply",
-        "title": "Установить фильтр",
+        "command": "1c-platform-tools.metadata.filters.collapseAll",
+        "title": "Свернуть",
         "category": "1C: Метаданные",
-        "icon": "$(check)"
+        "icon": "$(collapse-all)"
       },
       {
         "command": "1c-platform-tools.metadata.filters.reset",
-        "title": "Сбросить фильтр",
+        "title": "Очистить фильтр",
         "category": "1C: Метаданные",
         "icon": "$(clear-all)"
-      },
-      {
-        "command": "1c-platform-tools.metadata.find",
-        "title": "Поиск",
-        "category": "1C: Метаданные",
-        "icon": "$(search)"
       },
       {
         "command": "1c-platform-tools.metadata.addDocument",
@@ -1788,24 +1783,19 @@
           "group": "navigation@5"
         },
         {
-          "command": "1c-platform-tools.metadata.find",
-          "when": "view == 1c-platform-tools-metadata-tree",
-          "group": "navigation@2"
-        },
-        {
           "submenu": "1c-platform-tools.metadata.overflowMenu",
           "when": "view == 1c-platform-tools-metadata-tree",
           "group": "navigation@6"
         },
         {
-          "command": "1c-platform-tools.metadata.filters.apply",
-          "when": "view == 1c-platform-tools-metadata-filters",
-          "group": "navigation@1"
-        },
-        {
           "command": "1c-platform-tools.metadata.filters.reset",
           "when": "view == 1c-platform-tools-metadata-filters",
           "group": "navigation@2"
+        },
+        {
+          "command": "1c-platform-tools.metadata.filters.collapseAll",
+          "when": "view == 1c-platform-tools-metadata-filters",
+          "group": "navigation@1"
         }
       ],
       "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -499,30 +499,6 @@
         "icon": "$(collapse-all)"
       },
       {
-        "command": "1c-platform-tools.metadata.filters.includeNested.on",
-        "title": "Включать объекты из подчинённых подсистем",
-        "category": "1C: Метаданные",
-        "icon": "$(list-flat)"
-      },
-      {
-        "command": "1c-platform-tools.metadata.filters.includeNested.off",
-        "title": "Не включать объекты из подчинённых подсистем",
-        "category": "1C: Метаданные",
-        "icon": "$(list-tree)"
-      },
-      {
-        "command": "1c-platform-tools.metadata.filters.includeParents.on",
-        "title": "Включать объекты из родительских подсистем",
-        "category": "1C: Метаданные",
-        "icon": "$(type-hierarchy)"
-      },
-      {
-        "command": "1c-platform-tools.metadata.filters.includeParents.off",
-        "title": "Не включать объекты из родительских подсистем",
-        "category": "1C: Метаданные",
-        "icon": "$(type-hierarchy-super)"
-      },
-      {
         "command": "1c-platform-tools.metadata.filters.reset",
         "title": "Очистить фильтр",
         "category": "1C: Метаданные",
@@ -1812,29 +1788,9 @@
           "group": "navigation@6"
         },
         {
-          "command": "1c-platform-tools.metadata.filters.includeNested.on",
-          "when": "view == 1c-platform-tools-metadata-filters && !1c-platform-tools.metadata.filters.includeNested",
-          "group": "navigation@1"
-        },
-        {
-          "command": "1c-platform-tools.metadata.filters.includeNested.off",
-          "when": "view == 1c-platform-tools-metadata-filters && 1c-platform-tools.metadata.filters.includeNested",
-          "group": "navigation@1"
-        },
-        {
-          "command": "1c-platform-tools.metadata.filters.includeParents.on",
-          "when": "view == 1c-platform-tools-metadata-filters && !1c-platform-tools.metadata.filters.includeParents",
-          "group": "navigation@2"
-        },
-        {
-          "command": "1c-platform-tools.metadata.filters.includeParents.off",
-          "when": "view == 1c-platform-tools-metadata-filters && 1c-platform-tools.metadata.filters.includeParents",
-          "group": "navigation@2"
-        },
-        {
           "command": "1c-platform-tools.metadata.filters.reset",
           "when": "view == 1c-platform-tools-metadata-filters",
-          "group": "navigation@3"
+          "group": "navigation@1"
         },
         {
           "command": "1c-platform-tools.metadata.filters.collapseAll",

--- a/src/app/registerMetadataFlow.ts
+++ b/src/app/registerMetadataFlow.ts
@@ -14,12 +14,13 @@ export function registerMetadataFlow(
 	context: vscode.ExtensionContext,
 	isProject: boolean
 ): MetadataFlow {
-	const { metadataTreeProvider, metadataTreeView } = registerMetadataView(context);
+	const { metadataTreeProvider, metadataTreeView, metadataSearchProvider } = registerMetadataView(context);
 
 	const metadataFeatureDisposables = registerMetadataFeature({
 		context,
 		metadataTreeProvider,
 		metadataTreeView,
+		metadataSearchProvider,
 	});
 	context.subscriptions.push(...metadataFeatureDisposables);
 

--- a/src/app/registerMetadataFlow.ts
+++ b/src/app/registerMetadataFlow.ts
@@ -14,13 +14,15 @@ export function registerMetadataFlow(
 	context: vscode.ExtensionContext,
 	isProject: boolean
 ): MetadataFlow {
-	const { metadataTreeProvider, metadataTreeView, metadataSearchProvider } = registerMetadataView(context);
+	const { metadataTreeProvider, metadataTreeView, metadataSearchProvider, metadataFilterProvider } =
+		registerMetadataView(context);
 
 	const metadataFeatureDisposables = registerMetadataFeature({
 		context,
 		metadataTreeProvider,
 		metadataTreeView,
 		metadataSearchProvider,
+		metadataFilterProvider,
 	});
 	context.subscriptions.push(...metadataFeatureDisposables);
 

--- a/src/features/metadata/mdSparrowParams.ts
+++ b/src/features/metadata/mdSparrowParams.ts
@@ -63,6 +63,7 @@ export type MdSparrowOp =
 	| 'cf-configuration-properties-get'
 	| 'cf-list-child-objects'
 	| 'cf-list-catalogs'
+	| 'cf-md-subsystem-tree'
 	| 'project-metadata-tree'
 	| 'cf-md-graph';
 

--- a/src/features/metadata/metadataFilterView.ts
+++ b/src/features/metadata/metadataFilterView.ts
@@ -1,13 +1,12 @@
 /**
  * Панель «Фильтры»: поле поиска и дерево подсистем с флажками — отбор дерева метаданных.
  * Строки повторяют дерево метаданных: тот же значок подсистемы и та же геометрия узлов.
- * Охват (подчинённые, родительские) задаётся командами в шапке панели.
+ * Подсистемы и их состав приходят от md-sparrow одной операцией на источник.
  * @module metadataFilterView
  */
-import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { hasNestedSubsystems, nestedSubsystemXmls, parentSubsystemXml, type SubsystemRef } from './metadataSubsystemFilter';
-import type { MetadataLeafTreeItem, MetadataTreeDataProvider } from './metadataTreeView';
+import { loadSubsystemTrees, type SubsystemNode } from './metadataSubsystemFilter';
+import type { MetadataTreeDataProvider } from './metadataTreeView';
 
 export const METADATA_FILTERS_VIEW_ID = '1c-platform-tools-metadata-filters';
 
@@ -17,52 +16,81 @@ const APPLY_DEBOUNCE_MS = 350;
 export type FilterOptionKey = 'includeNested' | 'includeParents';
 
 export interface FilterSelection {
-	readonly subsystems: readonly SubsystemRef[];
+	/** Прочитанное дерево подсистем: по нему считается состав отбора. */
+	readonly roots: readonly SubsystemNode[];
+	/** Пути к XML отмеченных подсистем. */
+	readonly checkedPaths: ReadonlySet<string>;
 	readonly includeNested: boolean;
 	readonly includeParents: boolean;
 }
 
-/** Узел дерева подсистем для webview. */
+/** Узел дерева подсистем для webview: только то, что нужно нарисовать. */
 interface SubsystemTreeNode {
 	readonly key: string;
 	readonly name: string;
 	readonly children: SubsystemTreeNode[];
 }
 
+function toWebviewNodes(nodes: readonly SubsystemNode[]): SubsystemTreeNode[] {
+	return [...nodes]
+		.sort((a, b) => a.name.localeCompare(b.name, 'ru'))
+		.map((node) => ({ key: node.xmlPath, name: node.name, children: toWebviewNodes(node.children) }));
+}
+
 export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 	private _view: vscode.WebviewView | undefined;
-	private readonly _refByKey = new Map<string, SubsystemRef>();
+	private _roots: SubsystemNode[] = [];
+	private _loading: Promise<void> | undefined;
 	private readonly _checked = new Set<string>();
 	private readonly _options: Record<FilterOptionKey, boolean> = { includeNested: true, includeParents: false };
 	private _applyTimer: ReturnType<typeof setTimeout> | undefined;
 
 	constructor(
-		private readonly _extensionUri: vscode.Uri,
+		private readonly _context: vscode.ExtensionContext,
 		private readonly _treeProvider: MetadataTreeDataProvider,
 		private readonly _onSelectionChanged: (selection: FilterSelection) => void
 	) {}
+
+	get roots(): readonly SubsystemNode[] {
+		return this._roots;
+	}
 
 	resolveWebviewView(view: vscode.WebviewView): void {
 		this._view = view;
 		view.webview.options = {
 			enableScripts: true,
-			localResourceRoots: [vscode.Uri.joinPath(this._extensionUri, 'resources')],
+			localResourceRoots: [vscode.Uri.joinPath(this._context.extensionUri, 'resources')],
 		};
 		view.webview.html = this.html(view.webview);
 		view.webview.onDidReceiveMessage((msg: unknown) => this.onMessage(msg));
 		view.onDidChangeVisibility(() => {
 			if (view.visible) {
-				this.pushTree();
+				void this.reload();
 			}
 		});
 		view.onDidDispose(() => {
 			this._view = undefined;
 		});
-		this.pushTree();
+		void this.reload();
 	}
 
 	/** Перечитывает подсистемы: дерево метаданных могло обновиться. */
 	refresh(): void {
+		void this.reload();
+	}
+
+	/** Читает подсистемы через md-sparrow; параллельные вызовы ждут один и тот же запрос. */
+	private async reload(): Promise<void> {
+		if (!this._loading) {
+			this._loading = loadSubsystemTrees(this._context, this._treeProvider)
+				.then((roots) => {
+					this._roots = roots;
+				})
+				.finally(() => {
+					this._loading = undefined;
+				});
+		}
+		await this._loading;
 		this.pushTree();
 	}
 
@@ -107,15 +135,9 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 		}
 		this._applyTimer = setTimeout(() => {
 			this._applyTimer = undefined;
-			const subsystems: SubsystemRef[] = [];
-			for (const key of this._checked) {
-				const ref = this._refByKey.get(key);
-				if (ref) {
-					subsystems.push(ref);
-				}
-			}
 			this._onSelectionChanged({
-				subsystems,
+				roots: this._roots,
+				checkedPaths: new Set(this._checked),
 				includeNested: this._options.includeNested,
 				includeParents: this._options.includeParents,
 			});
@@ -126,55 +148,16 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 		if (!this._view) {
 			return;
 		}
-		this._refByKey.clear();
-		const roots = this._treeProvider
-			.listSubsystemLeaves()
-			.filter((leaf) => leaf.resourceUri && !parentSubsystemXml(leaf.resourceUri.fsPath))
-			.map((leaf) => this.refFromLeaf(leaf))
-			.filter((ref): ref is SubsystemRef => ref !== undefined);
 		void this._view.webview.postMessage({
 			type: 'tree',
-			nodes: this.toNodes(roots),
+			nodes: toWebviewNodes(this._roots),
 			checked: [...this._checked],
 			options: this._options,
 		});
 	}
 
-	private toNodes(refs: SubsystemRef[]): SubsystemTreeNode[] {
-		return refs
-			.sort((a, b) => a.name.localeCompare(b.name, 'ru'))
-			.map((ref) => {
-				this._refByKey.set(ref.xmlAbs, ref);
-				const children = hasNestedSubsystems(ref.xmlAbs, ref.name)
-					? this.toNodes(
-							nestedSubsystemXmls(ref.xmlAbs, ref.name).map((xmlAbs) => ({
-								sourceId: ref.sourceId,
-								name: path.basename(xmlAbs, '.xml'),
-								xmlAbs,
-								configurationXmlAbs: ref.configurationXmlAbs,
-								metadataRootAbs: ref.metadataRootAbs,
-							}))
-						)
-					: [];
-				return { key: ref.xmlAbs, name: ref.name, children };
-			});
-	}
-
-	private refFromLeaf(leaf: MetadataLeafTreeItem): SubsystemRef | undefined {
-		if (!leaf.resourceUri) {
-			return undefined;
-		}
-		return {
-			sourceId: leaf.sourceId,
-			name: leaf.name,
-			xmlAbs: leaf.resourceUri.fsPath,
-			configurationXmlAbs: leaf.configurationXmlAbs,
-			metadataRootAbs: leaf.metadataRootAbs,
-		};
-	}
-
 	private iconUri(webview: vscode.Webview, ...parts: string[]): string {
-		return webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'resources', ...parts)).toString();
+		return webview.asWebviewUri(vscode.Uri.joinPath(this._context.extensionUri, 'resources', ...parts)).toString();
 	}
 
 	private html(webview: vscode.Webview): string {

--- a/src/features/metadata/metadataFilterView.ts
+++ b/src/features/metadata/metadataFilterView.ts
@@ -1,0 +1,173 @@
+/**
+ * Панель «Фильтры»: дерево подсистем с флажками — отбор объектов дерева метаданных.
+ * Раскладка повторяет диалог «Фильтр по подсистемам» из EDT: подсистемы с флажками
+ * и два переключателя охвата.
+ * @module metadataFilterView
+ */
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { hasNestedSubsystems, nestedSubsystemXmls, parentSubsystemXml, type SubsystemRef } from './metadataSubsystemFilter';
+import type { MetadataLeafTreeItem, MetadataTreeDataProvider } from './metadataTreeView';
+
+export const METADATA_FILTERS_VIEW_ID = '1c-platform-tools-metadata-filters';
+
+type FilterOptionKey = 'includeNested' | 'includeParents';
+
+/** Узел панели «Фильтры»: подсистема либо переключатель охвата. */
+export class MetadataFilterTreeItem extends vscode.TreeItem {
+	constructor(
+		public readonly kind: 'subsystem' | 'option',
+		public readonly key: string,
+		label: string,
+		collapsibleState: vscode.TreeItemCollapsibleState,
+		checked: boolean,
+		public readonly subsystem?: SubsystemRef,
+		public readonly option?: FilterOptionKey
+	) {
+		super(label, collapsibleState);
+		this.checkboxState = checked
+			? vscode.TreeItemCheckboxState.Checked
+			: vscode.TreeItemCheckboxState.Unchecked;
+		this.contextValue = kind === 'subsystem' ? 'metadataFilterSubsystem' : 'metadataFilterOption';
+		if (kind === 'subsystem') {
+			this.iconPath = new vscode.ThemeIcon('symbol-namespace');
+		}
+	}
+}
+
+const OPTION_LABEL: Record<FilterOptionKey, string> = {
+	includeNested: 'Включать объекты из подчинённых подсистем',
+	includeParents: 'Включать объекты из родительских подсистем',
+};
+
+export class MetadataFilterTreeDataProvider implements vscode.TreeDataProvider<MetadataFilterTreeItem> {
+	private readonly _onDidChange = new vscode.EventEmitter<MetadataFilterTreeItem | undefined | null | void>();
+	readonly onDidChangeTreeData = this._onDidChange.event;
+
+	/** Отмеченные подсистемы: ключ — путь к XML. */
+	private readonly _checked = new Map<string, SubsystemRef>();
+	private readonly _options: Record<FilterOptionKey, boolean> = {
+		includeNested: true,
+		includeParents: false,
+	};
+
+	constructor(private readonly _treeProvider: MetadataTreeDataProvider) {}
+
+	refresh(): void {
+		this._onDidChange.fire(undefined);
+	}
+
+	get checkedSubsystems(): SubsystemRef[] {
+		return [...this._checked.values()];
+	}
+
+	get options(): { includeNested: boolean; includeParents: boolean } {
+		return { ...this._options };
+	}
+
+	/** Снимает все флажки подсистем; охват не трогаем. */
+	clearChecked(): void {
+		if (this._checked.size === 0) {
+			return;
+		}
+		this._checked.clear();
+		this._onDidChange.fire(undefined);
+	}
+
+	setChecked(item: MetadataFilterTreeItem, checked: boolean): void {
+		if (item.kind === 'option' && item.option) {
+			this._options[item.option] = checked;
+			this._onDidChange.fire(undefined);
+			return;
+		}
+		if (!item.subsystem) {
+			return;
+		}
+		if (checked) {
+			this._checked.set(item.subsystem.xmlAbs, item.subsystem);
+		} else {
+			this._checked.delete(item.subsystem.xmlAbs);
+		}
+		this._onDidChange.fire(undefined);
+	}
+
+	getTreeItem(element: MetadataFilterTreeItem): vscode.TreeItem {
+		return element;
+	}
+
+	getChildren(element?: MetadataFilterTreeItem): MetadataFilterTreeItem[] {
+		if (!element) {
+			return [...this.rootSubsystemItems(), ...this.optionItems()];
+		}
+		if (element.kind !== 'subsystem' || !element.subsystem) {
+			return [];
+		}
+		return this.nestedItems(element.subsystem);
+	}
+
+	private optionItems(): MetadataFilterTreeItem[] {
+		return (Object.keys(OPTION_LABEL) as FilterOptionKey[]).map(
+			(key) =>
+				new MetadataFilterTreeItem(
+					'option',
+					`option:${key}`,
+					OPTION_LABEL[key],
+					vscode.TreeItemCollapsibleState.None,
+					this._options[key],
+					undefined,
+					key
+				)
+		);
+	}
+
+	private rootSubsystemItems(): MetadataFilterTreeItem[] {
+		const roots = this._treeProvider
+			.listSubsystemLeaves()
+			.filter((leaf) => leaf.resourceUri && !parentSubsystemXml(leaf.resourceUri.fsPath))
+			.map((leaf) => this.refFromLeaf(leaf))
+			.filter((ref): ref is SubsystemRef => ref !== undefined);
+		return this.toItems(roots);
+	}
+
+	private nestedItems(parent: SubsystemRef): MetadataFilterTreeItem[] {
+		const nested = nestedSubsystemXmls(parent.xmlAbs, parent.name).map((xmlAbs) => ({
+			sourceId: parent.sourceId,
+			name: path.basename(xmlAbs, '.xml'),
+			xmlAbs,
+			configurationXmlAbs: parent.configurationXmlAbs,
+			metadataRootAbs: parent.metadataRootAbs,
+		}));
+		return this.toItems(nested);
+	}
+
+	private toItems(refs: SubsystemRef[]): MetadataFilterTreeItem[] {
+		return refs
+			.sort((a, b) => a.name.localeCompare(b.name, 'ru'))
+			.map(
+				(ref) =>
+					new MetadataFilterTreeItem(
+						'subsystem',
+						ref.xmlAbs,
+						ref.name,
+						hasNestedSubsystems(ref.xmlAbs, ref.name)
+							? vscode.TreeItemCollapsibleState.Collapsed
+							: vscode.TreeItemCollapsibleState.None,
+						this._checked.has(ref.xmlAbs),
+						ref
+					)
+			);
+	}
+
+	private refFromLeaf(leaf: MetadataLeafTreeItem): SubsystemRef | undefined {
+		if (!leaf.resourceUri) {
+			return undefined;
+		}
+		return {
+			sourceId: leaf.sourceId,
+			name: leaf.name,
+			xmlAbs: leaf.resourceUri.fsPath,
+			configurationXmlAbs: leaf.configurationXmlAbs,
+			metadataRootAbs: leaf.metadataRootAbs,
+		};
+	}
+}

--- a/src/features/metadata/metadataFilterView.ts
+++ b/src/features/metadata/metadataFilterView.ts
@@ -40,9 +40,7 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 		private readonly _extensionUri: vscode.Uri,
 		private readonly _treeProvider: MetadataTreeDataProvider,
 		private readonly _onSelectionChanged: (selection: FilterSelection) => void
-	) {
-		this.syncOptionContexts();
-	}
+	) {}
 
 	resolveWebviewView(view: vscode.WebviewView): void {
 		this._view = view;
@@ -72,19 +70,6 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 		void this._view?.webview.postMessage({ type: 'collapseAll' });
 	}
 
-	getOption(key: FilterOptionKey): boolean {
-		return this._options[key];
-	}
-
-	setOption(key: FilterOptionKey, value: boolean): void {
-		if (this._options[key] === value) {
-			return;
-		}
-		this._options[key] = value;
-		this.syncOptionContexts();
-		this.scheduleApply();
-	}
-
 	/** Снимает флажки и сбрасывает отбор. */
 	clear(): void {
 		this._checked.clear();
@@ -92,23 +77,22 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 		this.scheduleApply();
 	}
 
-	private syncOptionContexts(): void {
-		for (const key of Object.keys(this._options) as FilterOptionKey[]) {
-			void vscode.commands.executeCommand('setContext', `1c-platform-tools.metadata.filters.${key}`, this._options[key]);
-		}
-	}
-
 	private onMessage(msg: unknown): void {
 		if (typeof msg !== 'object' || msg === null) {
 			return;
 		}
-		const message = msg as { type?: string; key?: string; checked?: boolean };
+		const message = msg as { type?: string; key?: string; checked?: boolean; option?: FilterOptionKey };
 		if (message.type === 'toggle' && typeof message.key === 'string') {
 			if (message.checked) {
 				this._checked.add(message.key);
 			} else {
 				this._checked.delete(message.key);
 			}
+			this.scheduleApply();
+			return;
+		}
+		if (message.type === 'option' && message.option) {
+			this._options[message.option] = message.checked === true;
 			this.scheduleApply();
 			return;
 		}
@@ -152,6 +136,7 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 			type: 'tree',
 			nodes: this.toNodes(roots),
 			checked: [...this._checked],
+			options: this._options,
 		});
 	}
 
@@ -304,6 +289,21 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 		padding: 4px 8px;
 		color: var(--vscode-descriptionForeground);
 	}
+	.options {
+		margin-top: 6px;
+		padding: 6px 8px 0 8px;
+		border-top: 1px solid var(--vscode-panel-border);
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+	.options label {
+		display: flex;
+		align-items: flex-start;
+		gap: 6px;
+		cursor: pointer;
+		color: var(--vscode-descriptionForeground);
+	}
 	body.vscode-dark {
 		color-scheme: dark;
 	}
@@ -315,11 +315,17 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 		<button id="clearSearch" class="search-clear hidden" type="button" title="Очистить">×</button>
 	</div>
 	<div id="tree"></div>
+	<div class="options">
+		<label><input id="includeNested" type="checkbox" checked /><span>Включать объекты из подчинённых подсистем</span></label>
+		<label><input id="includeParents" type="checkbox" /><span>Включать объекты из родительских подсистем</span></label>
+	</div>
 	<script>
 		const vscodeApi = acquireVsCodeApi();
 		const treeRoot = document.getElementById('tree');
 		const searchInput = document.getElementById('q');
 		const clearSearchBtn = document.getElementById('clearSearch');
+		const nestedBox = document.getElementById('includeNested');
+		const parentsBox = document.getElementById('includeParents');
 		const ICON_LIGHT = '${iconLight}';
 		const ICON_DARK = '${iconDark}';
 		// Те же шевроны, что рисует VS Code в деревьях.
@@ -435,6 +441,12 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 			searchInput.focus();
 			render();
 		});
+		nestedBox.addEventListener('change', function () {
+			vscodeApi.postMessage({ type: 'option', option: 'includeNested', checked: nestedBox.checked });
+		});
+		parentsBox.addEventListener('change', function () {
+			vscodeApi.postMessage({ type: 'option', option: 'includeParents', checked: parentsBox.checked });
+		});
 
 		window.addEventListener('message', function (event) {
 			const msg = event.data;
@@ -444,6 +456,8 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 			if (msg.type === 'tree') {
 				nodes = msg.nodes || [];
 				checked = new Set(msg.checked || []);
+				nestedBox.checked = !!(msg.options && msg.options.includeNested);
+				parentsBox.checked = !!(msg.options && msg.options.includeParents);
 				render();
 			}
 			if (msg.type === 'collapseAll') {

--- a/src/features/metadata/metadataFilterView.ts
+++ b/src/features/metadata/metadataFilterView.ts
@@ -1,7 +1,7 @@
 /**
- * Панель «Фильтры»: поле поиска, дерево подсистем с флажками и переключатели охвата.
- * Раскладка повторяет диалог «Фильтр по подсистемам» из EDT; отбор применяется сразу,
- * без отдельной кнопки.
+ * Панель «Фильтры»: поле поиска и дерево подсистем с флажками — отбор дерева метаданных.
+ * Строки повторяют дерево метаданных: тот же значок подсистемы и та же геометрия узлов.
+ * Охват (подчинённые, родительские) задаётся командами в шапке панели.
  * @module metadataFilterView
  */
 import * as path from 'node:path';
@@ -37,14 +37,20 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 	private _applyTimer: ReturnType<typeof setTimeout> | undefined;
 
 	constructor(
+		private readonly _extensionUri: vscode.Uri,
 		private readonly _treeProvider: MetadataTreeDataProvider,
 		private readonly _onSelectionChanged: (selection: FilterSelection) => void
-	) {}
+	) {
+		this.syncOptionContexts();
+	}
 
 	resolveWebviewView(view: vscode.WebviewView): void {
 		this._view = view;
-		view.webview.options = { enableScripts: true };
-		view.webview.html = this.html();
+		view.webview.options = {
+			enableScripts: true,
+			localResourceRoots: [vscode.Uri.joinPath(this._extensionUri, 'resources')],
+		};
+		view.webview.html = this.html(view.webview);
 		view.webview.onDidReceiveMessage((msg: unknown) => this.onMessage(msg));
 		view.onDidChangeVisibility(() => {
 			if (view.visible) {
@@ -66,6 +72,19 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 		void this._view?.webview.postMessage({ type: 'collapseAll' });
 	}
 
+	getOption(key: FilterOptionKey): boolean {
+		return this._options[key];
+	}
+
+	setOption(key: FilterOptionKey, value: boolean): void {
+		if (this._options[key] === value) {
+			return;
+		}
+		this._options[key] = value;
+		this.syncOptionContexts();
+		this.scheduleApply();
+	}
+
 	/** Снимает флажки и сбрасывает отбор. */
 	clear(): void {
 		this._checked.clear();
@@ -73,22 +92,23 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 		this.scheduleApply();
 	}
 
+	private syncOptionContexts(): void {
+		for (const key of Object.keys(this._options) as FilterOptionKey[]) {
+			void vscode.commands.executeCommand('setContext', `1c-platform-tools.metadata.filters.${key}`, this._options[key]);
+		}
+	}
+
 	private onMessage(msg: unknown): void {
 		if (typeof msg !== 'object' || msg === null) {
 			return;
 		}
-		const message = msg as { type?: string; key?: string; checked?: boolean; option?: FilterOptionKey };
+		const message = msg as { type?: string; key?: string; checked?: boolean };
 		if (message.type === 'toggle' && typeof message.key === 'string') {
 			if (message.checked) {
 				this._checked.add(message.key);
 			} else {
 				this._checked.delete(message.key);
 			}
-			this.scheduleApply();
-			return;
-		}
-		if (message.type === 'option' && message.option) {
-			this._options[message.option] = message.checked === true;
 			this.scheduleApply();
 			return;
 		}
@@ -128,12 +148,10 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 			.filter((leaf) => leaf.resourceUri && !parentSubsystemXml(leaf.resourceUri.fsPath))
 			.map((leaf) => this.refFromLeaf(leaf))
 			.filter((ref): ref is SubsystemRef => ref !== undefined);
-		const nodes = this.toNodes(roots);
 		void this._view.webview.postMessage({
 			type: 'tree',
-			nodes,
+			nodes: this.toNodes(roots),
 			checked: [...this._checked],
-			options: this._options,
 		});
 	}
 
@@ -170,7 +188,14 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 		};
 	}
 
-	private html(): string {
+	private iconUri(webview: vscode.Webview, ...parts: string[]): string {
+		return webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'resources', ...parts)).toString();
+	}
+
+	private html(webview: vscode.Webview): string {
+		// Значок подсистемы — тот же файл, что и в дереве метаданных.
+		const iconLight = this.iconUri(webview, 'metadata-tree-icons', 'subsystem.svg');
+		const iconDark = this.iconUri(webview, 'metadata-tree-icons', 'dark', 'subsystem.svg');
 		return `<!DOCTYPE html>
 <html lang="ru">
 <head>
@@ -216,31 +241,56 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 	.search-clear.hidden {
 		display: none;
 	}
+	/* Геометрия строки — как у дерева метаданных: 22px, отступ уровня 8px, значок 16px. */
 	.row {
 		display: flex;
 		align-items: center;
-		gap: 4px;
-		padding: 1px 8px;
+		height: 22px;
+		gap: 6px;
+		padding-right: 8px;
 		white-space: nowrap;
+		cursor: pointer;
 	}
 	.row:hover {
 		background: var(--vscode-list-hoverBackground);
 	}
 	.twisty {
-		width: 14px;
-		flex: 0 0 14px;
+		width: 16px;
+		height: 16px;
+		flex: 0 0 16px;
 		border: none;
 		background: transparent;
-		color: var(--vscode-foreground);
-		cursor: pointer;
 		padding: 0;
-		font-size: 10px;
-		line-height: 1;
-		text-align: center;
+		color: var(--vscode-icon-foreground, var(--vscode-foreground));
+		cursor: pointer;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 	}
 	.twisty.empty {
 		visibility: hidden;
 		cursor: default;
+	}
+	.twisty svg {
+		width: 16px;
+		height: 16px;
+		fill: currentColor;
+	}
+	.node-icon {
+		width: 16px;
+		height: 16px;
+		flex: 0 0 16px;
+	}
+	.icon-dark {
+		display: none;
+	}
+	body.vscode-dark .icon-dark,
+	body.vscode-high-contrast:not(.vscode-high-contrast-light) .icon-dark {
+		display: inline;
+	}
+	body.vscode-dark .icon-light,
+	body.vscode-high-contrast:not(.vscode-high-contrast-light) .icon-light {
+		display: none;
 	}
 	label.name {
 		display: flex;
@@ -249,21 +299,6 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 		cursor: pointer;
 		overflow: hidden;
 		text-overflow: ellipsis;
-	}
-	.options {
-		margin-top: 6px;
-		padding: 6px 8px 0 8px;
-		border-top: 1px solid var(--vscode-panel-border);
-		display: flex;
-		flex-direction: column;
-		gap: 4px;
-	}
-	.options label {
-		display: flex;
-		align-items: flex-start;
-		gap: 6px;
-		cursor: pointer;
-		color: var(--vscode-descriptionForeground);
 	}
 	.empty-note {
 		padding: 4px 8px;
@@ -280,17 +315,16 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 		<button id="clearSearch" class="search-clear hidden" type="button" title="Очистить">×</button>
 	</div>
 	<div id="tree"></div>
-	<div class="options">
-		<label><input id="includeNested" type="checkbox" checked /><span>Включать объекты из подчинённых подсистем</span></label>
-		<label><input id="includeParents" type="checkbox" /><span>Включать объекты из родительских подсистем</span></label>
-	</div>
 	<script>
 		const vscodeApi = acquireVsCodeApi();
 		const treeRoot = document.getElementById('tree');
 		const searchInput = document.getElementById('q');
 		const clearSearchBtn = document.getElementById('clearSearch');
-		const nestedBox = document.getElementById('includeNested');
-		const parentsBox = document.getElementById('includeParents');
+		const ICON_LIGHT = '${iconLight}';
+		const ICON_DARK = '${iconDark}';
+		// Те же шевроны, что рисует VS Code в деревьях.
+		const CHEVRON_RIGHT = '<svg viewBox="0 0 16 16"><path d="M5.7 13.7L5 13l5-5-5-5 .7-.7L11.4 8z"/></svg>';
+		const CHEVRON_DOWN = '<svg viewBox="0 0 16 16"><path d="M7.976 10.072l4.357-4.357.62.618L8.284 11h-.618L3 6.333l.619-.618 4.357 4.357z"/></svg>';
 		let nodes = [];
 		let checked = new Set();
 		let collapsed = new Set();
@@ -315,13 +349,20 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 			// При поиске ветки с совпадениями раскрыты, иначе результат пришлось бы разворачивать руками.
 			const isCollapsed = query ? false : collapsed.has(node.key);
 			const twisty = hasChildren
-				? '<button class="twisty" data-twisty="' + escapeAttr(node.key) + '">' + (isCollapsed ? '▶' : '▼') + '</button>'
+				? '<button class="twisty" data-twisty="' + escapeHtml(node.key) + '" title="Развернуть или свернуть">' +
+					(isCollapsed ? CHEVRON_RIGHT : CHEVRON_DOWN) +
+					'</button>'
 				: '<span class="twisty empty"></span>';
-			const box = '<input type="checkbox" data-key="' + escapeAttr(node.key) + '"' + (checked.has(node.key) ? ' checked' : '') + ' />';
+			const icon =
+				'<img class="node-icon icon-light" src="' + ICON_LIGHT + '" alt="" />' +
+				'<img class="node-icon icon-dark" src="' + ICON_DARK + '" alt="" />';
+			const box =
+				'<input type="checkbox" data-key="' + escapeHtml(node.key) + '"' + (checked.has(node.key) ? ' checked' : '') + ' />';
 			const row =
-				'<div class="row" style="padding-left:' + (8 + depth * 14) + 'px">' +
+				'<div class="row" style="padding-left:' + (4 + depth * 8) + 'px">' +
 				twisty +
-				'<label class="name">' + box + '<span>' + escapeHtml(node.name) + '</span></label>' +
+				box +
+				'<label class="name">' + icon + '<span>' + escapeHtml(node.name) + '</span></label>' +
 				'</div>';
 			const children = hasChildren && !isCollapsed
 				? visibleChildren.map((child) => rowHtml(child, depth + 1)).join('')
@@ -364,10 +405,6 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 			});
 		}
 
-		function escapeAttr(text) {
-			return escapeHtml(text);
-		}
-
 		function collectKeys(list, out) {
 			for (const node of list) {
 				if (node.children.length > 0) {
@@ -398,12 +435,6 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 			searchInput.focus();
 			render();
 		});
-		nestedBox.addEventListener('change', function () {
-			vscodeApi.postMessage({ type: 'option', option: 'includeNested', checked: nestedBox.checked });
-		});
-		parentsBox.addEventListener('change', function () {
-			vscodeApi.postMessage({ type: 'option', option: 'includeParents', checked: parentsBox.checked });
-		});
 
 		window.addEventListener('message', function (event) {
 			const msg = event.data;
@@ -413,8 +444,6 @@ export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
 			if (msg.type === 'tree') {
 				nodes = msg.nodes || [];
 				checked = new Set(msg.checked || []);
-				nestedBox.checked = !!(msg.options && msg.options.includeNested);
-				parentsBox.checked = !!(msg.options && msg.options.includeParents);
 				render();
 			}
 			if (msg.type === 'collapseAll') {

--- a/src/features/metadata/metadataFilterView.ts
+++ b/src/features/metadata/metadataFilterView.ts
@@ -1,7 +1,7 @@
 /**
- * Панель «Фильтры»: дерево подсистем с флажками — отбор объектов дерева метаданных.
- * Раскладка повторяет диалог «Фильтр по подсистемам» из EDT: подсистемы с флажками
- * и два переключателя охвата.
+ * Панель «Фильтры»: поле поиска, дерево подсистем с флажками и переключатели охвата.
+ * Раскладка повторяет диалог «Фильтр по подсистемам» из EDT; отбор применяется сразу,
+ * без отдельной кнопки.
  * @module metadataFilterView
  */
 import * as path from 'node:path';
@@ -11,151 +11,150 @@ import type { MetadataLeafTreeItem, MetadataTreeDataProvider } from './metadataT
 
 export const METADATA_FILTERS_VIEW_ID = '1c-platform-tools-metadata-filters';
 
-type FilterOptionKey = 'includeNested' | 'includeParents';
+/** Пауза перед применением: подсистемы отмечают пачкой, состав читаем один раз. */
+const APPLY_DEBOUNCE_MS = 350;
 
-/** Узел панели «Фильтры»: подсистема либо переключатель охвата. */
-export class MetadataFilterTreeItem extends vscode.TreeItem {
-	constructor(
-		public readonly kind: 'subsystem' | 'option',
-		public readonly key: string,
-		label: string,
-		collapsibleState: vscode.TreeItemCollapsibleState,
-		checked: boolean,
-		public readonly subsystem?: SubsystemRef,
-		public readonly option?: FilterOptionKey
-	) {
-		super(label, collapsibleState);
-		this.checkboxState = checked
-			? vscode.TreeItemCheckboxState.Checked
-			: vscode.TreeItemCheckboxState.Unchecked;
-		this.contextValue = kind === 'subsystem' ? 'metadataFilterSubsystem' : 'metadataFilterOption';
-		if (kind === 'subsystem') {
-			this.iconPath = new vscode.ThemeIcon('symbol-namespace');
-		}
-	}
+export type FilterOptionKey = 'includeNested' | 'includeParents';
+
+export interface FilterSelection {
+	readonly subsystems: readonly SubsystemRef[];
+	readonly includeNested: boolean;
+	readonly includeParents: boolean;
 }
 
-const OPTION_LABEL: Record<FilterOptionKey, string> = {
-	includeNested: 'Включать объекты из подчинённых подсистем',
-	includeParents: 'Включать объекты из родительских подсистем',
-};
+/** Узел дерева подсистем для webview. */
+interface SubsystemTreeNode {
+	readonly key: string;
+	readonly name: string;
+	readonly children: SubsystemTreeNode[];
+}
 
-export class MetadataFilterTreeDataProvider implements vscode.TreeDataProvider<MetadataFilterTreeItem> {
-	private readonly _onDidChange = new vscode.EventEmitter<MetadataFilterTreeItem | undefined | null | void>();
-	readonly onDidChangeTreeData = this._onDidChange.event;
+export class MetadataFilterViewProvider implements vscode.WebviewViewProvider {
+	private _view: vscode.WebviewView | undefined;
+	private readonly _refByKey = new Map<string, SubsystemRef>();
+	private readonly _checked = new Set<string>();
+	private readonly _options: Record<FilterOptionKey, boolean> = { includeNested: true, includeParents: false };
+	private _applyTimer: ReturnType<typeof setTimeout> | undefined;
 
-	/** Отмеченные подсистемы: ключ — путь к XML. */
-	private readonly _checked = new Map<string, SubsystemRef>();
-	private readonly _options: Record<FilterOptionKey, boolean> = {
-		includeNested: true,
-		includeParents: false,
-	};
+	constructor(
+		private readonly _treeProvider: MetadataTreeDataProvider,
+		private readonly _onSelectionChanged: (selection: FilterSelection) => void
+	) {}
 
-	constructor(private readonly _treeProvider: MetadataTreeDataProvider) {}
+	resolveWebviewView(view: vscode.WebviewView): void {
+		this._view = view;
+		view.webview.options = { enableScripts: true };
+		view.webview.html = this.html();
+		view.webview.onDidReceiveMessage((msg: unknown) => this.onMessage(msg));
+		view.onDidChangeVisibility(() => {
+			if (view.visible) {
+				this.pushTree();
+			}
+		});
+		view.onDidDispose(() => {
+			this._view = undefined;
+		});
+		this.pushTree();
+	}
 
+	/** Перечитывает подсистемы: дерево метаданных могло обновиться. */
 	refresh(): void {
-		this._onDidChange.fire(undefined);
+		this.pushTree();
 	}
 
-	get checkedSubsystems(): SubsystemRef[] {
-		return [...this._checked.values()];
+	collapseAll(): void {
+		void this._view?.webview.postMessage({ type: 'collapseAll' });
 	}
 
-	get options(): { includeNested: boolean; includeParents: boolean } {
-		return { ...this._options };
-	}
-
-	/** Снимает все флажки подсистем; охват не трогаем. */
-	clearChecked(): void {
-		if (this._checked.size === 0) {
-			return;
-		}
+	/** Снимает флажки и сбрасывает отбор. */
+	clear(): void {
 		this._checked.clear();
-		this._onDidChange.fire(undefined);
+		void this._view?.webview.postMessage({ type: 'clearChecked' });
+		this.scheduleApply();
 	}
 
-	setChecked(item: MetadataFilterTreeItem, checked: boolean): void {
-		if (item.kind === 'option' && item.option) {
-			this._options[item.option] = checked;
-			this._onDidChange.fire(undefined);
+	private onMessage(msg: unknown): void {
+		if (typeof msg !== 'object' || msg === null) {
 			return;
 		}
-		if (!item.subsystem) {
+		const message = msg as { type?: string; key?: string; checked?: boolean; option?: FilterOptionKey };
+		if (message.type === 'toggle' && typeof message.key === 'string') {
+			if (message.checked) {
+				this._checked.add(message.key);
+			} else {
+				this._checked.delete(message.key);
+			}
+			this.scheduleApply();
 			return;
 		}
-		if (checked) {
-			this._checked.set(item.subsystem.xmlAbs, item.subsystem);
-		} else {
-			this._checked.delete(item.subsystem.xmlAbs);
+		if (message.type === 'option' && message.option) {
+			this._options[message.option] = message.checked === true;
+			this.scheduleApply();
+			return;
 		}
-		this._onDidChange.fire(undefined);
-	}
-
-	getTreeItem(element: MetadataFilterTreeItem): vscode.TreeItem {
-		return element;
-	}
-
-	getChildren(element?: MetadataFilterTreeItem): MetadataFilterTreeItem[] {
-		if (!element) {
-			return [...this.rootSubsystemItems(), ...this.optionItems()];
+		if (message.type === 'ready') {
+			this.pushTree();
 		}
-		if (element.kind !== 'subsystem' || !element.subsystem) {
-			return [];
+	}
+
+	private scheduleApply(): void {
+		if (this._applyTimer) {
+			clearTimeout(this._applyTimer);
 		}
-		return this.nestedItems(element.subsystem);
+		this._applyTimer = setTimeout(() => {
+			this._applyTimer = undefined;
+			const subsystems: SubsystemRef[] = [];
+			for (const key of this._checked) {
+				const ref = this._refByKey.get(key);
+				if (ref) {
+					subsystems.push(ref);
+				}
+			}
+			this._onSelectionChanged({
+				subsystems,
+				includeNested: this._options.includeNested,
+				includeParents: this._options.includeParents,
+			});
+		}, APPLY_DEBOUNCE_MS);
 	}
 
-	private optionItems(): MetadataFilterTreeItem[] {
-		return (Object.keys(OPTION_LABEL) as FilterOptionKey[]).map(
-			(key) =>
-				new MetadataFilterTreeItem(
-					'option',
-					`option:${key}`,
-					OPTION_LABEL[key],
-					vscode.TreeItemCollapsibleState.None,
-					this._options[key],
-					undefined,
-					key
-				)
-		);
-	}
-
-	private rootSubsystemItems(): MetadataFilterTreeItem[] {
+	private pushTree(): void {
+		if (!this._view) {
+			return;
+		}
+		this._refByKey.clear();
 		const roots = this._treeProvider
 			.listSubsystemLeaves()
 			.filter((leaf) => leaf.resourceUri && !parentSubsystemXml(leaf.resourceUri.fsPath))
 			.map((leaf) => this.refFromLeaf(leaf))
 			.filter((ref): ref is SubsystemRef => ref !== undefined);
-		return this.toItems(roots);
+		const nodes = this.toNodes(roots);
+		void this._view.webview.postMessage({
+			type: 'tree',
+			nodes,
+			checked: [...this._checked],
+			options: this._options,
+		});
 	}
 
-	private nestedItems(parent: SubsystemRef): MetadataFilterTreeItem[] {
-		const nested = nestedSubsystemXmls(parent.xmlAbs, parent.name).map((xmlAbs) => ({
-			sourceId: parent.sourceId,
-			name: path.basename(xmlAbs, '.xml'),
-			xmlAbs,
-			configurationXmlAbs: parent.configurationXmlAbs,
-			metadataRootAbs: parent.metadataRootAbs,
-		}));
-		return this.toItems(nested);
-	}
-
-	private toItems(refs: SubsystemRef[]): MetadataFilterTreeItem[] {
+	private toNodes(refs: SubsystemRef[]): SubsystemTreeNode[] {
 		return refs
 			.sort((a, b) => a.name.localeCompare(b.name, 'ru'))
-			.map(
-				(ref) =>
-					new MetadataFilterTreeItem(
-						'subsystem',
-						ref.xmlAbs,
-						ref.name,
-						hasNestedSubsystems(ref.xmlAbs, ref.name)
-							? vscode.TreeItemCollapsibleState.Collapsed
-							: vscode.TreeItemCollapsibleState.None,
-						this._checked.has(ref.xmlAbs),
-						ref
-					)
-			);
+			.map((ref) => {
+				this._refByKey.set(ref.xmlAbs, ref);
+				const children = hasNestedSubsystems(ref.xmlAbs, ref.name)
+					? this.toNodes(
+							nestedSubsystemXmls(ref.xmlAbs, ref.name).map((xmlAbs) => ({
+								sourceId: ref.sourceId,
+								name: path.basename(xmlAbs, '.xml'),
+								xmlAbs,
+								configurationXmlAbs: ref.configurationXmlAbs,
+								metadataRootAbs: ref.metadataRootAbs,
+							}))
+						)
+					: [];
+				return { key: ref.xmlAbs, name: ref.name, children };
+			});
 	}
 
 	private refFromLeaf(leaf: MetadataLeafTreeItem): SubsystemRef | undefined {
@@ -169,5 +168,268 @@ export class MetadataFilterTreeDataProvider implements vscode.TreeDataProvider<M
 			configurationXmlAbs: leaf.configurationXmlAbs,
 			metadataRootAbs: leaf.metadataRootAbs,
 		};
+	}
+
+	private html(): string {
+		return `<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8" />
+<style>
+	body {
+		margin: 0;
+		padding: 4px 0 6px 0;
+		font-family: var(--vscode-font-family);
+		font-size: var(--vscode-font-size);
+		color: var(--vscode-foreground);
+	}
+	.search {
+		position: relative;
+		padding: 0 8px 4px 8px;
+	}
+	.search input {
+		width: 100%;
+		box-sizing: border-box;
+		padding: 3px 22px 3px 6px;
+		border-radius: 2px;
+		border: 1px solid var(--vscode-input-border, transparent);
+		background: var(--vscode-input-background);
+		color: var(--vscode-input-foreground);
+		font-family: inherit;
+		font-size: inherit;
+	}
+	.search input:focus {
+		outline: 1px solid var(--vscode-focusBorder);
+		outline-offset: -1px;
+	}
+	.search-clear {
+		position: absolute;
+		top: 2px;
+		right: 12px;
+		border: none;
+		background: transparent;
+		color: var(--vscode-descriptionForeground);
+		cursor: pointer;
+		font-size: 13px;
+		line-height: 1;
+	}
+	.search-clear.hidden {
+		display: none;
+	}
+	.row {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 1px 8px;
+		white-space: nowrap;
+	}
+	.row:hover {
+		background: var(--vscode-list-hoverBackground);
+	}
+	.twisty {
+		width: 14px;
+		flex: 0 0 14px;
+		border: none;
+		background: transparent;
+		color: var(--vscode-foreground);
+		cursor: pointer;
+		padding: 0;
+		font-size: 10px;
+		line-height: 1;
+		text-align: center;
+	}
+	.twisty.empty {
+		visibility: hidden;
+		cursor: default;
+	}
+	label.name {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		cursor: pointer;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.options {
+		margin-top: 6px;
+		padding: 6px 8px 0 8px;
+		border-top: 1px solid var(--vscode-panel-border);
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+	.options label {
+		display: flex;
+		align-items: flex-start;
+		gap: 6px;
+		cursor: pointer;
+		color: var(--vscode-descriptionForeground);
+	}
+	.empty-note {
+		padding: 4px 8px;
+		color: var(--vscode-descriptionForeground);
+	}
+	body.vscode-dark {
+		color-scheme: dark;
+	}
+</style>
+</head>
+<body>
+	<div class="search">
+		<input id="q" type="text" placeholder="Поиск подсистем…" autocomplete="off" />
+		<button id="clearSearch" class="search-clear hidden" type="button" title="Очистить">×</button>
+	</div>
+	<div id="tree"></div>
+	<div class="options">
+		<label><input id="includeNested" type="checkbox" checked /><span>Включать объекты из подчинённых подсистем</span></label>
+		<label><input id="includeParents" type="checkbox" /><span>Включать объекты из родительских подсистем</span></label>
+	</div>
+	<script>
+		const vscodeApi = acquireVsCodeApi();
+		const treeRoot = document.getElementById('tree');
+		const searchInput = document.getElementById('q');
+		const clearSearchBtn = document.getElementById('clearSearch');
+		const nestedBox = document.getElementById('includeNested');
+		const parentsBox = document.getElementById('includeParents');
+		let nodes = [];
+		let checked = new Set();
+		let collapsed = new Set();
+		let query = '';
+
+		function matches(node) {
+			if (!query) {
+				return true;
+			}
+			const terms = query.toLowerCase().split(/\\s+/).filter(Boolean);
+			const name = node.name.toLowerCase();
+			return terms.every((term) => name.includes(term));
+		}
+
+		function subtreeMatches(node) {
+			return matches(node) || node.children.some(subtreeMatches);
+		}
+
+		function rowHtml(node, depth) {
+			const visibleChildren = node.children.filter(subtreeMatches);
+			const hasChildren = visibleChildren.length > 0;
+			// При поиске ветки с совпадениями раскрыты, иначе результат пришлось бы разворачивать руками.
+			const isCollapsed = query ? false : collapsed.has(node.key);
+			const twisty = hasChildren
+				? '<button class="twisty" data-twisty="' + escapeAttr(node.key) + '">' + (isCollapsed ? '▶' : '▼') + '</button>'
+				: '<span class="twisty empty"></span>';
+			const box = '<input type="checkbox" data-key="' + escapeAttr(node.key) + '"' + (checked.has(node.key) ? ' checked' : '') + ' />';
+			const row =
+				'<div class="row" style="padding-left:' + (8 + depth * 14) + 'px">' +
+				twisty +
+				'<label class="name">' + box + '<span>' + escapeHtml(node.name) + '</span></label>' +
+				'</div>';
+			const children = hasChildren && !isCollapsed
+				? visibleChildren.map((child) => rowHtml(child, depth + 1)).join('')
+				: '';
+			return row + children;
+		}
+
+		function render() {
+			const visible = nodes.filter(subtreeMatches);
+			treeRoot.innerHTML = visible.length
+				? visible.map((node) => rowHtml(node, 0)).join('')
+				: '<div class="empty-note">' + (query ? 'Подсистемы не найдены' : 'Подсистем нет') + '</div>';
+			for (const box of treeRoot.querySelectorAll('input[type=checkbox]')) {
+				box.addEventListener('change', function () {
+					const key = box.getAttribute('data-key');
+					if (box.checked) {
+						checked.add(key);
+					} else {
+						checked.delete(key);
+					}
+					vscodeApi.postMessage({ type: 'toggle', key: key, checked: box.checked });
+				});
+			}
+			for (const btn of treeRoot.querySelectorAll('[data-twisty]')) {
+				btn.addEventListener('click', function () {
+					const key = btn.getAttribute('data-twisty');
+					if (collapsed.has(key)) {
+						collapsed.delete(key);
+					} else {
+						collapsed.add(key);
+					}
+					render();
+				});
+			}
+		}
+
+		function escapeHtml(text) {
+			return String(text).replace(/[&<>"']/g, function (ch) {
+				return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch];
+			});
+		}
+
+		function escapeAttr(text) {
+			return escapeHtml(text);
+		}
+
+		function collectKeys(list, out) {
+			for (const node of list) {
+				if (node.children.length > 0) {
+					out.push(node.key);
+					collectKeys(node.children, out);
+				}
+			}
+			return out;
+		}
+
+		searchInput.addEventListener('input', function () {
+			query = searchInput.value.trim();
+			clearSearchBtn.classList.toggle('hidden', query.length === 0);
+			render();
+		});
+		searchInput.addEventListener('keydown', function (e) {
+			if (e.key === 'Escape' && searchInput.value) {
+				searchInput.value = '';
+				query = '';
+				clearSearchBtn.classList.add('hidden');
+				render();
+			}
+		});
+		clearSearchBtn.addEventListener('click', function () {
+			searchInput.value = '';
+			query = '';
+			clearSearchBtn.classList.add('hidden');
+			searchInput.focus();
+			render();
+		});
+		nestedBox.addEventListener('change', function () {
+			vscodeApi.postMessage({ type: 'option', option: 'includeNested', checked: nestedBox.checked });
+		});
+		parentsBox.addEventListener('change', function () {
+			vscodeApi.postMessage({ type: 'option', option: 'includeParents', checked: parentsBox.checked });
+		});
+
+		window.addEventListener('message', function (event) {
+			const msg = event.data;
+			if (!msg) {
+				return;
+			}
+			if (msg.type === 'tree') {
+				nodes = msg.nodes || [];
+				checked = new Set(msg.checked || []);
+				nestedBox.checked = !!(msg.options && msg.options.includeNested);
+				parentsBox.checked = !!(msg.options && msg.options.includeParents);
+				render();
+			}
+			if (msg.type === 'collapseAll') {
+				collapsed = new Set(collectKeys(nodes, []));
+				render();
+			}
+			if (msg.type === 'clearChecked') {
+				checked = new Set();
+				render();
+			}
+		});
+
+		vscodeApi.postMessage({ type: 'ready' });
+	</script>
+</body>
+</html>`;
 	}
 }

--- a/src/features/metadata/metadataSearchView.ts
+++ b/src/features/metadata/metadataSearchView.ts
@@ -39,6 +39,11 @@ export class MetadataSearchViewProvider implements vscode.WebviewViewProvider {
 		this._onQueryChanged('');
 	}
 
+	/** Показывает в поле запрос, введённый другим способом: поле и кнопка-лупа ищут одно и то же. */
+	showQuery(query: string): void {
+		this._view?.webview.postMessage({ type: 'setQuery', query });
+	}
+
 	private html(): string {
 		return `<!DOCTYPE html>
 <html lang="ru">
@@ -126,9 +131,16 @@ export class MetadataSearchViewProvider implements vscode.WebviewViewProvider {
 			send();
 		});
 		window.addEventListener('message', function (event) {
-			if (event.data && event.data.type === 'clear') {
+			if (!event.data) {
+				return;
+			}
+			if (event.data.type === 'clear') {
 				input.value = '';
 				clearBtn.classList.add('hidden');
+			}
+			if (event.data.type === 'setQuery') {
+				input.value = event.data.query || '';
+				clearBtn.classList.toggle('hidden', input.value.length === 0);
 			}
 		});
 	</script>

--- a/src/features/metadata/metadataSubsystemFilter.ts
+++ b/src/features/metadata/metadataSubsystemFilter.ts
@@ -1,0 +1,274 @@
+/**
+ * Отбор объектов дерева метаданных по подсистемам: общая логика для панели «Фильтры»
+ * и контекстного меню подсистемы.
+ *
+ * Иерархию подсистем берём из раскладки файлов (`Subsystems/<Имя>/Subsystems/<Вложенная>.xml`),
+ * состав — из `cf-md-object-get`, поэтому читаем только выбранные ветки.
+ * @module metadataSubsystemFilter
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { ensureMdSparrowRuntime } from './mdSparrowBootstrap';
+import { runMdSparrowParamsRead } from './mdSparrowParams';
+import { mdSparrowSchemaFlagFromConfigurationXml } from './mdSparrowSchemaVersion';
+import type { MetadataTreeDataProvider } from './metadataTreeView';
+
+/** Подсистема как источник отбора: имя и пути, которых хватает для чтения состава. */
+export interface SubsystemRef {
+	readonly sourceId: string;
+	readonly name: string;
+	readonly xmlAbs: string;
+	readonly configurationXmlAbs: string | undefined;
+	readonly metadataRootAbs: string | undefined;
+}
+
+export interface SubsystemFilterOptions {
+	/** Включать объекты из подчинённых подсистем. */
+	readonly includeNested: boolean;
+	/** Включать объекты из родительских подсистем. */
+	readonly includeParents: boolean;
+}
+
+const CLI_ERR_PREVIEW = 500;
+
+/** XML родительской подсистемы либо undefined для подсистемы верхнего уровня. */
+export function parentSubsystemXml(xmlAbs: string): string | undefined {
+	const dir = path.dirname(xmlAbs);
+	if (path.basename(dir) !== 'Subsystems') {
+		return undefined;
+	}
+	const ownerDir = path.dirname(dir);
+	const ownerParent = path.dirname(ownerDir);
+	if (path.basename(ownerParent) !== 'Subsystems') {
+		return undefined;
+	}
+	return path.join(ownerParent, `${path.basename(ownerDir)}.xml`);
+}
+
+/** XML подчинённых подсистем по раскладке файлов. */
+export function nestedSubsystemXmls(xmlAbs: string, name: string): string[] {
+	const dir = path.join(path.dirname(xmlAbs), name, 'Subsystems');
+	try {
+		return fs
+			.readdirSync(dir, { withFileTypes: true })
+			.filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.xml'))
+			.map((entry) => path.join(dir, entry.name));
+	} catch {
+		return [];
+	}
+}
+
+export function hasNestedSubsystems(xmlAbs: string, name: string): boolean {
+	return nestedSubsystemXmls(xmlAbs, name).length > 0;
+}
+
+function refFrom(source: SubsystemRef, xmlAbs: string): SubsystemRef {
+	return {
+		sourceId: source.sourceId,
+		name: path.basename(xmlAbs, '.xml'),
+		xmlAbs,
+		configurationXmlAbs: source.configurationXmlAbs,
+		metadataRootAbs: source.metadataRootAbs,
+	};
+}
+
+interface SubsystemDto {
+	contentRefs?: unknown[];
+	nestedSubsystems?: unknown[];
+}
+
+/**
+ * Считает состав отбора по выбранным подсистемам и применяет его к дереву.
+ *
+ * @returns false, если состав прочитать не удалось
+ */
+export async function applySubsystemFilter(
+	context: vscode.ExtensionContext,
+	provider: MetadataTreeDataProvider,
+	selected: readonly SubsystemRef[],
+	options: SubsystemFilterOptions,
+	label: string
+): Promise<boolean> {
+	if (selected.length === 0) {
+		return false;
+	}
+	const runtime = await ensureMdSparrowRuntime(context);
+	const schemaByConfig = new Map<string, string>();
+	const readDto = async (ref: SubsystemRef): Promise<SubsystemDto | undefined> => {
+		if (!ref.configurationXmlAbs || !ref.metadataRootAbs) {
+			return undefined;
+		}
+		let schema = schemaByConfig.get(ref.configurationXmlAbs);
+		if (!schema) {
+			schema = await mdSparrowSchemaFlagFromConfigurationXml(ref.configurationXmlAbs);
+			schemaByConfig.set(ref.configurationXmlAbs, schema);
+		}
+		const res = await runMdSparrowParamsRead(
+			runtime,
+			{ op: 'cf-md-object-get', objectXml: ref.xmlAbs, schemaVersion: schema },
+			{ cwd: ref.metadataRootAbs }
+		);
+		if (res.exitCode !== 0) {
+			const errText = (res.stderr.trim() || res.stdout.trim() || `код ${res.exitCode}`).slice(0, CLI_ERR_PREVIEW);
+			void vscode.window.showErrorMessage(errText);
+			return undefined;
+		}
+		try {
+			return JSON.parse(res.stdout.trim()) as SubsystemDto;
+		} catch {
+			void vscode.window.showErrorMessage(`Не удалось разобрать состав подсистемы: ${ref.name}`);
+			return undefined;
+		}
+	};
+
+	const allowedNames = new Set<string>();
+	const allowedKeys = new Set<string>();
+	const allowedSubsystemNames = new Set<string>();
+	const visited = new Set<string>();
+	let read = false;
+
+	const addContent = (dto: SubsystemDto): void => {
+		const refs = Array.isArray(dto.contentRefs) ? dto.contentRefs.filter((x): x is string => typeof x === 'string') : [];
+		for (const name of parseContentRefsToObjectNames(refs)) {
+			allowedNames.add(name);
+		}
+		for (const key of parseContentRefsToObjectKeys(refs)) {
+			allowedKeys.add(key);
+		}
+	};
+
+	const addSubsystem = (ref: SubsystemRef): void => {
+		allowedSubsystemNames.add(ref.name);
+		allowedNames.add(ref.name);
+		allowedKeys.add(`Subsystem.${ref.name}`);
+	};
+
+	const walkDown = async (ref: SubsystemRef): Promise<void> => {
+		if (visited.has(ref.xmlAbs)) {
+			return;
+		}
+		visited.add(ref.xmlAbs);
+		addSubsystem(ref);
+		const dto = await readDto(ref);
+		if (!dto) {
+			return;
+		}
+		read = true;
+		addContent(dto);
+		if (!options.includeNested) {
+			return;
+		}
+		for (const nestedXml of nestedSubsystemXmls(ref.xmlAbs, ref.name)) {
+			await walkDown(refFrom(ref, nestedXml));
+		}
+	};
+
+	const walkUp = async (ref: SubsystemRef): Promise<void> => {
+		let parentXml = parentSubsystemXml(ref.xmlAbs);
+		while (parentXml) {
+			const parent = refFrom(ref, parentXml);
+			if (visited.has(parent.xmlAbs)) {
+				break;
+			}
+			visited.add(parent.xmlAbs);
+			addSubsystem(parent);
+			const dto = await readDto(parent);
+			if (dto) {
+				read = true;
+				addContent(dto);
+			}
+			parentXml = parentSubsystemXml(parent.xmlAbs);
+		}
+	};
+
+	for (const ref of selected) {
+		await walkDown(ref);
+	}
+	if (options.includeParents) {
+		for (const ref of selected) {
+			await walkUp(ref);
+		}
+	}
+	if (!read) {
+		return false;
+	}
+	provider.setSubsystemFilter(label, allowedNames, allowedKeys, allowedSubsystemNames);
+	void vscode.commands.executeCommand('setContext', '1c-platform-tools.metadata.subsystemFilterActive', true);
+	return true;
+}
+
+/**
+ * Имена объектов из ссылок состава: {@code Catalog.Номенклатура} и {@code Catalogs/Номенклатура.xml}
+ * дают {@code Номенклатура}.
+ */
+export function parseContentRefsToObjectNames(contentRefs: string[]): Set<string> {
+	const out = new Set<string>();
+	for (const raw of contentRefs) {
+		const trimmed = raw.trim();
+		if (!trimmed) {
+			continue;
+		}
+		const pathParts = trimmed.split(/[\\/]/g).filter((x) => x.length > 0);
+		const lastSegment = (pathParts[pathParts.length - 1] ?? '').replace(/\.xml$/i, '');
+		const dotParts = lastSegment.split('.').filter((x) => x.length > 0);
+		const candidate = dotParts[dotParts.length - 1] ?? '';
+		if (candidate) {
+			out.add(candidate);
+		}
+	}
+	return out;
+}
+
+export function parseContentRefsToObjectKeys(contentRefs: string[]): Set<string> {
+	const out = new Set<string>();
+	for (const raw of contentRefs) {
+		const trimmed = raw.trim();
+		if (!trimmed) {
+			continue;
+		}
+		const parts = trimmed.split('.');
+		if (parts.length >= 2) {
+			const objectType = normalizeMdObjectTypeFromRefPrefix(parts[0] ?? '');
+			const objectName = parts.slice(1).join('.').trim();
+			if (objectType && objectName) {
+				out.add(`${objectType}.${objectName}`);
+			}
+		}
+	}
+	return out;
+}
+
+function normalizeMdObjectTypeFromRefPrefix(prefix: string): string {
+	const p = prefix.trim();
+	switch (p) {
+		case 'Catalog':
+		case 'Constant':
+		case 'Enum':
+		case 'Document':
+		case 'DocumentJournal':
+		case 'Report':
+		case 'DataProcessor':
+		case 'ChartOfCharacteristicTypes':
+		case 'ChartOfAccounts':
+		case 'ChartOfCalculationTypes':
+		case 'InformationRegister':
+		case 'AccumulationRegister':
+		case 'AccountingRegister':
+		case 'CalculationRegister':
+		case 'BusinessProcess':
+		case 'Task':
+		case 'ExchangePlan':
+		case 'CommonModule':
+		case 'CommonPicture':
+		case 'CommonAttribute':
+		case 'Subsystem':
+		case 'Role':
+		case 'SessionParameter':
+		case 'ExternalDataSource':
+		case 'DocumentNumerator':
+			return p;
+		default:
+			return '';
+	}
+}

--- a/src/features/metadata/metadataSubsystemFilter.ts
+++ b/src/features/metadata/metadataSubsystemFilter.ts
@@ -1,26 +1,26 @@
 /**
- * Отбор объектов дерева метаданных по подсистемам: общая логика для панели «Фильтры»
- * и контекстного меню подсистемы.
+ * Отбор объектов дерева метаданных по подсистемам.
  *
- * Иерархию подсистем берём из раскладки файлов (`Subsystems/<Имя>/Subsystems/<Вложенная>.xml`),
- * состав — из `cf-md-object-get`, поэтому читаем только выбранные ветки.
+ * Дерево подсистем и их состав читает md-sparrow одной операцией `cf-md-subsystem-tree`:
+ * вложенность берётся из XML, а не угадывается по раскладке каталогов.
  * @module metadataSubsystemFilter
  */
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
+import { logger } from '../../shared/logger';
 import { ensureMdSparrowRuntime } from './mdSparrowBootstrap';
 import { runMdSparrowParamsRead } from './mdSparrowParams';
 import { mdSparrowSchemaFlagFromConfigurationXml } from './mdSparrowSchemaVersion';
 import type { MetadataTreeDataProvider } from './metadataTreeView';
 
-/** Подсистема как источник отбора: имя и пути, которых хватает для чтения состава. */
-export interface SubsystemRef {
-	readonly sourceId: string;
+const log = logger.scope('метаданные');
+
+/** Узел дерева подсистем, как его отдаёт md-sparrow. */
+export interface SubsystemNode {
 	readonly name: string;
-	readonly xmlAbs: string;
-	readonly configurationXmlAbs: string | undefined;
-	readonly metadataRootAbs: string | undefined;
+	readonly xmlPath: string;
+	readonly contentRefs: readonly string[];
+	readonly children: readonly SubsystemNode[];
 }
 
 export interface SubsystemFilterOptions {
@@ -30,172 +30,128 @@ export interface SubsystemFilterOptions {
 	readonly includeParents: boolean;
 }
 
+/** Состав отбора: имена и ключи разрешённых объектов. */
+export interface SubsystemFilterResult {
+	readonly names: Set<string>;
+	readonly keys: Set<string>;
+	readonly subsystemNames: Set<string>;
+}
+
 const CLI_ERR_PREVIEW = 500;
 
-/** XML родительской подсистемы либо undefined для подсистемы верхнего уровня. */
-export function parentSubsystemXml(xmlAbs: string): string | undefined {
-	const dir = path.dirname(xmlAbs);
-	if (path.basename(dir) !== 'Subsystems') {
-		return undefined;
-	}
-	const ownerDir = path.dirname(dir);
-	const ownerParent = path.dirname(ownerDir);
-	if (path.basename(ownerParent) !== 'Subsystems') {
-		return undefined;
-	}
-	return path.join(ownerParent, `${path.basename(ownerDir)}.xml`);
-}
-
-/** XML подчинённых подсистем по раскладке файлов. */
-export function nestedSubsystemXmls(xmlAbs: string, name: string): string[] {
-	const dir = path.join(path.dirname(xmlAbs), name, 'Subsystems');
-	try {
-		return fs
-			.readdirSync(dir, { withFileTypes: true })
-			.filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.xml'))
-			.map((entry) => path.join(dir, entry.name));
-	} catch {
+/**
+ * Читает подсистемы всех источников проекта одной операцией на источник.
+ */
+export async function loadSubsystemTrees(
+	context: vscode.ExtensionContext,
+	treeProvider: MetadataTreeDataProvider
+): Promise<SubsystemNode[]> {
+	const cached = treeProvider.getCachedTree();
+	const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+	if (!cached || !workspaceRoot) {
 		return [];
 	}
-}
-
-export function hasNestedSubsystems(xmlAbs: string, name: string): boolean {
-	return nestedSubsystemXmls(xmlAbs, name).length > 0;
-}
-
-function refFrom(source: SubsystemRef, xmlAbs: string): SubsystemRef {
-	return {
-		sourceId: source.sourceId,
-		name: path.basename(xmlAbs, '.xml'),
-		xmlAbs,
-		configurationXmlAbs: source.configurationXmlAbs,
-		metadataRootAbs: source.metadataRootAbs,
-	};
-}
-
-interface SubsystemDto {
-	contentRefs?: unknown[];
-	nestedSubsystems?: unknown[];
+	const runtime = await ensureMdSparrowRuntime(context);
+	const out: SubsystemNode[] = [];
+	for (const source of cached.sources) {
+		if (!source.configurationXmlRelativePath) {
+			continue;
+		}
+		const configurationXml = path.join(workspaceRoot, source.configurationXmlRelativePath);
+		const metadataRoot = source.metadataRootRelativePath
+			? path.join(workspaceRoot, source.metadataRootRelativePath)
+			: path.dirname(configurationXml);
+		try {
+			const schema = await mdSparrowSchemaFlagFromConfigurationXml(configurationXml);
+			const res = await runMdSparrowParamsRead(
+				runtime,
+				{ op: 'cf-md-subsystem-tree', configurationXml, schemaVersion: schema },
+				{ cwd: metadataRoot }
+			);
+			if (res.exitCode !== 0) {
+				log.error(`подсистемы: ${(res.stderr.trim() || res.stdout.trim()).slice(0, CLI_ERR_PREVIEW)}`);
+				continue;
+			}
+			const nodes = JSON.parse(res.stdout.trim()) as SubsystemNode[];
+			if (Array.isArray(nodes)) {
+				out.push(...nodes);
+			}
+		} catch (e) {
+			log.error(`подсистемы: ${e instanceof Error ? e.message : String(e)}`);
+		}
+	}
+	return out;
 }
 
 /**
- * Считает состав отбора по выбранным подсистемам и применяет его к дереву.
+ * Считает состав отбора по отмеченным подсистемам.
  *
- * @returns false, если состав прочитать не удалось
+ * @param checkedPaths пути к XML отмеченных подсистем
  */
-export async function applySubsystemFilter(
-	context: vscode.ExtensionContext,
-	provider: MetadataTreeDataProvider,
-	selected: readonly SubsystemRef[],
-	options: SubsystemFilterOptions,
-	label: string
-): Promise<boolean> {
-	if (selected.length === 0) {
-		return false;
+export function computeSubsystemFilter(
+	roots: readonly SubsystemNode[],
+	checkedPaths: ReadonlySet<string>,
+	options: SubsystemFilterOptions
+): SubsystemFilterResult {
+	const result: SubsystemFilterResult = { names: new Set(), keys: new Set(), subsystemNames: new Set() };
+	if (checkedPaths.size === 0) {
+		return result;
 	}
-	const runtime = await ensureMdSparrowRuntime(context);
-	const schemaByConfig = new Map<string, string>();
-	const readDto = async (ref: SubsystemRef): Promise<SubsystemDto | undefined> => {
-		if (!ref.configurationXmlAbs || !ref.metadataRootAbs) {
-			return undefined;
-		}
-		let schema = schemaByConfig.get(ref.configurationXmlAbs);
-		if (!schema) {
-			schema = await mdSparrowSchemaFlagFromConfigurationXml(ref.configurationXmlAbs);
-			schemaByConfig.set(ref.configurationXmlAbs, schema);
-		}
-		const res = await runMdSparrowParamsRead(
-			runtime,
-			{ op: 'cf-md-object-get', objectXml: ref.xmlAbs, schemaVersion: schema },
-			{ cwd: ref.metadataRootAbs }
-		);
-		if (res.exitCode !== 0) {
-			const errText = (res.stderr.trim() || res.stdout.trim() || `код ${res.exitCode}`).slice(0, CLI_ERR_PREVIEW);
-			void vscode.window.showErrorMessage(errText);
-			return undefined;
-		}
-		try {
-			return JSON.parse(res.stdout.trim()) as SubsystemDto;
-		} catch {
-			void vscode.window.showErrorMessage(`Не удалось разобрать состав подсистемы: ${ref.name}`);
-			return undefined;
-		}
-	};
-
-	const allowedNames = new Set<string>();
-	const allowedKeys = new Set<string>();
-	const allowedSubsystemNames = new Set<string>();
-	const visited = new Set<string>();
-	let read = false;
-
-	const addContent = (dto: SubsystemDto): void => {
-		const refs = Array.isArray(dto.contentRefs) ? dto.contentRefs.filter((x): x is string => typeof x === 'string') : [];
-		for (const name of parseContentRefsToObjectNames(refs)) {
-			allowedNames.add(name);
-		}
-		for (const key of parseContentRefsToObjectKeys(refs)) {
-			allowedKeys.add(key);
-		}
-	};
-
-	const addSubsystem = (ref: SubsystemRef): void => {
-		allowedSubsystemNames.add(ref.name);
-		allowedNames.add(ref.name);
-		allowedKeys.add(`Subsystem.${ref.name}`);
-	};
-
-	const walkDown = async (ref: SubsystemRef): Promise<void> => {
-		if (visited.has(ref.xmlAbs)) {
-			return;
-		}
-		visited.add(ref.xmlAbs);
-		addSubsystem(ref);
-		const dto = await readDto(ref);
-		if (!dto) {
-			return;
-		}
-		read = true;
-		addContent(dto);
-		if (!options.includeNested) {
-			return;
-		}
-		for (const nestedXml of nestedSubsystemXmls(ref.xmlAbs, ref.name)) {
-			await walkDown(refFrom(ref, nestedXml));
-		}
-	};
-
-	const walkUp = async (ref: SubsystemRef): Promise<void> => {
-		let parentXml = parentSubsystemXml(ref.xmlAbs);
-		while (parentXml) {
-			const parent = refFrom(ref, parentXml);
-			if (visited.has(parent.xmlAbs)) {
-				break;
+	const walk = (node: SubsystemNode, ancestors: SubsystemNode[]): void => {
+		if (checkedPaths.has(node.xmlPath)) {
+			include(node, result);
+			if (options.includeNested) {
+				for (const child of node.children) {
+					includeSubtree(child, result);
+				}
 			}
-			visited.add(parent.xmlAbs);
-			addSubsystem(parent);
-			const dto = await readDto(parent);
-			if (dto) {
-				read = true;
-				addContent(dto);
+			if (options.includeParents) {
+				for (const ancestor of ancestors) {
+					include(ancestor, result);
+				}
 			}
-			parentXml = parentSubsystemXml(parent.xmlAbs);
+		}
+		for (const child of node.children) {
+			walk(child, [...ancestors, node]);
 		}
 	};
-
-	for (const ref of selected) {
-		await walkDown(ref);
+	for (const root of roots) {
+		walk(root, []);
 	}
-	if (options.includeParents) {
-		for (const ref of selected) {
-			await walkUp(ref);
+	return result;
+}
+
+function includeSubtree(node: SubsystemNode, result: SubsystemFilterResult): void {
+	include(node, result);
+	for (const child of node.children) {
+		includeSubtree(child, result);
+	}
+}
+
+function include(node: SubsystemNode, result: SubsystemFilterResult): void {
+	result.subsystemNames.add(node.name);
+	result.names.add(node.name);
+	result.keys.add(`Subsystem.${node.name}`);
+	for (const name of parseContentRefsToObjectNames([...node.contentRefs])) {
+		result.names.add(name);
+	}
+	for (const key of parseContentRefsToObjectKeys([...node.contentRefs])) {
+		result.keys.add(key);
+	}
+}
+
+/** Находит подсистему по имени: контекстное меню дерева отдаёт только имя узла. */
+export function findSubsystemByName(roots: readonly SubsystemNode[], name: string): SubsystemNode | undefined {
+	for (const root of roots) {
+		if (root.name === name) {
+			return root;
+		}
+		const found = findSubsystemByName(root.children, name);
+		if (found) {
+			return found;
 		}
 	}
-	if (!read) {
-		return false;
-	}
-	provider.setSubsystemFilter(label, allowedNames, allowedKeys, allowedSubsystemNames);
-	void vscode.commands.executeCommand('setContext', '1c-platform-tools.metadata.subsystemFilterActive', true);
-	return true;
+	return undefined;
 }
 
 /**

--- a/src/features/metadata/metadataTreeView.ts
+++ b/src/features/metadata/metadataTreeView.ts
@@ -1169,6 +1169,15 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 		return this._textFilter?.query;
 	}
 
+	/** Подсистемы всех источников — кандидаты для фильтра по подсистеме. */
+	listSubsystemLeaves(): MetadataLeafTreeItem[] {
+		const out: MetadataLeafTreeItem[] = [];
+		for (const bySource of this._subsystemsBySource.values()) {
+			out.push(...bySource.values());
+		}
+		return out;
+	}
+
 	clearSubsystemFilter(): void {
 		if (!this._subsystemFilter) {
 			return;

--- a/src/features/metadata/metadataTreeView.ts
+++ b/src/features/metadata/metadataTreeView.ts
@@ -1169,6 +1169,15 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 		return this._textFilter?.query;
 	}
 
+	/** Группы всех источников: нужны, чтобы раскрыть дерево перед штатным поиском. */
+	listGroupItems(): MetadataMdGroupTreeItem[] {
+		const out: MetadataMdGroupTreeItem[] = [];
+		for (const groups of this._groupsBySource.values()) {
+			out.push(...groups);
+		}
+		return out;
+	}
+
 	/** Подсистемы всех источников — кандидаты для фильтра по подсистеме. */
 	listSubsystemLeaves(): MetadataLeafTreeItem[] {
 		const out: MetadataLeafTreeItem[] = [];

--- a/src/features/metadata/metadataTreeView.ts
+++ b/src/features/metadata/metadataTreeView.ts
@@ -1169,15 +1169,6 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 		return this._textFilter?.query;
 	}
 
-	/** Группы всех источников: нужны, чтобы раскрыть дерево перед штатным поиском. */
-	listGroupItems(): MetadataMdGroupTreeItem[] {
-		const out: MetadataMdGroupTreeItem[] = [];
-		for (const groups of this._groupsBySource.values()) {
-			out.push(...groups);
-		}
-		return out;
-	}
-
 	/** Подсистемы всех источников — кандидаты для фильтра по подсистеме. */
 	listSubsystemLeaves(): MetadataLeafTreeItem[] {
 		const out: MetadataLeafTreeItem[] = [];

--- a/src/features/metadata/registerMetadataFeature.ts
+++ b/src/features/metadata/registerMetadataFeature.ts
@@ -17,6 +17,7 @@ import {
 	type ExternalArtifactPropertiesDto,
 } from './metadataExternalArtifactPropertiesPanel';
 import { createMdSparrowMutationRunner } from './mdSparrowMutationQueue';
+import { MetadataSearchViewProvider } from './metadataSearchView';
 import { openMetadataObjectPropertiesEditor } from './metadataObjectPropertiesPanel';
 import {
 	openMetadataSourcePropertiesPanel,
@@ -49,6 +50,7 @@ export interface RegisterMetadataFeatureParams {
 	context: vscode.ExtensionContext;
 	metadataTreeProvider: MetadataTreeDataProvider;
 	metadataTreeView: vscode.TreeView<vscode.TreeItem>;
+	metadataSearchProvider: MetadataSearchViewProvider;
 }
 
 /**
@@ -57,7 +59,7 @@ export interface RegisterMetadataFeatureParams {
 export function registerMetadataFeature(
 	params: RegisterMetadataFeatureParams
 ): vscode.Disposable[] {
-	const { context, metadataTreeProvider, metadataTreeView } = params;
+	const { context, metadataTreeProvider, metadataTreeView, metadataSearchProvider } = params;
 
 	const MD_SPARROW_CLI_ERR_PREVIEW = 500;
 
@@ -819,6 +821,39 @@ export function registerMetadataFeature(
 		}),
 		vscode.commands.registerCommand('1c-platform-tools.metadata.refresh', () => {
 			void metadataTreeProvider.refresh();
+		}),
+		vscode.commands.registerCommand('1c-platform-tools.metadata.find', () => {
+			// Тот же фильтр, что и у поля над деревом: ищем по всей конфигурации, а не по раскрытым веткам.
+			const box = vscode.window.createInputBox();
+			box.title = 'Поиск по метаданным';
+			box.placeholder = 'Часть имени; несколько слов — должны встречаться все';
+			box.value = metadataTreeProvider.getTextFilter() ?? '';
+			box.onDidChangeValue((value) => {
+				metadataTreeProvider.setTextFilter(value);
+				metadataSearchProvider.showQuery(value);
+			});
+			box.onDidAccept(() => box.hide());
+			box.onDidHide(() => box.dispose());
+			box.show();
+		}),
+		vscode.commands.registerCommand('1c-platform-tools.metadata.pickSubsystemFilter', async () => {
+			const subsystems = metadataTreeProvider.listSubsystemLeaves();
+			if (subsystems.length === 0) {
+				void vscode.window.showInformationMessage('В дереве метаданных нет подсистем.');
+				return;
+			}
+			const items = subsystems
+				.map((leaf) => ({ label: leaf.name, description: leaf.sourceId, leaf }))
+				.sort((a, b) => a.label.localeCompare(b.label, 'ru'));
+			const picked = await vscode.window.showQuickPick(items, {
+				title: 'Фильтр по подсистемам',
+				placeHolder: 'Выберите подсистему',
+				matchOnDescription: true,
+			});
+			if (!picked) {
+				return;
+			}
+			await vscode.commands.executeCommand('1c-platform-tools.metadata.filterBySubsystem', picked.leaf);
 		}),
 		vscode.commands.registerCommand('1c-platform-tools.metadata.addDocument', async () => {
 			await vscode.commands.executeCommand('1c-platform-tools.metadata.addMdObject', 'DOCUMENT');

--- a/src/features/metadata/registerMetadataFeature.ts
+++ b/src/features/metadata/registerMetadataFeature.ts
@@ -17,7 +17,7 @@ import {
 	type ExternalArtifactPropertiesDto,
 } from './metadataExternalArtifactPropertiesPanel';
 import { createMdSparrowMutationRunner } from './mdSparrowMutationQueue';
-import type { MetadataFilterTreeDataProvider } from './metadataFilterView';
+import type { MetadataFilterViewProvider } from './metadataFilterView';
 import { MetadataSearchViewProvider } from './metadataSearchView';
 import { applySubsystemFilter } from './metadataSubsystemFilter';
 import { openMetadataObjectPropertiesEditor } from './metadataObjectPropertiesPanel';
@@ -53,7 +53,7 @@ export interface RegisterMetadataFeatureParams {
 	metadataTreeProvider: MetadataTreeDataProvider;
 	metadataTreeView: vscode.TreeView<vscode.TreeItem>;
 	metadataSearchProvider: MetadataSearchViewProvider;
-	metadataFilterProvider: MetadataFilterTreeDataProvider;
+	metadataFilterProvider: MetadataFilterViewProvider;
 }
 
 /**
@@ -759,40 +759,11 @@ export function registerMetadataFeature(
 		vscode.commands.registerCommand('1c-platform-tools.metadata.refresh', () => {
 			void metadataTreeProvider.refresh();
 		}),
-		vscode.commands.registerCommand('1c-platform-tools.metadata.find', async () => {
-			// Штатный виджет поиска ищет только по загруженным узлам, поэтому сперва раскрываем группы:
-			// объекты уже в кэше дерева, повторных чтений не будет.
-			for (const group of metadataTreeProvider.listGroupItems()) {
-				try {
-					await metadataTreeView.reveal(group, { expand: true, select: false, focus: false });
-				} catch {
-					// Узел мог исчезнуть после обновления дерева — остальные всё равно раскрываем.
-				}
-			}
-			await vscode.commands.executeCommand('1c-platform-tools-metadata-tree.focus');
-			await vscode.commands.executeCommand('list.find');
-		}),
-		vscode.commands.registerCommand('1c-platform-tools.metadata.filters.apply', async () => {
-			const checked = metadataFilterProvider.checkedSubsystems;
-			if (checked.length === 0) {
-				void vscode.window.showInformationMessage('Отметьте подсистемы в панели «Фильтры».');
-				return;
-			}
-			const label = checked.length === 1 ? checked[0].name : `подсистем: ${checked.length}`;
-			const applied = await applySubsystemFilter(
-				context,
-				metadataTreeProvider,
-				checked,
-				metadataFilterProvider.options,
-				label
-			);
-			if (applied) {
-				void vscode.window.showInformationMessage(`Фильтр по подсистемам: ${label}`);
-			}
-		}),
 		vscode.commands.registerCommand('1c-platform-tools.metadata.filters.reset', () => {
-			metadataFilterProvider.clearChecked();
-			void vscode.commands.executeCommand('1c-platform-tools.metadata.clearSubsystemFilter');
+			metadataFilterProvider.clear();
+		}),
+		vscode.commands.registerCommand('1c-platform-tools.metadata.filters.collapseAll', () => {
+			metadataFilterProvider.collapseAll();
 		}),
 		vscode.commands.registerCommand('1c-platform-tools.metadata.addDocument', async () => {
 			await vscode.commands.executeCommand('1c-platform-tools.metadata.addMdObject', 'DOCUMENT');

--- a/src/features/metadata/registerMetadataFeature.ts
+++ b/src/features/metadata/registerMetadataFeature.ts
@@ -765,6 +765,18 @@ export function registerMetadataFeature(
 		vscode.commands.registerCommand('1c-platform-tools.metadata.filters.collapseAll', () => {
 			metadataFilterProvider.collapseAll();
 		}),
+		vscode.commands.registerCommand('1c-platform-tools.metadata.filters.includeNested.on', () => {
+			metadataFilterProvider.setOption('includeNested', true);
+		}),
+		vscode.commands.registerCommand('1c-platform-tools.metadata.filters.includeNested.off', () => {
+			metadataFilterProvider.setOption('includeNested', false);
+		}),
+		vscode.commands.registerCommand('1c-platform-tools.metadata.filters.includeParents.on', () => {
+			metadataFilterProvider.setOption('includeParents', true);
+		}),
+		vscode.commands.registerCommand('1c-platform-tools.metadata.filters.includeParents.off', () => {
+			metadataFilterProvider.setOption('includeParents', false);
+		}),
 		vscode.commands.registerCommand('1c-platform-tools.metadata.addDocument', async () => {
 			await vscode.commands.executeCommand('1c-platform-tools.metadata.addMdObject', 'DOCUMENT');
 		}),

--- a/src/features/metadata/registerMetadataFeature.ts
+++ b/src/features/metadata/registerMetadataFeature.ts
@@ -765,18 +765,6 @@ export function registerMetadataFeature(
 		vscode.commands.registerCommand('1c-platform-tools.metadata.filters.collapseAll', () => {
 			metadataFilterProvider.collapseAll();
 		}),
-		vscode.commands.registerCommand('1c-platform-tools.metadata.filters.includeNested.on', () => {
-			metadataFilterProvider.setOption('includeNested', true);
-		}),
-		vscode.commands.registerCommand('1c-platform-tools.metadata.filters.includeNested.off', () => {
-			metadataFilterProvider.setOption('includeNested', false);
-		}),
-		vscode.commands.registerCommand('1c-platform-tools.metadata.filters.includeParents.on', () => {
-			metadataFilterProvider.setOption('includeParents', true);
-		}),
-		vscode.commands.registerCommand('1c-platform-tools.metadata.filters.includeParents.off', () => {
-			metadataFilterProvider.setOption('includeParents', false);
-		}),
 		vscode.commands.registerCommand('1c-platform-tools.metadata.addDocument', async () => {
 			await vscode.commands.executeCommand('1c-platform-tools.metadata.addMdObject', 'DOCUMENT');
 		}),

--- a/src/features/metadata/registerMetadataFeature.ts
+++ b/src/features/metadata/registerMetadataFeature.ts
@@ -17,7 +17,9 @@ import {
 	type ExternalArtifactPropertiesDto,
 } from './metadataExternalArtifactPropertiesPanel';
 import { createMdSparrowMutationRunner } from './mdSparrowMutationQueue';
+import type { MetadataFilterTreeDataProvider } from './metadataFilterView';
 import { MetadataSearchViewProvider } from './metadataSearchView';
+import { applySubsystemFilter } from './metadataSubsystemFilter';
 import { openMetadataObjectPropertiesEditor } from './metadataObjectPropertiesPanel';
 import {
 	openMetadataSourcePropertiesPanel,
@@ -51,6 +53,7 @@ export interface RegisterMetadataFeatureParams {
 	metadataTreeProvider: MetadataTreeDataProvider;
 	metadataTreeView: vscode.TreeView<vscode.TreeItem>;
 	metadataSearchProvider: MetadataSearchViewProvider;
+	metadataFilterProvider: MetadataFilterTreeDataProvider;
 }
 
 /**
@@ -59,7 +62,7 @@ export interface RegisterMetadataFeatureParams {
 export function registerMetadataFeature(
 	params: RegisterMetadataFeatureParams
 ): vscode.Disposable[] {
-	const { context, metadataTreeProvider, metadataTreeView, metadataSearchProvider } = params;
+	const { context, metadataTreeProvider, metadataTreeView, metadataSearchProvider, metadataFilterProvider } = params;
 
 	const MD_SPARROW_CLI_ERR_PREVIEW = 500;
 
@@ -509,72 +512,6 @@ export function registerMetadataFeature(
 		}
 	}
 
-	function parseContentRefsToObjectNames(contentRefs: string[]): Set<string> {
-		const out = new Set<string>();
-		for (const raw of contentRefs) {
-			const trimmed = raw.trim();
-			if (!trimmed) {
-				continue;
-			}
-			const slashParts = trimmed.split(/[\\/]/g).filter((x) => x.length > 0);
-			const dotParts = trimmed.split('.').filter((x) => x.length > 0);
-			const candidateFromSlash = slashParts[slashParts.length - 1] ?? '';
-			const candidateFromDot = dotParts[dotParts.length - 1] ?? '';
-			const candidate = candidateFromDot.length >= candidateFromSlash.length ? candidateFromDot : candidateFromSlash;
-			if (candidate) {
-				out.add(candidate);
-			}
-		}
-		return out;
-	}
-
-	function parseContentRefsToObjectKeys(contentRefs: string[]): Set<string> {
-		const out = new Set<string>();
-		for (const raw of contentRefs) {
-			const trimmed = raw.trim();
-			if (!trimmed) {
-				continue;
-			}
-			const parts = trimmed.split('.');
-			if (parts.length >= 2) {
-				const objectType = normalizeMdObjectTypeFromRefPrefix(parts[0] ?? '');
-				const objectName = parts.slice(1).join('.').trim();
-				if (objectType && objectName) {
-					out.add(`${objectType}.${objectName}`);
-				}
-			}
-		}
-		return out;
-	}
-
-	function normalizeMdObjectTypeFromRefPrefix(prefix: string): string {
-		const p = prefix.trim();
-		switch (p) {
-			case 'Catalog':
-			case 'Constant':
-			case 'Enum':
-			case 'Document':
-			case 'Report':
-			case 'DataProcessor':
-			case 'Task':
-			case 'ChartOfAccounts':
-			case 'ChartOfCharacteristicTypes':
-			case 'ChartOfCalculationTypes':
-			case 'CommonModule':
-			case 'Subsystem':
-			case 'SessionParameter':
-			case 'ExchangePlan':
-			case 'CommonAttribute':
-			case 'CommonPicture':
-			case 'DocumentNumerator':
-			case 'ExternalDataSource':
-			case 'Role':
-				return p;
-			default:
-				return '';
-		}
-	}
-
 	function parseExternalArtifactSourceKindFromArgs(
 		args: readonly unknown[]
 	): 'externalErf' | 'externalEpf' | undefined {
@@ -822,38 +759,40 @@ export function registerMetadataFeature(
 		vscode.commands.registerCommand('1c-platform-tools.metadata.refresh', () => {
 			void metadataTreeProvider.refresh();
 		}),
-		vscode.commands.registerCommand('1c-platform-tools.metadata.find', () => {
-			// Тот же фильтр, что и у поля над деревом: ищем по всей конфигурации, а не по раскрытым веткам.
-			const box = vscode.window.createInputBox();
-			box.title = 'Поиск по метаданным';
-			box.placeholder = 'Часть имени; несколько слов — должны встречаться все';
-			box.value = metadataTreeProvider.getTextFilter() ?? '';
-			box.onDidChangeValue((value) => {
-				metadataTreeProvider.setTextFilter(value);
-				metadataSearchProvider.showQuery(value);
-			});
-			box.onDidAccept(() => box.hide());
-			box.onDidHide(() => box.dispose());
-			box.show();
+		vscode.commands.registerCommand('1c-platform-tools.metadata.find', async () => {
+			// Штатный виджет поиска ищет только по загруженным узлам, поэтому сперва раскрываем группы:
+			// объекты уже в кэше дерева, повторных чтений не будет.
+			for (const group of metadataTreeProvider.listGroupItems()) {
+				try {
+					await metadataTreeView.reveal(group, { expand: true, select: false, focus: false });
+				} catch {
+					// Узел мог исчезнуть после обновления дерева — остальные всё равно раскрываем.
+				}
+			}
+			await vscode.commands.executeCommand('1c-platform-tools-metadata-tree.focus');
+			await vscode.commands.executeCommand('list.find');
 		}),
-		vscode.commands.registerCommand('1c-platform-tools.metadata.pickSubsystemFilter', async () => {
-			const subsystems = metadataTreeProvider.listSubsystemLeaves();
-			if (subsystems.length === 0) {
-				void vscode.window.showInformationMessage('В дереве метаданных нет подсистем.');
+		vscode.commands.registerCommand('1c-platform-tools.metadata.filters.apply', async () => {
+			const checked = metadataFilterProvider.checkedSubsystems;
+			if (checked.length === 0) {
+				void vscode.window.showInformationMessage('Отметьте подсистемы в панели «Фильтры».');
 				return;
 			}
-			const items = subsystems
-				.map((leaf) => ({ label: leaf.name, description: leaf.sourceId, leaf }))
-				.sort((a, b) => a.label.localeCompare(b.label, 'ru'));
-			const picked = await vscode.window.showQuickPick(items, {
-				title: 'Фильтр по подсистемам',
-				placeHolder: 'Выберите подсистему',
-				matchOnDescription: true,
-			});
-			if (!picked) {
-				return;
+			const label = checked.length === 1 ? checked[0].name : `подсистем: ${checked.length}`;
+			const applied = await applySubsystemFilter(
+				context,
+				metadataTreeProvider,
+				checked,
+				metadataFilterProvider.options,
+				label
+			);
+			if (applied) {
+				void vscode.window.showInformationMessage(`Фильтр по подсистемам: ${label}`);
 			}
-			await vscode.commands.executeCommand('1c-platform-tools.metadata.filterBySubsystem', picked.leaf);
+		}),
+		vscode.commands.registerCommand('1c-platform-tools.metadata.filters.reset', () => {
+			metadataFilterProvider.clearChecked();
+			void vscode.commands.executeCommand('1c-platform-tools.metadata.clearSubsystemFilter');
 		}),
 		vscode.commands.registerCommand('1c-platform-tools.metadata.addDocument', async () => {
 			await vscode.commands.executeCommand('1c-platform-tools.metadata.addMdObject', 'DOCUMENT');
@@ -1416,126 +1355,24 @@ export function registerMetadataFeature(
 					void vscode.window.showInformationMessage('Выберите подсистему в дереве метаданных.');
 					return;
 				}
-				const cfgPath = node.configurationXmlAbs;
-				const cfRoot = node.metadataRootAbs;
-				if (!cfgPath || !cfRoot) {
-					void vscode.window.showInformationMessage('Нет выгрузки CF или Configuration.xml.');
-					return;
-				}
-				const schema = await mdSparrowSchemaFlagFromConfigurationXml(cfgPath);
-				const runtime = await ensureMdSparrowRuntime(context);
-				const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-				if (!workspaceRoot) {
-					void vscode.window.showInformationMessage('Нет открытой папки workspace.');
-					return;
-				}
-				type SubsystemDto = { contentRefs?: unknown[]; nestedSubsystems?: unknown[] };
-				const readSubsystemDto = async (subsystemNode: MetadataLeafTreeItem): Promise<SubsystemDto | undefined> => {
-					if (!subsystemNode.resourceUri) {
-						return undefined;
-					}
-					const getRes = await runMdSparrowParamsRead(
-						runtime,
-						{ op: 'cf-md-object-get', objectXml: subsystemNode.resourceUri.fsPath, schemaVersion: schema },
-						{ cwd: cfRoot }
-					);
-					if (getRes.exitCode !== 0) {
-						const errText = (getRes.stderr.trim() || getRes.stdout.trim() || `код ${getRes.exitCode}`).slice(
-							0,
-							MD_SPARROW_CLI_ERR_PREVIEW
-						);
-						void vscode.window.showErrorMessage(errText);
-						return undefined;
-					}
-					try {
-						return JSON.parse(getRes.stdout.trim()) as SubsystemDto;
-					} catch {
-						void vscode.window.showErrorMessage('Не удалось разобрать состав подсистемы.');
-						return undefined;
-					}
-				};
-
-				const tree = metadataTreeProvider.getCachedTree();
-				const subsystemNameToLeaf = new Map<string, MetadataLeafTreeItem>();
-				if (tree) {
-					for (const src of tree.sources) {
-						for (const group of src.groups) {
-							for (const subgroup of group.subgroups ?? []) {
-								for (const mdItem of subgroup.items) {
-									if (mdItem.objectType !== 'Subsystem') {
-										continue;
-									}
-									const rel = mdItem.relativePath?.length ? mdItem.relativePath : undefined;
-									const leafNode = new MetadataLeafTreeItem(
-										src.id,
-										group.id,
-										subgroup.id,
-										mdItem.objectType,
-										mdItem.name,
-										rel,
-										workspaceRoot,
-										context.extensionUri,
-										src.configurationXmlRelativePath ? path.join(workspaceRoot, src.configurationXmlRelativePath) : undefined,
-										src.metadataRootRelativePath ? path.join(workspaceRoot, src.metadataRootRelativePath) : undefined
-									);
-									subsystemNameToLeaf.set(mdItem.name, leafNode);
-								}
-							}
-						}
-					}
-				}
-				subsystemNameToLeaf.set(node.name, node);
-
-				const visitedSubsystems = new Set<string>();
-				const allowedSubsystemNames = new Set<string>();
-				const allowedNames = new Set<string>();
-				const allowedKeys = new Set<string>();
-
-				const walkSubsystem = async (subsystemLeaf: MetadataLeafTreeItem): Promise<void> => {
-					if (visitedSubsystems.has(subsystemLeaf.name)) {
-						return;
-					}
-					visitedSubsystems.add(subsystemLeaf.name);
-					allowedSubsystemNames.add(subsystemLeaf.name);
-					allowedNames.add(subsystemLeaf.name);
-					allowedKeys.add(`Subsystem.${subsystemLeaf.name}`);
-
-					const dto = await readSubsystemDto(subsystemLeaf);
-					if (!dto) {
-						return;
-					}
-					const refs = Array.isArray(dto.contentRefs)
-						? dto.contentRefs.filter((x): x is string => typeof x === 'string')
-						: [];
-					for (const name of parseContentRefsToObjectNames(refs)) {
-						allowedNames.add(name);
-					}
-					for (const key of parseContentRefsToObjectKeys(refs)) {
-						allowedKeys.add(key);
-					}
-					const nestedSubsystems = Array.isArray(dto.nestedSubsystems)
-						? dto.nestedSubsystems.filter((x): x is string => typeof x === 'string')
-						: [];
-					for (const nestedName of nestedSubsystems) {
-						const nestedLeaf = subsystemNameToLeaf.get(nestedName);
-						if (nestedLeaf) {
-							await walkSubsystem(nestedLeaf);
-						} else {
-							allowedSubsystemNames.add(nestedName);
-							allowedNames.add(nestedName);
-							allowedKeys.add(`Subsystem.${nestedName}`);
-						}
-					}
-				};
-
-				await walkSubsystem(node);
-				metadataTreeProvider.setSubsystemFilter(node.name, allowedNames, allowedKeys, allowedSubsystemNames);
-				void vscode.commands.executeCommand(
-					'setContext',
-					'1c-platform-tools.metadata.subsystemFilterActive',
-					true
+				const applied = await applySubsystemFilter(
+					context,
+					metadataTreeProvider,
+					[
+						{
+							sourceId: node.sourceId,
+							name: node.name,
+							xmlAbs: node.resourceUri.fsPath,
+							configurationXmlAbs: node.configurationXmlAbs,
+							metadataRootAbs: node.metadataRootAbs,
+						},
+					],
+					{ includeNested: true, includeParents: false },
+					node.name
 				);
-				void vscode.window.showInformationMessage(`Фильтр подсистемы: ${node.name}`);
+				if (applied) {
+					void vscode.window.showInformationMessage(`Фильтр подсистемы: ${node.name}`);
+				}
 			}
 		),
 		vscode.commands.registerCommand('1c-platform-tools.metadata.clearSubsystemFilter', async () => {

--- a/src/features/metadata/registerMetadataFeature.ts
+++ b/src/features/metadata/registerMetadataFeature.ts
@@ -19,7 +19,7 @@ import {
 import { createMdSparrowMutationRunner } from './mdSparrowMutationQueue';
 import type { MetadataFilterViewProvider } from './metadataFilterView';
 import { MetadataSearchViewProvider } from './metadataSearchView';
-import { applySubsystemFilter } from './metadataSubsystemFilter';
+import { computeSubsystemFilter, findSubsystemByName, loadSubsystemTrees } from './metadataSubsystemFilter';
 import { openMetadataObjectPropertiesEditor } from './metadataObjectPropertiesPanel';
 import {
 	openMetadataSourcePropertiesPanel,
@@ -1326,24 +1326,23 @@ export function registerMetadataFeature(
 					void vscode.window.showInformationMessage('Выберите подсистему в дереве метаданных.');
 					return;
 				}
-				const applied = await applySubsystemFilter(
-					context,
-					metadataTreeProvider,
-					[
-						{
-							sourceId: node.sourceId,
-							name: node.name,
-							xmlAbs: node.resourceUri.fsPath,
-							configurationXmlAbs: node.configurationXmlAbs,
-							metadataRootAbs: node.metadataRootAbs,
-						},
-					],
-					{ includeNested: true, includeParents: false },
-					node.name
-				);
-				if (applied) {
-					void vscode.window.showInformationMessage(`Фильтр подсистемы: ${node.name}`);
+				const roots = await loadSubsystemTrees(context, metadataTreeProvider);
+				const subsystem = findSubsystemByName(roots, node.name);
+				if (!subsystem) {
+					void vscode.window.showInformationMessage(`Не удалось прочитать подсистему: ${node.name}`);
+					return;
 				}
+				const result = computeSubsystemFilter(roots, new Set([subsystem.xmlPath]), {
+					includeNested: true,
+					includeParents: false,
+				});
+				metadataTreeProvider.setSubsystemFilter(node.name, result.names, result.keys, result.subsystemNames);
+				void vscode.commands.executeCommand(
+					'setContext',
+					'1c-platform-tools.metadata.subsystemFilterActive',
+					true
+				);
+				void vscode.window.showInformationMessage(`Фильтр подсистемы: ${node.name}`);
 			}
 		),
 		vscode.commands.registerCommand('1c-platform-tools.metadata.clearSubsystemFilter', async () => {

--- a/src/features/metadata/registerMetadataView.ts
+++ b/src/features/metadata/registerMetadataView.ts
@@ -4,17 +4,32 @@ import {
 	MetadataTreeDataProvider,
 } from './metadataTreeView';
 import { METADATA_SEARCH_VIEW_ID, MetadataSearchViewProvider } from './metadataSearchView';
-import {
-	METADATA_FILTERS_VIEW_ID,
-	MetadataFilterTreeDataProvider,
-	type MetadataFilterTreeItem,
-} from './metadataFilterView';
+import { METADATA_FILTERS_VIEW_ID, MetadataFilterViewProvider, type FilterSelection } from './metadataFilterView';
+import { applySubsystemFilter } from './metadataSubsystemFilter';
+
+/** Отмеченные подсистемы применяются сразу: пустой набор снимает отбор. */
+async function applyFilterSelection(
+	context: vscode.ExtensionContext,
+	metadataTreeProvider: MetadataTreeDataProvider,
+	selection: FilterSelection
+): Promise<void> {
+	if (selection.subsystems.length === 0) {
+		metadataTreeProvider.clearSubsystemFilter();
+		void vscode.commands.executeCommand('setContext', '1c-platform-tools.metadata.subsystemFilterActive', false);
+		return;
+	}
+	const label =
+		selection.subsystems.length === 1
+			? selection.subsystems[0].name
+			: `подсистем: ${selection.subsystems.length}`;
+	await applySubsystemFilter(context, metadataTreeProvider, selection.subsystems, selection, label);
+}
 
 export interface MetadataViewRegistration {
 	metadataTreeProvider: MetadataTreeDataProvider;
 	metadataTreeView: vscode.TreeView<vscode.TreeItem>;
 	metadataSearchProvider: MetadataSearchViewProvider;
-	metadataFilterProvider: MetadataFilterTreeDataProvider;
+	metadataFilterProvider: MetadataFilterViewProvider;
 }
 
 /**
@@ -37,19 +52,11 @@ export function registerMetadataView(
 		vscode.window.registerWebviewViewProvider(METADATA_SEARCH_VIEW_ID, metadataSearchProvider)
 	);
 
-	const metadataFilterProvider = new MetadataFilterTreeDataProvider(metadataTreeProvider);
-	const metadataFilterView = vscode.window.createTreeView<MetadataFilterTreeItem>(METADATA_FILTERS_VIEW_ID, {
-		treeDataProvider: metadataFilterProvider,
-		// Флажками управляем сами: охват подчинённых и родительских задают переключатели, а не иерархия.
-		manageCheckboxStateManually: true,
+	const metadataFilterProvider = new MetadataFilterViewProvider(metadataTreeProvider, (selection) => {
+		void applyFilterSelection(context, metadataTreeProvider, selection);
 	});
 	context.subscriptions.push(
-		metadataFilterView,
-		metadataFilterView.onDidChangeCheckboxState((event) => {
-			for (const [item, state] of event.items) {
-				metadataFilterProvider.setChecked(item, state === vscode.TreeItemCheckboxState.Checked);
-			}
-		})
+		vscode.window.registerWebviewViewProvider(METADATA_FILTERS_VIEW_ID, metadataFilterProvider)
 	);
 
 	const syncMetadataCatalogSelectionContext = (): void => {

--- a/src/features/metadata/registerMetadataView.ts
+++ b/src/features/metadata/registerMetadataView.ts
@@ -52,9 +52,13 @@ export function registerMetadataView(
 		vscode.window.registerWebviewViewProvider(METADATA_SEARCH_VIEW_ID, metadataSearchProvider)
 	);
 
-	const metadataFilterProvider = new MetadataFilterViewProvider(metadataTreeProvider, (selection) => {
-		void applyFilterSelection(context, metadataTreeProvider, selection);
-	});
+	const metadataFilterProvider = new MetadataFilterViewProvider(
+		context.extensionUri,
+		metadataTreeProvider,
+		(selection) => {
+			void applyFilterSelection(context, metadataTreeProvider, selection);
+		}
+	);
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(METADATA_FILTERS_VIEW_ID, metadataFilterProvider)
 	);

--- a/src/features/metadata/registerMetadataView.ts
+++ b/src/features/metadata/registerMetadataView.ts
@@ -60,7 +60,11 @@ export function registerMetadataView(
 		}
 	);
 	context.subscriptions.push(
-		vscode.window.registerWebviewViewProvider(METADATA_FILTERS_VIEW_ID, metadataFilterProvider)
+		vscode.window.registerWebviewViewProvider(METADATA_FILTERS_VIEW_ID, metadataFilterProvider),
+		// Панель открывается раньше, чем дерево прочитано: без этого список подсистем остаётся пустым.
+		metadataTreeProvider.onDidChangeTreeData(() => {
+			metadataFilterProvider.refresh();
+		})
 	);
 
 	const syncMetadataCatalogSelectionContext = (): void => {

--- a/src/features/metadata/registerMetadataView.ts
+++ b/src/features/metadata/registerMetadataView.ts
@@ -5,24 +5,22 @@ import {
 } from './metadataTreeView';
 import { METADATA_SEARCH_VIEW_ID, MetadataSearchViewProvider } from './metadataSearchView';
 import { METADATA_FILTERS_VIEW_ID, MetadataFilterViewProvider, type FilterSelection } from './metadataFilterView';
-import { applySubsystemFilter } from './metadataSubsystemFilter';
+import { computeSubsystemFilter } from './metadataSubsystemFilter';
 
 /** Отмеченные подсистемы применяются сразу: пустой набор снимает отбор. */
-async function applyFilterSelection(
-	context: vscode.ExtensionContext,
-	metadataTreeProvider: MetadataTreeDataProvider,
-	selection: FilterSelection
-): Promise<void> {
-	if (selection.subsystems.length === 0) {
+function applyFilterSelection(metadataTreeProvider: MetadataTreeDataProvider, selection: FilterSelection): void {
+	if (selection.checkedPaths.size === 0) {
 		metadataTreeProvider.clearSubsystemFilter();
 		void vscode.commands.executeCommand('setContext', '1c-platform-tools.metadata.subsystemFilterActive', false);
 		return;
 	}
+	const result = computeSubsystemFilter(selection.roots, selection.checkedPaths, selection);
 	const label =
-		selection.subsystems.length === 1
-			? selection.subsystems[0].name
-			: `подсистем: ${selection.subsystems.length}`;
-	await applySubsystemFilter(context, metadataTreeProvider, selection.subsystems, selection, label);
+		selection.checkedPaths.size === 1
+			? [...result.subsystemNames][0] ?? 'подсистема'
+			: `подсистем: ${selection.checkedPaths.size}`;
+	metadataTreeProvider.setSubsystemFilter(label, result.names, result.keys, result.subsystemNames);
+	void vscode.commands.executeCommand('setContext', '1c-platform-tools.metadata.subsystemFilterActive', true);
 }
 
 export interface MetadataViewRegistration {
@@ -52,13 +50,9 @@ export function registerMetadataView(
 		vscode.window.registerWebviewViewProvider(METADATA_SEARCH_VIEW_ID, metadataSearchProvider)
 	);
 
-	const metadataFilterProvider = new MetadataFilterViewProvider(
-		context.extensionUri,
-		metadataTreeProvider,
-		(selection) => {
-			void applyFilterSelection(context, metadataTreeProvider, selection);
-		}
-	);
+	const metadataFilterProvider = new MetadataFilterViewProvider(context, metadataTreeProvider, (selection) => {
+		applyFilterSelection(metadataTreeProvider, selection);
+	});
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(METADATA_FILTERS_VIEW_ID, metadataFilterProvider),
 		// Панель открывается раньше, чем дерево прочитано: без этого список подсистем остаётся пустым.

--- a/src/features/metadata/registerMetadataView.ts
+++ b/src/features/metadata/registerMetadataView.ts
@@ -8,6 +8,7 @@ import { METADATA_SEARCH_VIEW_ID, MetadataSearchViewProvider } from './metadataS
 export interface MetadataViewRegistration {
 	metadataTreeProvider: MetadataTreeDataProvider;
 	metadataTreeView: vscode.TreeView<vscode.TreeItem>;
+	metadataSearchProvider: MetadataSearchViewProvider;
 }
 
 /**
@@ -74,5 +75,5 @@ export function registerMetadataView(
 		metadataTreeView.onDidChangeSelection(syncMetadataCatalogSelectionContext)
 	);
 
-	return { metadataTreeProvider, metadataTreeView };
+	return { metadataTreeProvider, metadataTreeView, metadataSearchProvider };
 }

--- a/src/features/metadata/registerMetadataView.ts
+++ b/src/features/metadata/registerMetadataView.ts
@@ -4,11 +4,17 @@ import {
 	MetadataTreeDataProvider,
 } from './metadataTreeView';
 import { METADATA_SEARCH_VIEW_ID, MetadataSearchViewProvider } from './metadataSearchView';
+import {
+	METADATA_FILTERS_VIEW_ID,
+	MetadataFilterTreeDataProvider,
+	type MetadataFilterTreeItem,
+} from './metadataFilterView';
 
 export interface MetadataViewRegistration {
 	metadataTreeProvider: MetadataTreeDataProvider;
 	metadataTreeView: vscode.TreeView<vscode.TreeItem>;
 	metadataSearchProvider: MetadataSearchViewProvider;
+	metadataFilterProvider: MetadataFilterTreeDataProvider;
 }
 
 /**
@@ -29,6 +35,21 @@ export function registerMetadataView(
 	});
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(METADATA_SEARCH_VIEW_ID, metadataSearchProvider)
+	);
+
+	const metadataFilterProvider = new MetadataFilterTreeDataProvider(metadataTreeProvider);
+	const metadataFilterView = vscode.window.createTreeView<MetadataFilterTreeItem>(METADATA_FILTERS_VIEW_ID, {
+		treeDataProvider: metadataFilterProvider,
+		// Флажками управляем сами: охват подчинённых и родительских задают переключатели, а не иерархия.
+		manageCheckboxStateManually: true,
+	});
+	context.subscriptions.push(
+		metadataFilterView,
+		metadataFilterView.onDidChangeCheckboxState((event) => {
+			for (const [item, state] of event.items) {
+				metadataFilterProvider.setChecked(item, state === vscode.TreeItemCheckboxState.Checked);
+			}
+		})
 	);
 
 	const syncMetadataCatalogSelectionContext = (): void => {
@@ -75,5 +96,5 @@ export function registerMetadataView(
 		metadataTreeView.onDidChangeSelection(syncMetadataCatalogSelectionContext)
 	);
 
-	return { metadataTreeProvider, metadataTreeView, metadataSearchProvider };
+	return { metadataTreeProvider, metadataTreeView, metadataSearchProvider, metadataFilterProvider };
 }

--- a/src/test/metadata/metadataSubsystemFilter.test.ts
+++ b/src/test/metadata/metadataSubsystemFilter.test.ts
@@ -1,54 +1,97 @@
 import * as assert from 'node:assert';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
 import {
-	hasNestedSubsystems,
-	nestedSubsystemXmls,
-	parentSubsystemXml,
+	computeSubsystemFilter,
+	findSubsystemByName,
 	parseContentRefsToObjectKeys,
 	parseContentRefsToObjectNames,
+	type SubsystemNode,
 } from '../../features/metadata/metadataSubsystemFilter';
 
-suite('metadataSubsystemFilter: иерархия подсистем по раскладке файлов', () => {
-	let root: string;
+/** Дерево как его отдаёт md-sparrow: Продажи → Заказы, плюс отдельные Закупки. */
+function roots(): SubsystemNode[] {
+	return [
+		{
+			name: 'Продажи',
+			xmlPath: 'C:/ws/src/cf/Subsystems/Продажи.xml',
+			contentRefs: ['Catalog.Партнеры'],
+			children: [
+				{
+					name: 'Заказы',
+					xmlPath: 'C:/ws/src/cf/Subsystems/Продажи/Subsystems/Заказы.xml',
+					contentRefs: ['Document.ЗаказПокупателя'],
+					children: [
+						{
+							name: 'Согласование',
+							xmlPath: 'C:/ws/src/cf/Subsystems/Продажи/Subsystems/Заказы/Subsystems/Согласование.xml',
+							contentRefs: ['Catalog.Согласования'],
+							children: [],
+						},
+					],
+				},
+			],
+		},
+		{
+			name: 'Закупки',
+			xmlPath: 'C:/ws/src/cf/Subsystems/Закупки.xml',
+			contentRefs: ['Document.ЗаказПоставщику'],
+			children: [],
+		},
+	];
+}
 
-	setup(() => {
-		// src/cf/Subsystems/Продажи.xml + вложенная Продажи/Subsystems/Заказы.xml
-		root = fs.mkdtempSync(path.join(os.tmpdir(), 'md-subsystems-'));
-		const subsystems = path.join(root, 'src', 'cf', 'Subsystems');
-		fs.mkdirSync(path.join(subsystems, 'Продажи', 'Subsystems'), { recursive: true });
-		fs.writeFileSync(path.join(subsystems, 'Продажи.xml'), '<MetaDataObject/>', 'utf-8');
-		fs.writeFileSync(path.join(subsystems, 'Продажи', 'Subsystems', 'Заказы.xml'), '<MetaDataObject/>', 'utf-8');
-		fs.writeFileSync(path.join(subsystems, 'Закупки.xml'), '<MetaDataObject/>', 'utf-8');
+const ORDERS = 'C:/ws/src/cf/Subsystems/Продажи/Subsystems/Заказы.xml';
+
+suite('metadataSubsystemFilter: состав отбора', () => {
+	test('пустой набор ничего не разрешает', () => {
+		const result = computeSubsystemFilter(roots(), new Set(), { includeNested: true, includeParents: false });
+		assert.strictEqual(result.names.size, 0);
+		assert.strictEqual(result.keys.size, 0);
 	});
 
-	teardown(() => {
-		fs.rmSync(root, { recursive: true, force: true });
-	});
+	test('подчинённые включаются по переключателю', () => {
+		const withNested = computeSubsystemFilter(roots(), new Set([ORDERS]), {
+			includeNested: true,
+			includeParents: false,
+		});
+		assert.deepStrictEqual(
+			[...withNested.keys].sort(),
+			['Catalog.Согласования', 'Document.ЗаказПокупателя', 'Subsystem.Заказы', 'Subsystem.Согласование'],
+			'объекты вложенной подсистемы попадают в отбор'
+		);
 
-	function xml(...parts: string[]): string {
-		return path.join(root, 'src', 'cf', 'Subsystems', ...parts);
-	}
-
-	test('у подсистемы верхнего уровня родителя нет', () => {
-		assert.strictEqual(parentSubsystemXml(xml('Продажи.xml')), undefined);
-	});
-
-	test('у вложенной подсистемы родитель — XML владельца', () => {
-		assert.strictEqual(
-			parentSubsystemXml(xml('Продажи', 'Subsystems', 'Заказы.xml')),
-			xml('Продажи.xml')
+		const withoutNested = computeSubsystemFilter(roots(), new Set([ORDERS]), {
+			includeNested: false,
+			includeParents: false,
+		});
+		assert.deepStrictEqual(
+			[...withoutNested.keys].sort(),
+			['Document.ЗаказПокупателя', 'Subsystem.Заказы'],
+			'без переключателя берём только саму подсистему'
 		);
 	});
 
-	test('подчинённые подсистемы берутся из каталога владельца', () => {
-		assert.deepStrictEqual(nestedSubsystemXmls(xml('Продажи.xml'), 'Продажи'), [
-			xml('Продажи', 'Subsystems', 'Заказы.xml'),
-		]);
-		assert.ok(hasNestedSubsystems(xml('Продажи.xml'), 'Продажи'));
-		assert.deepStrictEqual(nestedSubsystemXmls(xml('Закупки.xml'), 'Закупки'), []);
-		assert.ok(!hasNestedSubsystems(xml('Закупки.xml'), 'Закупки'));
+	test('родительские включаются по переключателю', () => {
+		const withParents = computeSubsystemFilter(roots(), new Set([ORDERS]), {
+			includeNested: false,
+			includeParents: true,
+		});
+		assert.ok(withParents.keys.has('Catalog.Партнеры'), 'объекты родителя попадают в отбор');
+		assert.ok(withParents.subsystemNames.has('Продажи'));
+		assert.ok(!withParents.keys.has('Document.ЗаказПоставщику'), 'соседняя ветка не попадает');
+	});
+
+	test('несколько отмеченных подсистем объединяются', () => {
+		const result = computeSubsystemFilter(roots(), new Set([ORDERS, 'C:/ws/src/cf/Subsystems/Закупки.xml']), {
+			includeNested: false,
+			includeParents: false,
+		});
+		assert.ok(result.keys.has('Document.ЗаказПокупателя'));
+		assert.ok(result.keys.has('Document.ЗаказПоставщику'));
+	});
+
+	test('подсистема ищется по имени на любом уровне', () => {
+		assert.strictEqual(findSubsystemByName(roots(), 'Согласование')?.name, 'Согласование');
+		assert.strictEqual(findSubsystemByName(roots(), 'Нет'), undefined);
 	});
 });
 

--- a/src/test/metadata/metadataSubsystemFilter.test.ts
+++ b/src/test/metadata/metadataSubsystemFilter.test.ts
@@ -1,0 +1,79 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	hasNestedSubsystems,
+	nestedSubsystemXmls,
+	parentSubsystemXml,
+	parseContentRefsToObjectKeys,
+	parseContentRefsToObjectNames,
+} from '../../features/metadata/metadataSubsystemFilter';
+
+suite('metadataSubsystemFilter: иерархия подсистем по раскладке файлов', () => {
+	let root: string;
+
+	setup(() => {
+		// src/cf/Subsystems/Продажи.xml + вложенная Продажи/Subsystems/Заказы.xml
+		root = fs.mkdtempSync(path.join(os.tmpdir(), 'md-subsystems-'));
+		const subsystems = path.join(root, 'src', 'cf', 'Subsystems');
+		fs.mkdirSync(path.join(subsystems, 'Продажи', 'Subsystems'), { recursive: true });
+		fs.writeFileSync(path.join(subsystems, 'Продажи.xml'), '<MetaDataObject/>', 'utf-8');
+		fs.writeFileSync(path.join(subsystems, 'Продажи', 'Subsystems', 'Заказы.xml'), '<MetaDataObject/>', 'utf-8');
+		fs.writeFileSync(path.join(subsystems, 'Закупки.xml'), '<MetaDataObject/>', 'utf-8');
+	});
+
+	teardown(() => {
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	function xml(...parts: string[]): string {
+		return path.join(root, 'src', 'cf', 'Subsystems', ...parts);
+	}
+
+	test('у подсистемы верхнего уровня родителя нет', () => {
+		assert.strictEqual(parentSubsystemXml(xml('Продажи.xml')), undefined);
+	});
+
+	test('у вложенной подсистемы родитель — XML владельца', () => {
+		assert.strictEqual(
+			parentSubsystemXml(xml('Продажи', 'Subsystems', 'Заказы.xml')),
+			xml('Продажи.xml')
+		);
+	});
+
+	test('подчинённые подсистемы берутся из каталога владельца', () => {
+		assert.deepStrictEqual(nestedSubsystemXmls(xml('Продажи.xml'), 'Продажи'), [
+			xml('Продажи', 'Subsystems', 'Заказы.xml'),
+		]);
+		assert.ok(hasNestedSubsystems(xml('Продажи.xml'), 'Продажи'));
+		assert.deepStrictEqual(nestedSubsystemXmls(xml('Закупки.xml'), 'Закупки'), []);
+		assert.ok(!hasNestedSubsystems(xml('Закупки.xml'), 'Закупки'));
+	});
+});
+
+suite('metadataSubsystemFilter: разбор состава подсистемы', () => {
+	test('имена объектов вытаскиваются из ссылок и из путей', () => {
+		const names = parseContentRefsToObjectNames([
+			'Catalog.Номенклатура',
+			'Document.ЗаказПокупателя',
+			'Catalogs/Партнеры.xml',
+			'  ',
+		]);
+		assert.deepStrictEqual([...names].sort(), ['ЗаказПокупателя', 'Номенклатура', 'Партнеры']);
+	});
+
+	test('ключи объектов собираются из вида и имени', () => {
+		const keys = parseContentRefsToObjectKeys([
+			'Catalog.Номенклатура',
+			'AccumulationRegister.Остатки',
+			'НеИзвестныйВид.Объект',
+			'БезТочки',
+		]);
+		assert.deepStrictEqual(
+			[...keys].sort(),
+			['AccumulationRegister.Остатки', 'Catalog.Номенклатура'],
+			'неизвестные виды и ссылки без вида отбрасываются'
+		);
+	});
+});


### PR DESCRIPTION
Отбор дерева метаданных по подсистемам — панель «Фильтры» в контейнере «Метаданные». Поле поиска над деревом метаданных остаётся как было.

## Панель «Фильтры»
Раскладка как в диалоге EDT, свёрнута по умолчанию:
- **поле поиска подсистем** сверху с крестиком: несколько слов ищутся по отдельности («демо замет» находит «_ДемоЗаметкиПользователя»), ветки с совпадениями раскрываются, родители остаются видны;
- **дерево подсистем с флажками**, без значков, вложенные подсистемы раскрываются;
- **переключатели охвата**: «Включать объекты из подчинённых подсистем» (включён) и «Включать объекты из родительских подсистем»;
- в шапке — «Свернуть» и «Очистить фильтр» (доступна всегда).

Отбор применяется **сразу** при простановке флажка, отдельной кнопки «Установить» нет. Клики по нескольким подсистемам собираются за 350 мс, чтобы состав читался один раз.

Иерархия берётся из раскладки файлов (`Subsystems/<Имя>/Subsystems/<Вложенная>.xml`) — открытие панели ничего не читает. Состав читается через `cf-md-object-get` только у отмеченных веток.

Отличие от EDT: это панель сайдбара, а не плавающее окно — расширениям VS Code модальные окна недоступны.

## Про лупу
Кнопка убрана. Штатный виджет поиска ищет только по загруженным узлам, поэтому перед ним приходилось разворачивать всё дерево — на реальной конфигурации это заняло около минуты и повесило интерфейс. Сам виджет никуда не делся: Ctrl+F на дереве работает в пределах раскрытых веток.

## Заодно
Логика отбора вынесена из `registerMetadataFeature` в отдельный модуль и переиспользуется контекстным меню подсистемы. Починен разбор имён из ссылок состава: из `Catalog.Номенклатура` возвращалась вся строка вместо `Номенклатура`, отбор держался только на ключах вида.

## Проверка
434 теста, eslint и tsc зелёные. Тесты: иерархия подсистем по раскладке файлов и разбор ссылок состава. Разметку панели проверил на макете: поиск по двум словам, сворачивание, отправка отметки.

Руками: «Фильтры» → найти подсистему по части имени → поставить флажок → дерево метаданных сразу отбирается; «Очистить фильтр» возвращает всё.

Основан на #224 — вливать после него.