### PR TITLE
feat(metadata): палитра свойств строки состава — тип реквизитов

### DIFF
--- a/resources/webview/metadata-object.css
+++ b/resources/webview/metadata-object.css
@@ -907,3 +907,15 @@ select.edit-input {
 	gap: 2px;
 	align-items: center;
 }
+
+/* Палитра: выбранная строка состава и подсказка о снятии выделения. */
+.struct-item-selected {
+	background: var(--vscode-list-activeSelectionBackground);
+	color: var(--vscode-list-activeSelectionForeground);
+}
+
+.palette-note {
+	margin-top: 8px;
+	color: var(--vscode-descriptionForeground);
+	font-size: 12px;
+}

--- a/resources/webview/metadata-object.css
+++ b/resources/webview/metadata-object.css
@@ -908,14 +908,46 @@ select.edit-input {
 	align-items: center;
 }
 
-/* Палитра: выбранная строка состава и подсказка о снятии выделения. */
+/* Палитра свойств строки: третья колонка вкладки «Данные», как в EDT. */
+.edit-data-layout-palette {
+	grid-template-columns: minmax(240px, 1fr) minmax(280px, 1.1fr) minmax(260px, 1fr);
+}
+
+.edit-data-palette {
+	min-width: 0;
+	border-left: 1px solid var(--vscode-panel-border);
+	padding-left: 16px;
+}
+
+.palette-head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	margin-bottom: 10px;
+}
+
+.palette-head .section-title {
+	margin: 0;
+	overflow-wrap: anywhere;
+}
+
+.palette-close {
+	flex: 0 0 auto;
+	border: none;
+	background: transparent;
+	color: var(--vscode-descriptionForeground);
+	cursor: pointer;
+	font-size: 14px;
+	line-height: 1;
+	padding: 0 4px;
+}
+
+.palette-close:hover {
+	color: var(--vscode-foreground);
+}
+
 .struct-item-selected {
 	background: var(--vscode-list-activeSelectionBackground);
 	color: var(--vscode-list-activeSelectionForeground);
-}
-
-.palette-note {
-	margin-top: 8px;
-	color: var(--vscode-descriptionForeground);
-	font-size: 12px;
 }

--- a/resources/webview/metadata-object.js
+++ b/resources/webview/metadata-object.js
@@ -37,6 +37,8 @@
 			? structureEditsFromLists(model.structureLists)
 			: null;
 	let editFilter = '';
+	/** Путь выбранной строки состава: по нему показываем палитру свойств. */
+	let selectedStructPath = '';
 
 	/** Синоним из имени по правилу 1С: «ВалютаБанка» → «Валюта банка», «БИКБанка» → «БИК банка». */
 	function synonymFromName(name) {
@@ -94,12 +96,15 @@
 
 	function structRowFrom(r) {
 		const item = typeof r === 'object' && r !== null ? r : {};
+		const type = item.type && typeof item.type === 'object' ? item.type : null;
 		return {
 			originalName: typeof item.name === 'string' ? item.name : '',
 			name: typeof item.name === 'string' ? item.name : '',
 			synonymRu: typeof item.synonymRu === 'string' ? item.synonymRu : '',
 			baselineSynonymRu: typeof item.synonymRu === 'string' ? item.synonymRu : '',
 			comment: typeof item.comment === 'string' ? item.comment : '',
+			type: type ? deepClone(type) : null,
+			baselineTypeKey: type ? JSON.stringify(type) : '',
 			deleted: false,
 		};
 	}
@@ -141,7 +146,14 @@
 	}
 
 	function structRowDirty(row) {
-		return row.deleted || !row.originalName || row.name !== row.originalName || row.synonymRu !== row.baselineSynonymRu;
+		const typeKey = row.type ? JSON.stringify(row.type) : '';
+		return (
+			row.deleted ||
+			!row.originalName ||
+			row.name !== row.originalName ||
+			row.synonymRu !== row.baselineSynonymRu ||
+			typeKey !== row.baselineTypeKey
+		);
 	}
 
 	function structOrderKey(structure) {
@@ -226,6 +238,7 @@
 				originalName: row.originalName || undefined,
 				name: String(row.name || '').trim(),
 				synonymRu: row.synonymRu,
+				type: row.type || undefined,
 				deleted: Boolean(row.deleted),
 			};
 		};
