### PR TITLE
fix(metadata): требуем минимальную версию md-sparrow

### DIFF
--- a/src/app/registerCoreCommands.ts
+++ b/src/app/registerCoreCommands.ts
@@ -40,7 +40,7 @@ export function registerCoreCommands(
 		artifact: new ArtifactCommands(),
 		externalFiles: new ExternalFilesCommands(),
 		support: new SupportCommands(),
-		dependencies: new DependenciesCommands(),
+		dependencies: new DependenciesCommands(context),
 		run: new RunCommands(),
 		test: new TestCommands(),
 		setVersion: new SetVersionCommands(),

--- a/src/commands/dependenciesCommands.ts
+++ b/src/commands/dependenciesCommands.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { ensureOvm } from '../shared/ovmComponent';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import * as fs from 'node:fs/promises';
@@ -19,7 +20,7 @@ import { streamDownload } from '../shared/githubReleaseLoader';
 const log = logger.scope('commands');
 
 /** URL для скачивания OVM (OneScript Version Manager) */
-const OVM_DOWNLOAD_URL = 'https://github.com/oscript-library/ovm/releases/latest/download/ovm.exe';
+
 
 /** Регулярное выражение для извлечения ВерсияСреды из packagedef (например .ВерсияСреды("2.0.0")) */
 const PACKAGEDEF_VERSIYA_SREDY = /\.ВерсияСреды\s*\(\s*["']([^"']+)["']\s*\)/;
@@ -205,6 +206,11 @@ async function showGitAdminCommands(): Promise<void> {
  * Команды для управления зависимостями проекта
  */
 export class DependenciesCommands extends BaseCommand {
+	/** Контекст нужен для кэша компонентов: OVM берём оттуда. */
+	constructor(private readonly context: vscode.ExtensionContext) {
+		super();
+	}
+
 	/**
 	 * Предлагает перезапустить окно после инициализации проекта, чтобы гарантированно
 	 * обновились контейнеры и команды, зависящие от контекста проекта.
@@ -808,26 +814,22 @@ export class DependenciesCommands extends BaseCommand {
 		const commandName = getInstallOneScriptCommandName();
 		const { mtimeMs: ovmOscriptMtimeBefore } = getOvmOscriptPathAndMtime();
 
+		// OVM берём из кэша компонентов: качаем средствами Node, а не оболочкой.
+		// Связку «скачать .exe в оболочке и запустить» антивирусы метят как trojan-downloader.
+		let ovmPath: string;
+		try {
+			ovmPath = await ensureOvm(this.context);
+		} catch (error) {
+			const errMsg = (error as Error).message;
+			log.error(`Не удалось получить OVM: ${errMsg}`);
+			logger.show();
+			vscode.window.showErrorMessage(`Не удалось получить OVM: ${errMsg}`);
+			return;
+		}
+
 		if (process.platform === 'win32') {
-			const tempOvm = path.join(os.tmpdir(), 'ovm.exe');
 			const ovmBinHint = String.raw`$env:LOCALAPPDATA\ovm\current\bin`;
-
-			// OVM скачиваем средствами Node, а не Invoke-WebRequest в PowerShell.
-			// Связку «скачать .exe в оболочке и запустить» антивирусы метят как trojan-downloader.
-			try {
-				await vscode.window.withProgress(
-					{ location: vscode.ProgressLocation.Notification, title: `Загрузка OVM (${ovmVersion})…` },
-					() => streamDownload(OVM_DOWNLOAD_URL, tempOvm, {})
-				);
-			} catch (error) {
-				const errMsg = (error as Error).message;
-				log.error(`Не удалось скачать OVM: ${errMsg}. URL: ${OVM_DOWNLOAD_URL}`);
-				logger.show();
-				vscode.window.showErrorMessage(`Не удалось скачать OVM: ${errMsg}`);
-				return;
-			}
-
-			const ovmQuoted = `'${tempOvm.replaceAll("'", "''")}'`;
+			const ovmQuoted = `'${ovmPath.replaceAll("'", "''")}'`;
 			const psScript = [
 				'$ErrorActionPreference = "Stop"',
 				`Write-Host "Установка OneScript (${ovmVersion})..."`,
@@ -844,13 +846,10 @@ export class DependenciesCommands extends BaseCommand {
 			});
 			terminal.show();
 		} else {
-			const tmpOvm = path.join(os.tmpdir(), 'ovm.exe');
 			const shScript = [
-				`echo "Загрузка OVM из ${OVM_DOWNLOAD_URL}..."`,
-				`curl -L -o ${JSON.stringify(tmpOvm)} ${JSON.stringify(OVM_DOWNLOAD_URL)}`,
 				`echo "Установка OneScript (${ovmVersion})..."`,
-				`mono ${JSON.stringify(tmpOvm)} install ${ovmVersion}`,
-				`mono ${JSON.stringify(tmpOvm)} use ${ovmVersion}`,
+				`mono ${JSON.stringify(ovmPath)} install ${ovmVersion}`,
+				`mono ${JSON.stringify(ovmPath)} use ${ovmVersion}`,
 				`echo "Готово. Путь OVM: $HOME/.local/share/ovm/current/bin"`
 			].join(' && ');
 

--- a/src/features/metadata/mdSparrowBootstrap.ts
+++ b/src/features/metadata/mdSparrowBootstrap.ts
@@ -24,7 +24,6 @@ import {
 } from '../../shared/githubReleaseLoader';
 import {
 	MD_SPARROW_DEFAULT_REPO,
-	MD_SPARROW_MIN_VERSION,
 	MD_SPARROW_JAR_REGEX,
 	adoptiumBinaryUrl,
 } from './mdSparrowConstants';
@@ -46,7 +45,6 @@ const MD_SPARROW_SPEC: ReleaseComponentSpec = {
 	stampName: '.jar-info.json',
 	assetRegex: MD_SPARROW_JAR_REGEX,
 	label: 'md-sparrow',
-	minVersion: MD_SPARROW_MIN_VERSION,
 	extract: false,
 };
 

--- a/src/features/metadata/mdSparrowBootstrap.ts
+++ b/src/features/metadata/mdSparrowBootstrap.ts
@@ -24,6 +24,7 @@ import {
 } from '../../shared/githubReleaseLoader';
 import {
 	MD_SPARROW_DEFAULT_REPO,
+	MD_SPARROW_MIN_VERSION,
 	MD_SPARROW_JAR_REGEX,
 	adoptiumBinaryUrl,
 } from './mdSparrowConstants';
@@ -45,6 +46,7 @@ const MD_SPARROW_SPEC: ReleaseComponentSpec = {
 	stampName: '.jar-info.json',
 	assetRegex: MD_SPARROW_JAR_REGEX,
 	label: 'md-sparrow',
+	minVersion: MD_SPARROW_MIN_VERSION,
 	extract: false,
 };
 

--- a/src/features/metadata/mdSparrowConstants.ts
+++ b/src/features/metadata/mdSparrowConstants.ts
@@ -9,12 +9,6 @@ export const MD_SPARROW_DEFAULT_REPO = 'yellow-hammer/md-sparrow';
 /** Паттерн имени fat-JAR в релизе GitHub */
 export const MD_SPARROW_JAR_REGEX = /md-sparrow-.*-all\.jar$/i;
 
-/**
- * Минимальная версия md-sparrow: панели свойств зовут операции, которых в более старых JAR нет
- * (чтение и запись свойств документов, перечислений, констант, регистров, дерево подсистем).
- * Кэш старее этой версии загрузчик перекачивает.
- */
-export const MD_SPARROW_MIN_VERSION = '0.4.0';
 
 /** API Temurin JRE 21 (ga) — редирект на архив */
 export function adoptiumBinaryUrl(): string {

--- a/src/features/metadata/mdSparrowConstants.ts
+++ b/src/features/metadata/mdSparrowConstants.ts
@@ -9,6 +9,13 @@ export const MD_SPARROW_DEFAULT_REPO = 'yellow-hammer/md-sparrow';
 /** Паттерн имени fat-JAR в релизе GitHub */
 export const MD_SPARROW_JAR_REGEX = /md-sparrow-.*-all\.jar$/i;
 
+/**
+ * Минимальная версия md-sparrow: панели свойств зовут операции, которых в более старых JAR нет
+ * (чтение и запись свойств документов, перечислений, констант, регистров, дерево подсистем).
+ * Кэш старее этой версии загрузчик перекачивает.
+ */
+export const MD_SPARROW_MIN_VERSION = '0.4.0';
+
 /** API Temurin JRE 21 (ga) — редирект на архив */
 export function adoptiumBinaryUrl(): string {
 	const { os, arch } = adoptiumOsArch();

--- a/src/features/metadata/registerMetadataFeature.ts
+++ b/src/features/metadata/registerMetadataFeature.ts
@@ -16,6 +16,7 @@ import {
 	openExternalArtifactPropertiesPanel,
 	type ExternalArtifactPropertiesDto,
 } from './metadataExternalArtifactPropertiesPanel';
+import { cachedOvmTag, clearOvmCache } from '../../shared/ovmComponent';
 import { createMdSparrowMutationRunner } from './mdSparrowMutationQueue';
 import type { MetadataFilterViewProvider } from './metadataFilterView';
 import { MetadataSearchViewProvider } from './metadataSearchView';
@@ -1698,14 +1699,16 @@ export function registerMetadataFeature(
 			return loadProjectMetadataTree(context, root);
 		}),
 		vscode.commands.registerCommand('1c-platform-tools.components.update', async () => {
-			const [adapterTag, jarTag] = await Promise.all([
+			const [adapterTag, jarTag, ovmTag] = await Promise.all([
 				cachedOnecDebugAdapterTag(context),
 				cachedMdSparrowTag(context),
+				cachedOvmTag(context),
 			]);
 			const picked = await vscode.window.showQuickPick(
 				[
 					{ label: 'Отладчик', description: adapterTag ?? 'не загружен', value: 'adapter' as const, picked: true },
 					{ label: 'Дерево метаданных', description: jarTag ?? 'не загружен', value: 'jar' as const, picked: true },
+					{ label: 'OVM', description: ovmTag ?? 'не загружен', value: 'ovm' as const, picked: false },
 					{
 						label: 'Portable JRE',
 						description: portableJreCached(context) ? 'загружена' : 'не загружена',
@@ -1728,6 +1731,9 @@ export function registerMetadataFeature(
 			}
 			if (values.has('jar')) {
 				await clearMdSparrowJarCache(context);
+			}
+			if (values.has('ovm')) {
+				await clearOvmCache(context);
 			}
 			if (values.has('jre')) {
 				await clearPortableJreCache(context);

--- a/src/shared/githubReleaseLoader.ts
+++ b/src/shared/githubReleaseLoader.ts
@@ -48,11 +48,6 @@ export interface ReleaseComponentSpec {
 	label: string;
 	/** Распаковать архив (true) или сохранить файл как есть (false). */
 	extract: boolean;
-	/**
-	 * Минимальная версия компонента (`0.4.0`). Кэш старее переcкачиваем: без этого расширение
-	 * продолжало бы работать со старым JAR, где нужных операций ещё нет.
-	 */
-	minVersion?: string;
 }
 
 /** Результат загрузки: путь к файлу (extract=false) или к каталогу распаковки (extract=true). */
@@ -75,16 +70,21 @@ interface StampInfo {
  * Сравнение посегментно по числам; нечисловые теги — по строковому неравенству (консервативно).
  */
 /**
- * Версия тега ниже минимально требуемой.
- *
- * @param tag тег релиза (`v0.3.2`)
- * @param minVersion минимальная версия (`0.4.0`); пусто — требования нет
+ * Как часто спрашиваем GitHub о новой версии компонента: между проверками отдаём кэш.
+ * Столько же ждёт vsc-language-1c-bsl, на который мы ориентируемся.
  */
-export function isBelowMinVersion(tag: string, minVersion?: string): boolean {
-	if (!minVersion) {
-		return false;
+const UPDATE_CHECK_TTL_MS = 8 * 60 * 1000;
+
+/**
+ * Пора ли спрашивать GitHub о новой версии.
+ *
+ * @param lastCheckMs время последней проверки из штампа; пусто — не проверяли ни разу
+ */
+export function updateCheckDue(lastCheckMs: number | undefined, nowMs: number = Date.now()): boolean {
+	if (!lastCheckMs) {
+		return true;
 	}
-	return isNewerTag(minVersion, tag);
+	return nowMs - lastCheckMs >= UPDATE_CHECK_TTL_MS;
 }
 
 export function isNewerTag(candidate: string, current: string): boolean {
@@ -266,20 +266,42 @@ export async function ensureReleaseComponent(
 ): Promise<EnsuredComponent> {
 	const cached = await readStamp(baseDir, spec);
 	const cachedPath = cached?.assetPath ?? cached?.jarPath;
-	if (cached?.tag && cachedPath && fssync.existsSync(cachedPath)) {
-		if (!isBelowMinVersion(cached.tag, spec.minVersion)) {
-			log.debug(`${spec.label} из кэша: ${cachedPath} (${cached.tag})`);
-			return { tag: cached.tag, assetPath: cachedPath };
-		}
-		log.info(`${spec.label} в кэше ${cached.tag} старее ${spec.minVersion}: загружаем новый`);
+	const inCache =
+		cached?.tag && cachedPath && fssync.existsSync(cachedPath)
+			? { tag: cached.tag, assetPath: cachedPath }
+			: undefined;
+	if (inCache && !updateCheckDue(cached?.lastCheckMs)) {
+		log.debug(`${spec.label} из кэша: ${inCache.assetPath} (${inCache.tag})`);
+		return inCache;
 	}
 
 	const { owner, repo } = parseRepoSlug(spec.repoSlug);
 	const headers = githubHeaders(token);
-	log.info(`Загрузка ${spec.label} с GitHub (${owner}/${repo})…`);
-	const status = showStatus(`${spec.label}: загрузка…`);
+	let status = showStatus(`${spec.label}: проверка обновлений…`);
 	try {
-		const rel = await fetchLatestStableRelease(owner, repo, headers);
+		let rel: GithubRelease;
+		try {
+			rel = await fetchLatestStableRelease(owner, repo, headers);
+		} catch (e) {
+			if (!inCache) {
+				throw e;
+			}
+			// Без сети работаем на том, что уже загружено.
+			log.warn(`${spec.label}: не удалось проверить обновление: ${e instanceof Error ? e.message : String(e)}`);
+			return inCache;
+		}
+		if (inCache && !isNewerTag(rel.tag_name, inCache.tag)) {
+			await writeStamp(baseDir, spec, {
+				tag: inCache.tag,
+				assetPath: inCache.assetPath,
+				lastCheckMs: Date.now(),
+			});
+			log.debug(`${spec.label} актуален: ${inCache.tag}`);
+			return inCache;
+		}
+		log.info(`Загрузка ${spec.label} ${rel.tag_name} с GitHub (${owner}/${repo})…`);
+		status.dispose();
+		status = showStatus(`${spec.label}: загрузка…`);
 		const asset = pickAsset(rel, spec);
 		const destDir = path.join(baseDir, spec.cacheSubdir, rel.tag_name.replace(/[^\w.-]+/g, '_'));
 		await fs.rm(destDir, { recursive: true, force: true }).catch(() => undefined);
@@ -305,11 +327,6 @@ export async function ensureReleaseComponent(
 
 		await writeStamp(baseDir, spec, { tag: rel.tag_name, assetPath, lastCheckMs: Date.now() });
 		log.info(`${spec.label}: ${assetPath} (${rel.tag_name})`);
-		if (isBelowMinVersion(rel.tag_name, spec.minVersion)) {
-			void vscode.window.showWarningMessage(
-				`${spec.label} ${rel.tag_name} старее требуемой версии ${spec.minVersion}: часть возможностей не будет работать.`
-			);
-		}
 		return { tag: rel.tag_name, assetPath };
 	} finally {
 		status.dispose();

--- a/src/shared/githubReleaseLoader.ts
+++ b/src/shared/githubReleaseLoader.ts
@@ -48,6 +48,11 @@ export interface ReleaseComponentSpec {
 	label: string;
 	/** Распаковать архив (true) или сохранить файл как есть (false). */
 	extract: boolean;
+	/**
+	 * Минимальная версия компонента (`0.4.0`). Кэш старее переcкачиваем: без этого расширение
+	 * продолжало бы работать со старым JAR, где нужных операций ещё нет.
+	 */
+	minVersion?: string;
 }
 
 /** Результат загрузки: путь к файлу (extract=false) или к каталогу распаковки (extract=true). */
@@ -69,6 +74,19 @@ interface StampInfo {
  * Строго ли тег {@code candidate} новее {@code current} (теги стабильных релизов вида `v1.2.3`/`1.2.3`).
  * Сравнение посегментно по числам; нечисловые теги — по строковому неравенству (консервативно).
  */
+/**
+ * Версия тега ниже минимально требуемой.
+ *
+ * @param tag тег релиза (`v0.3.2`)
+ * @param minVersion минимальная версия (`0.4.0`); пусто — требования нет
+ */
+export function isBelowMinVersion(tag: string, minVersion?: string): boolean {
+	if (!minVersion) {
+		return false;
+	}
+	return isNewerTag(minVersion, tag);
+}
+
 export function isNewerTag(candidate: string, current: string): boolean {
 	const parts = (t: string): number[] =>
 		t
@@ -249,8 +267,11 @@ export async function ensureReleaseComponent(
 	const cached = await readStamp(baseDir, spec);
 	const cachedPath = cached?.assetPath ?? cached?.jarPath;
 	if (cached?.tag && cachedPath && fssync.existsSync(cachedPath)) {
-		log.debug(`${spec.label} из кэша: ${cachedPath} (${cached.tag})`);
-		return { tag: cached.tag, assetPath: cachedPath };
+		if (!isBelowMinVersion(cached.tag, spec.minVersion)) {
+			log.debug(`${spec.label} из кэша: ${cachedPath} (${cached.tag})`);
+			return { tag: cached.tag, assetPath: cachedPath };
+		}
+		log.info(`${spec.label} в кэше ${cached.tag} старее ${spec.minVersion}: загружаем новый`);
 	}
 
 	const { owner, repo } = parseRepoSlug(spec.repoSlug);
@@ -284,6 +305,11 @@ export async function ensureReleaseComponent(
 
 		await writeStamp(baseDir, spec, { tag: rel.tag_name, assetPath, lastCheckMs: Date.now() });
 		log.info(`${spec.label}: ${assetPath} (${rel.tag_name})`);
+		if (isBelowMinVersion(rel.tag_name, spec.minVersion)) {
+			void vscode.window.showWarningMessage(
+				`${spec.label} ${rel.tag_name} старее требуемой версии ${spec.minVersion}: часть возможностей не будет работать.`
+			);
+		}
 		return { tag: rel.tag_name, assetPath };
 	} finally {
 		status.dispose();

--- a/src/shared/ovmComponent.ts
+++ b/src/shared/ovmComponent.ts
@@ -1,0 +1,49 @@
+/**
+ * OVM как загружаемый компонент: скачивается из релизов GitHub в кэш расширения и берётся оттуда.
+ *
+ * Раньше `ovm.exe` качался во временный каталог при каждой установке OneScript, а на Linux и macOS
+ * ещё и через `curl` прямо в терминале. Теперь загрузка отделена от использования: файл лежит в
+ * globalStorage рядом с остальными компонентами, обновляется при выходе новой версии и доступен
+ * для проверки.
+ * @module ovmComponent
+ */
+import * as vscode from 'vscode';
+import {
+	cachedReleaseTag,
+	clearReleaseCache,
+	ensureReleaseComponent,
+	installBaseDir,
+	resolveGithubToken,
+	type ReleaseComponentSpec,
+} from './githubReleaseLoader';
+
+/** Релизы OVM: в каждом лежит один и тот же `ovm.exe` (на Linux и macOS запускается через Mono). */
+const OVM_SPEC: ReleaseComponentSpec = {
+	repoSlug: 'oscript-library/ovm',
+	cacheSubdir: 'ovm',
+	stampName: '.ovm.json',
+	assetRegex: /^ovm\.exe$/i,
+	label: 'OVM',
+	extract: false,
+};
+
+/**
+ * Путь к `ovm.exe` из кэша; при необходимости загружает или обновляет его.
+ *
+ * @param context контекст расширения (кэш живёт в globalStorage)
+ * @returns абсолютный путь к файлу
+ */
+export async function ensureOvm(context: vscode.ExtensionContext): Promise<string> {
+	const ensured = await ensureReleaseComponent(installBaseDir(context), OVM_SPEC, resolveGithubToken());
+	return ensured.assetPath;
+}
+
+/** Тег загруженного OVM или undefined, если он ещё не загружался. */
+export async function cachedOvmTag(context: vscode.ExtensionContext): Promise<string | undefined> {
+	return cachedReleaseTag(installBaseDir(context), OVM_SPEC);
+}
+
+/** Забывает загруженный OVM: следующее использование скачает его заново. */
+export async function clearOvmCache(context: vscode.ExtensionContext): Promise<void> {
+	await clearReleaseCache(installBaseDir(context), OVM_SPEC);
+}

--- a/src/test/utils/githubReleaseLoader.test.ts
+++ b/src/test/utils/githubReleaseLoader.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert';
-import { isBelowMinVersion, isNewerTag } from '../../shared/githubReleaseLoader';
+import { isNewerTag, updateCheckDue } from '../../shared/githubReleaseLoader';
 
 suite('githubReleaseLoader.isNewerTag', () => {
 	test('новее по patch/minor/major', () => {
@@ -24,19 +24,19 @@ suite('githubReleaseLoader.isNewerTag', () => {
 	});
 });
 
-suite('githubReleaseLoader: минимальная версия компонента', () => {
-	test('кэш старее требуемой версии считается негодным', () => {
-		assert.strictEqual(isBelowMinVersion('v0.3.2', '0.4.0'), true);
-		assert.strictEqual(isBelowMinVersion('0.3.9', '0.4.0'), true);
+suite('githubReleaseLoader: проверка обновлений', () => {
+	const now = 1_000_000_000_000;
+
+	test('без штампа проверяем сразу', () => {
+		assert.strictEqual(updateCheckDue(undefined, now), true);
 	});
 
-	test('кэш нужной версии и новее годится', () => {
-		assert.strictEqual(isBelowMinVersion('v0.4.0', '0.4.0'), false);
-		assert.strictEqual(isBelowMinVersion('v0.4.1', '0.4.0'), false);
-		assert.strictEqual(isBelowMinVersion('v1.0.0', '0.4.0'), false);
+	test('сразу после проверки отдаём кэш', () => {
+		assert.strictEqual(updateCheckDue(now - 60_000, now), false);
 	});
 
-	test('без требования подходит любой тег', () => {
-		assert.strictEqual(isBelowMinVersion('v0.0.1', undefined), false);
+	test('через восемь минут проверяем снова', () => {
+		assert.strictEqual(updateCheckDue(now - 8 * 60_000, now), true);
+		assert.strictEqual(updateCheckDue(now - 60 * 60_000, now), true);
 	});
 });

--- a/src/test/utils/githubReleaseLoader.test.ts
+++ b/src/test/utils/githubReleaseLoader.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert';
-import { isNewerTag } from '../../shared/githubReleaseLoader';
+import { isBelowMinVersion, isNewerTag } from '../../shared/githubReleaseLoader';
 
 suite('githubReleaseLoader.isNewerTag', () => {
 	test('новее по patch/minor/major', () => {
@@ -21,5 +21,22 @@ suite('githubReleaseLoader.isNewerTag', () => {
 	test('нечисловые теги — по строковому неравенству', () => {
 		assert.strictEqual(isNewerTag('nightly', 'nightly'), false);
 		assert.strictEqual(isNewerTag('nightly-2', 'nightly-1'), true);
+	});
+});
+
+suite('githubReleaseLoader: минимальная версия компонента', () => {
+	test('кэш старее требуемой версии считается негодным', () => {
+		assert.strictEqual(isBelowMinVersion('v0.3.2', '0.4.0'), true);
+		assert.strictEqual(isBelowMinVersion('0.3.9', '0.4.0'), true);
+	});
+
+	test('кэш нужной версии и новее годится', () => {
+		assert.strictEqual(isBelowMinVersion('v0.4.0', '0.4.0'), false);
+		assert.strictEqual(isBelowMinVersion('v0.4.1', '0.4.0'), false);
+		assert.strictEqual(isBelowMinVersion('v1.0.0', '0.4.0'), false);
+	});
+
+	test('без требования подходит любой тег', () => {
+		assert.strictEqual(isBelowMinVersion('v0.0.1', undefined), false);
 	});
 });


### PR DESCRIPTION
Без этого релиз сломается у тех, кто уже пользуется расширением.

## В чём дело
Загрузчик компонентов отдаёт JAR из кэша, ни разу не сверяя его версию: закэшированный однажды md-sparrow живёт вечно. После релиза расширения панели свойств начнут звать операции, которых в старом JAR нет (`cf-md-subsystem-tree`, `cf-md-dimension-*`, `cf-md-enum-value-*`, запись свойств документов, перечислений, констант, регистров), и пользователь получит «неизвестный op» вместо работающей панели.

## Что сделано
- У компонента появилась минимальная версия. Кэш старее её перекачиваем, а не отдаём.
- Для md-sparrow это `0.4.0` — версия, где есть все операции, которых требуют новые панели.
- Если в релизах нет нужной версии (например, JAR ещё не опубликован), показываем предупреждение вместо тихой поломки.

## Проверка
Тесты на решение о кэше: старее требуемой негодно, ровно требуемая и новее годится, без требования подходит любой тег. Всего 455 тестов, eslint и tsc зелёные.

Основан на #227 — вливать после него. Требует релиза md-sparrow 0.4.0 до релиза расширения.