@@ -550,15 +563,16 @@
 		return value.types[0];
 	}
 
-	function typeQualifierRows(field, value, type, disabled) {
+	function typeQualifierRows(field, value, type, disabled, attr) {
+		const pathAttr = attr || 'data-type-path';
 		const row = (label, html) =>
 			`<div class="type-row"><span class="type-label">${escapeHtml(label)}</span>${html}</div>`;
 		const num = (qualifier, key, current) =>
 			`<input class="edit-input type-input" type="text" inputmode="numeric" value="${escapeHtml(
 				current == null ? '' : String(current)
-			)}" data-type-path="${escapeHtml(field.path)}" data-type-qualifier="${qualifier}" data-type-key="${key}"${disabled} />`;
+			)}" ${pathAttr}="${escapeHtml(field.path)}" data-type-qualifier="${qualifier}" data-type-key="${key}"${disabled} />`;
 		const select = (qualifier, key, current, options) =>
-			`<select class="edit-input type-input" data-type-path="${escapeHtml(
+			`<select class="edit-input type-input" ${pathAttr}="${escapeHtml(
 				field.path
 			)}" data-type-qualifier="${qualifier}" data-type-key="${key}"${disabled}>${options
 				.map(
@@ -609,7 +623,8 @@
 		return '';
 	}
 
-	function typeControlHtml(field, value, disabled) {
+	function typeControlHtml(field, value, disabled, forStructRow) {
+		const attr = forStructRow ? 'data-type-spath' : 'data-type-path';
 		const type = primitiveTypeOf(value);
 		if (!type) {
 			// Ссылочный или составной тип: показываем как есть, менять пока нечем.
@@ -622,8 +637,8 @@
 				`<option value="${option.value}"${option.value === type ? ' selected' : ''}>${escapeHtml(option.label)}</option>`
 		).join('');
 		return `<div class="type-control">
-				<select class="edit-input" data-type-path="${escapeHtml(field.path)}" data-type-primary="1"${disabled}>${options}</select>
-				${typeQualifierRows(field, value, type, disabled)}
+				<select class="edit-input" ${attr}="${escapeHtml(field.path)}" data-type-primary="1"${disabled}>${options}</select>
+				${typeQualifierRows(field, value, type, disabled, attr)}
 			</div>`;
 	}
 
@@ -747,16 +762,17 @@
 			</div>`
 			: '';
 		if (tabId === 'edit_data') {
-			// Раскладка EDT: слева состав объекта, справа группы свойств.
+			// Раскладка EDT: слева состав объекта, справа палитра выбранной строки либо свойства объекта.
 			const tsHtml = structSupportsTabularSections()
 				? `<div class="section-title section-title-spaced">Табличные части</div>${structEditTsHtml()}`
 				: '';
+			const paletteHtml = structPaletteHtml();
 			contentRoot.innerHTML = `${filterHtml}<div class="edit-data-layout">
 					<div class="edit-data-structure">
 						${structListsHtml()}
 						${tsHtml}
 					</div>
-					<div class="edit-data-props">${groupsHtml}</div>
+					<div class="edit-data-props">${paletteHtml || groupsHtml}</div>
 				</div>`;
 			bindEditInputs(spec);
 			bindStructEditInputs(spec);
@@ -857,6 +873,53 @@
 		}
 		bindRefListButtons(spec);
 		bindTypeInputs(spec);
+		bindStructTypeInputs(spec);
+		bindStructSelection(spec);
+	}
+
+	function bindStructSelection(spec) {
+		if (!contentRoot) {
+			return;
+		}
+		for (const item of contentRoot.querySelectorAll('[data-sselect]')) {
+			item.addEventListener('mousedown', function () {
+				const spath = item.getAttribute('data-sselect');
+				if (selectedStructPath === spath) {
+					return;
+				}
+				selectedStructPath = spath;
+				renderEditTab(spec.id);
+			});
+		}
+	}
+
+	/** Тип строки состава: значение живёт в правках структуры, а не в свойствах объекта. */
+	function bindStructTypeInputs(spec) {
+		if (!contentRoot || !editedStructure) {
+			return;
+		}
+		for (const input of contentRoot.querySelectorAll('[data-type-spath]')) {
+			const spath = input.getAttribute('data-type-spath');
+			const isPrimary = input.hasAttribute('data-type-primary');
+			input.addEventListener('change', function () {
+				const row = structRowByPath(spath);
+				if (!row) {
+					return;
+				}
+				if (isPrimary) {
+					row.type = Object.assign({ types: [input.value] }, TYPE_DEFAULT_QUALIFIERS[input.value] || {});
+					renderEditTab(spec.id);
+					renderSaveBar();
+					return;
+				}
+				const qualifier = input.getAttribute('data-type-qualifier');
+				const key = input.getAttribute('data-type-key');
+				const next = Object.assign({}, row.type);
+				next[qualifier] = Object.assign({}, next[qualifier] || {}, { [key]: input.value });
+				row.type = next;
+				renderSaveBar();
+			});
+		}
 	}
 
 	function bindTypeInputs(spec) {
@@ -1093,7 +1156,8 @@
 		const deleted = row.deleted;
 		const invalid = !deleted && !structNameValid(row.name) ? ' struct-input-invalid' : '';
 		const dis = deleted ? ' disabled' : '';
-		return `<div class="struct-item${deleted ? ' struct-item-deleted' : ''}"${row.comment ? ` title="${escapeHtml(row.comment)}"` : ''}>
+		const selected = selectedStructPath === spath ? ' struct-item-selected' : '';
+		return `<div class="struct-item${deleted ? ' struct-item-deleted' : ''}${selected}" data-sselect="${spath}"${row.comment ? ` title="${escapeHtml(row.comment)}"` : ''}>
 			<input class="edit-input struct-input struct-input-name${invalid}" data-spath="${spath}" data-sfield="name" value="${escapeHtml(row.name)}" placeholder="Имя" spellcheck="false"${dis} />
 			<input class="edit-input struct-input" data-spath="${spath}" data-sfield="synonymRu" value="${escapeHtml(row.synonymRu)}" placeholder="Синоним"${dis} />
 			<span class="struct-actions-inline">
@@ -1124,6 +1188,39 @@
 				return title + structEditListHtml(editableIdx);
 			})
 			.join('');
+	}
+
+	/** Палитра свойств выбранной строки: пусто, если строка не выбрана — тогда показываем свойства объекта. */
+	function structPaletteHtml() {
+		const row = selectedStructPath ? structRowByPath(selectedStructPath) : null;
+		if (!row) {
+			return '';
+		}
+		const spath = selectedStructPath;
+		const typeRow = row.type
+			? `<div class="edit-row"><label class="edit-label">Тип</label><div class="edit-control">${typeControlHtml(
+					{ path: spath },
+					row.type,
+					row.deleted ? ' disabled' : '',
+					true
+				)}</div></div>`
+			: '';
+		return `<div class="edit-group">
+				<div class="section-title">Свойства: ${escapeHtml(row.name || '(без имени)')}</div>
+				<div class="edit-fields">
+					<div class="edit-row"><label class="edit-label">Имя</label><div class="edit-control">
+						<input class="edit-input" data-spath="${spath}" data-sfield="name" value="${escapeHtml(row.name)}" spellcheck="false" />
+					</div></div>
+					<div class="edit-row"><label class="edit-label">Синоним</label><div class="edit-control">
+						<input class="edit-input" data-spath="${spath}" data-sfield="synonymRu" value="${escapeHtml(row.synonymRu)}" />
+					</div></div>
+					<div class="edit-row"><label class="edit-label">Комментарий</label><div class="edit-control">
+						<input class="edit-input" data-spath="${spath}" data-sfield="comment" value="${escapeHtml(row.comment || '')}" />
+					</div></div>
+					${typeRow}
+				</div>
+			</div>
+			<div class="palette-note">Свойства объекта — снимите выделение строки</div>`;
 	}
 
 	function structReadonlyListHtml(list) {

--- a/resources/webview/metadata-object.js
+++ b/resources/webview/metadata-object.js
@@ -767,12 +767,15 @@
 				? `<div class="section-title section-title-spaced">Табличные части</div>${structEditTsHtml()}`
 				: '';
 			const paletteHtml = structPaletteHtml();
-			contentRoot.innerHTML = `${filterHtml}<div class="edit-data-layout">
+			contentRoot.innerHTML = `${filterHtml}<div class="edit-data-layout${
+				paletteHtml ? ' edit-data-layout-palette' : ''
+			}">
 					<div class="edit-data-structure">
 						${structListsHtml()}
 						${tsHtml}
 					</div>
-					<div class="edit-data-props">${paletteHtml || groupsHtml}</div>
+					<div class="edit-data-props">${groupsHtml}</div>
+					${paletteHtml}
 				</div>`;
 			bindEditInputs(spec);
 			bindStructEditInputs(spec);
@@ -882,12 +885,19 @@
 			return;
 		}
 		for (const item of contentRoot.querySelectorAll('[data-sselect]')) {
-			item.addEventListener('mousedown', function () {
-				const spath = item.getAttribute('data-sselect');
-				if (selectedStructPath === spath) {
+			item.addEventListener('mousedown', function (event) {
+				// Клик по полю ввода внутри строки не должен переключать выделение.
+				if (event.target && event.target.closest('input, button, select')) {
 					return;
 				}
-				selectedStructPath = spath;
+				const spath = item.getAttribute('data-sselect');
+				selectedStructPath = selectedStructPath === spath ? '' : spath;
+				renderEditTab(spec.id);
+			});
+		}
+		for (const btn of contentRoot.querySelectorAll('[data-spalette-close]')) {
+			btn.addEventListener('click', function () {
+				selectedStructPath = '';
 				renderEditTab(spec.id);
 			});
 		}
@@ -1190,7 +1200,7 @@
 			.join('');
 	}
 
-	/** Палитра свойств выбранной строки: пусто, если строка не выбрана — тогда показываем свойства объекта. */
+	/** Свойства выбранной строки состава: отдельная колонка рядом со свойствами объекта, как в EDT. */
 	function structPaletteHtml() {
 		const row = selectedStructPath ? structRowByPath(selectedStructPath) : null;
 		if (!row) {
@@ -1205,8 +1215,11 @@
 					true
 				)}</div></div>`
 			: '';
-		return `<div class="edit-group">
-				<div class="section-title">Свойства: ${escapeHtml(row.name || '(без имени)')}</div>
+		return `<div class="edit-data-palette">
+				<div class="palette-head">
+					<span class="section-title">Свойства: ${escapeHtml(row.name || '(без имени)')}</span>
+					<button type="button" class="palette-close" data-spalette-close="1" title="Закрыть">×</button>
+				</div>
 				<div class="edit-fields">
 					<div class="edit-row"><label class="edit-label">Имя</label><div class="edit-control">
 						<input class="edit-input" data-spath="${spath}" data-sfield="name" value="${escapeHtml(row.name)}" spellcheck="false" />
@@ -1219,8 +1232,7 @@
 					</div></div>
 					${typeRow}
 				</div>
-			</div>
-			<div class="palette-note">Свойства объекта — снимите выделение строки</div>`;
+			</div>`;
 	}
 
 	function structReadonlyListHtml(list) {

--- a/src/features/metadata/metadataObjectEditSpec.ts
+++ b/src/features/metadata/metadataObjectEditSpec.ts
@@ -1449,7 +1449,7 @@ function normalizeFieldValue(
  * Описание типа из webview: правим только примитивные типы с квалификаторами.
  * Ссылочный и составной тип отдаём как есть с диска — их правит пикер типов.
  */
-function normalizeTypeValue(value: unknown, rawValue: unknown): { ok: boolean; value?: unknown } {
+export function normalizeTypeValue(value: unknown, rawValue: unknown): { ok: boolean; value?: unknown } {
 	if (!isRecord(value) || !Array.isArray(value.types)) {
 		return { ok: false };
 	}

--- a/src/features/metadata/metadataObjectPropertiesPanel.ts
+++ b/src/features/metadata/metadataObjectPropertiesPanel.ts
@@ -23,6 +23,7 @@ import {
 	buildDocumentEditTabs,
 	buildEnumEditTabs,
 	buildRegisterEditTabs,
+	normalizeTypeValue,
 	type MetadataEditOption,
 	type MetadataEditTabSpec,
 } from './metadataObjectEditSpec';
@@ -109,6 +110,8 @@ interface MetadataPanelStructureLists {
 }
 
 interface MetadataNamedRow {
+	/** Описание типа как его отдаёт md-sparrow; у ТЧ и значений перечисления его нет. */
+	type?: unknown;
 	name: string;
 	synonymRu: string;
 	comment: string;
@@ -722,6 +725,7 @@ function asNamedRows(value: unknown): MetadataNamedRow[] {
 			name,
 			synonymRu: typeof record.synonymRu === 'string' ? record.synonymRu : '',
 			comment: typeof record.comment === 'string' ? record.comment : '',
+			type: record.type ?? undefined,
 		});
 	}
 	return out;
@@ -1401,6 +1405,8 @@ interface MetadataStructRowEdit {
 	name: string;
 	synonymRu: string;
 	deleted: boolean;
+	/** Описание типа из палитры; undefined — тип не правили. */
+	type?: unknown;
 }
 
 interface MetadataTabularSectionEdit extends MetadataStructRowEdit {
@@ -1467,6 +1473,7 @@ function parseStructRow(value: unknown): MetadataStructRowEdit | null {
 		name: typeof value.name === 'string' ? value.name.trim() : '',
 		synonymRu: typeof value.synonymRu === 'string' ? value.synonymRu : '',
 		deleted: value.deleted === true,
+		type: isRecord(value.type) ? value.type : undefined,
 	};
 }
 
@@ -1661,13 +1668,22 @@ export function structOpsFromEdits(edits: MetadataStructureEdits, objectXml: str
 	return ops;
 }
 
-/** Переносит синонимы строк структуры из правок в DTO (перечитанный после операций структуры). */
+/** Тип строки состава: правило то же, что у свойств объекта — ссылочный и составной не переписываем. */
+function normalizeStructRowType(edited: unknown, raw: unknown): unknown {
+	const normalized = normalizeTypeValue(edited, raw);
+	return normalized.ok ? normalized.value : undefined;
+}
+
+/**
+ * Переносит правки строк структуры (синоним, тип) в DTO, перечитанный после операций структуры.
+ * Тип нормализуется тем же правилом, что и у свойств объекта: ссылочный и составной не переписываем.
+ */
 export function applySynonymEdits(dto: Record<string, unknown>, edits: MetadataStructureEdits): void {
 	for (const list of edits.lists) {
-		const synonyms = new Map<string, string>();
+		const edited = new Map<string, MetadataStructRowEdit>();
 		for (const row of list.rows) {
 			if (!row.deleted && row.name) {
-				synonyms.set(row.name, row.synonymRu);
+				edited.set(row.name, row);
 			}
 		}
 		const dtoList = dto[list.kind];
@@ -1675,8 +1691,19 @@ export function applySynonymEdits(dto: Record<string, unknown>, edits: MetadataS
 			continue;
 		}
 		for (const raw of dtoList) {
-			if (isRecord(raw) && typeof raw.name === 'string' && synonyms.has(raw.name)) {
-				raw.synonymRu = synonyms.get(raw.name);
+			if (!isRecord(raw) || typeof raw.name !== 'string') {
+				continue;
+			}
+			const row = edited.get(raw.name);
+			if (!row) {
+				continue;
+			}
+			raw.synonymRu = row.synonymRu;
+			if (row.type !== undefined) {
+				const normalized = normalizeStructRowType(row.type, raw.type);
+				if (normalized !== undefined) {
+					raw.type = normalized;
+				}
 			}
 		}
 	}

--- a/src/test/metadata/metadataObjectEditSpec.test.ts
+++ b/src/test/metadata/metadataObjectEditSpec.test.ts
@@ -824,3 +824,52 @@ suite('metadataObjectEditSpec: состав регистра', () => {
 		);
 	});
 });
+
+suite('metadataObjectEditSpec: палитра строки состава', () => {
+	const panel = require('../../features/metadata/metadataObjectPropertiesPanel');
+
+	function editsWithType(type: unknown) {
+		return panel.parseStructureEdits({
+			lists: [{ kind: 'attributes', rows: [{ originalName: 'Валюта', name: 'Валюта', synonymRu: 'Валюта', type }] }],
+			tabularSections: [],
+		});
+	}
+
+	function dtoWith(type: unknown): Record<string, unknown> {
+		return {
+			kind: 'catalog',
+			attributes: [{ name: 'Валюта', synonymRu: 'Валюта', comment: '', type }],
+		};
+	}
+
+	test('тип строки сохраняется вместе с синонимом', () => {
+		const dto = dtoWith({ types: ['xs:string'], stringQualifiers: { length: '10', allowedLength: 'VARIABLE' } });
+		panel.applySynonymEdits(
+			dto,
+			editsWithType({ types: ['xs:string'], stringQualifiers: { length: '50', allowedLength: 'FIXED' } })
+		);
+		const attribute = (dto.attributes as Array<Record<string, unknown>>)[0];
+		assert.deepStrictEqual(attribute.type, {
+			types: ['xs:string'],
+			stringQualifiers: { length: '50', allowedLength: 'FIXED' },
+		});
+	});
+
+	test('ссылочный тип строки из палитры не переписывается', () => {
+		const ref = { types: ['cfg:CatalogRef.Валюты'] };
+		const dto = dtoWith(ref);
+		panel.applySynonymEdits(dto, editsWithType({ types: ['xs:string'] }));
+		assert.deepStrictEqual(
+			(dto.attributes as Array<Record<string, unknown>>)[0].type,
+			ref,
+			'ссылочный тип правит пикер типов, а не палитра'
+		);
+	});
+
+	test('строка без правки типа оставляет тип как на диске', () => {
+		const type = { types: ['xs:decimal'], numberQualifiers: { digits: '15', fractionDigits: '2', allowedSign: 'ANY' } };
+		const dto = dtoWith(type);
+		panel.applySynonymEdits(dto, editsWithType(undefined));
+		assert.deepStrictEqual((dto.attributes as Array<Record<string, unknown>>)[0].type, type);
+	});
+});


### PR DESCRIPTION
Первый этап палитры свойств (#214) для реквизитов: тип у реквизитов, измерений и ресурсов правится из панели.

## Как это выглядит
На вкладке «Данные» выбираем строку слева — справа появляется её палитра: имя, синоним, комментарий и **тип** с квалификаторами (у строки — длина и допустимая длина, у числа — длина, точность, неотрицательность, у даты — состав даты). Пока строка не выбрана, справа остаются свойства объекта, как было.

Раскладка повторяет редактор EDT: состав слева, свойства выбранного справа. Отличие: у нас палитра живёт в правой колонке вкладки, а не отдельной панелью среды.

## Что под этим
- **md-sparrow (#5):** тип попал в DTO реквизитов, измерений и ресурсов — читается вместе с именем и синонимом, пишется точечной заменой элемента `Type` нужного дочернего объекта.
- **Расширение:** правки состава несут тип; при сохранении он проходит ту же нормализацию, что и тип константы — из webview принимаются только примитивные типы, ссылочные и составные остаются как на диске (пикер типов — следующий этап #214).

## Чего пока нет
Остальные свойства палитры из референса EDT (индексирование, полнотекстовый поиск, история данных, использование, подсказка, проверка заполнения, параметры выбора) — их ещё нет в DTO. Это следующий шаг: DTO разрастётся, а палитра просто получит новые поля.

## Проверка
452 теста, eslint и tsc зелёные. Новые: тип строки сохраняется вместе с синонимом; ссылочный тип из палитры не переписывается; строка без правки типа оставляет тип как на диске. Со стороны md-sparrow — сквозной тест на живом справочнике: длина строкового реквизита 9 → 77, число строк в файле не меняется, значение читается обратно.

Требует md-sparrow#5. Основан на #227 — вливать после него.

Руками: свойства `_ДемоБанковскиеСчета` → «Данные» → выбрать реквизит «НомерСчета» → в палитре сменить длину → Сохранить → в `git diff` меняется только `<v8:Length>`.