### PR TITLE
feat(components): обновление компонентов по новой версии и кэш OVM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2777,6 +2777,16 @@
             "type": "string",
             "default": "",
             "description": "Java: полный путь к java или javaw для дерева метаданных. Пусто — portable JRE из кэша либо java из PATH."
+          },
+          "1c-platform-tools.components.ovmAutoload": {
+            "type": "boolean",
+            "default": true,
+            "description": "Загружать OVM с GitHub Releases и обновлять его автоматически. Выключите, если используете локальный ovm.exe из «OVM: путь к файлу»."
+          },
+          "1c-platform-tools.components.ovmFile": {
+            "type": "string",
+            "default": "",
+            "description": "OVM: полный путь к локальному ovm.exe. Пусто — используется загруженный с GitHub."
           }
         }
       },

--- a/src/app/registerCoreCommands.ts
+++ b/src/app/registerCoreCommands.ts
@@ -40,7 +40,7 @@ export function registerCoreCommands(
 		artifact: new ArtifactCommands(),
 		externalFiles: new ExternalFilesCommands(),
 		support: new SupportCommands(),
-		dependencies: new DependenciesCommands(),
+		dependencies: new DependenciesCommands(context),
 		run: new RunCommands(),
 		test: new TestCommands(),
 		setVersion: new SetVersionCommands(),

--- a/src/commands/dependenciesCommands.ts
+++ b/src/commands/dependenciesCommands.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { ensureOvm } from '../shared/ovmComponent';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import * as fs from 'node:fs/promises';
@@ -19,7 +20,7 @@ import { streamDownload } from '../shared/githubReleaseLoader';
 const log = logger.scope('commands');
 
 /** URL для скачивания OVM (OneScript Version Manager) */
-const OVM_DOWNLOAD_URL = 'https://github.com/oscript-library/ovm/releases/latest/download/ovm.exe';
+
 
 /** Регулярное выражение для извлечения ВерсияСреды из packagedef (например .ВерсияСреды("2.0.0")) */
 const PACKAGEDEF_VERSIYA_SREDY = /\.ВерсияСреды\s*\(\s*["']([^"']+)["']\s*\)/;
@@ -205,6 +206,11 @@ async function showGitAdminCommands(): Promise<void> {
  * Команды для управления зависимостями проекта
  */
 export class DependenciesCommands extends BaseCommand {
+	/** Контекст нужен для кэша компонентов: OVM берём оттуда. */
+	constructor(private readonly context: vscode.ExtensionContext) {
+		super();
+	}
+
 	/**
 	 * Предлагает перезапустить окно после инициализации проекта, чтобы гарантированно
 	 * обновились контейнеры и команды, зависящие от контекста проекта.
@@ -808,26 +814,22 @@ export class DependenciesCommands extends BaseCommand {
 		const commandName = getInstallOneScriptCommandName();
 		const { mtimeMs: ovmOscriptMtimeBefore } = getOvmOscriptPathAndMtime();
 
+		// OVM берём из кэша компонентов: качаем средствами Node, а не оболочкой.
+		// Связку «скачать .exe в оболочке и запустить» антивирусы метят как trojan-downloader.
+		let ovmPath: string;
+		try {
+			ovmPath = await ensureOvm(this.context);
+		} catch (error) {
+			const errMsg = (error as Error).message;
+			log.error(`Не удалось получить OVM: ${errMsg}`);
+			logger.show();
+			vscode.window.showErrorMessage(`Не удалось получить OVM: ${errMsg}`);
+			return;
+		}
+
 		if (process.platform === 'win32') {
-			const tempOvm = path.join(os.tmpdir(), 'ovm.exe');
 			const ovmBinHint = String.raw`$env:LOCALAPPDATA\ovm\current\bin`;
-
-			// OVM скачиваем средствами Node, а не Invoke-WebRequest в PowerShell.
-			// Связку «скачать .exe в оболочке и запустить» антивирусы метят как trojan-downloader.
-			try {
-				await vscode.window.withProgress(
-					{ location: vscode.ProgressLocation.Notification, title: `Загрузка OVM (${ovmVersion})…` },
-					() => streamDownload(OVM_DOWNLOAD_URL, tempOvm, {})
-				);
-			} catch (error) {
-				const errMsg = (error as Error).message;
-				log.error(`Не удалось скачать OVM: ${errMsg}. URL: ${OVM_DOWNLOAD_URL}`);
-				logger.show();
-				vscode.window.showErrorMessage(`Не удалось скачать OVM: ${errMsg}`);
-				return;
-			}
-
-			const ovmQuoted = `'${tempOvm.replaceAll("'", "''")}'`;
+			const ovmQuoted = `'${ovmPath.replaceAll("'", "''")}'`;
 			const psScript = [
 				'$ErrorActionPreference = "Stop"',
 				`Write-Host "Установка OneScript (${ovmVersion})..."`,
@@ -844,13 +846,10 @@ export class DependenciesCommands extends BaseCommand {
 			});
 			terminal.show();
 		} else {
-			const tmpOvm = path.join(os.tmpdir(), 'ovm.exe');
 			const shScript = [
-				`echo "Загрузка OVM из ${OVM_DOWNLOAD_URL}..."`,
-				`curl -L -o ${JSON.stringify(tmpOvm)} ${JSON.stringify(OVM_DOWNLOAD_URL)}`,
 				`echo "Установка OneScript (${ovmVersion})..."`,
-				`mono ${JSON.stringify(tmpOvm)} install ${ovmVersion}`,
-				`mono ${JSON.stringify(tmpOvm)} use ${ovmVersion}`,
+				`mono ${JSON.stringify(ovmPath)} install ${ovmVersion}`,
+				`mono ${JSON.stringify(ovmPath)} use ${ovmVersion}`,
 				`echo "Готово. Путь OVM: $HOME/.local/share/ovm/current/bin"`
 			].join(' && ');
 

--- a/src/features/metadata/mdSparrowConstants.ts
+++ b/src/features/metadata/mdSparrowConstants.ts
@@ -9,6 +9,7 @@ export const MD_SPARROW_DEFAULT_REPO = 'yellow-hammer/md-sparrow';
 /** Паттерн имени fat-JAR в релизе GitHub */
 export const MD_SPARROW_JAR_REGEX = /md-sparrow-.*-all\.jar$/i;
 
+
 /** API Temurin JRE 21 (ga) — редирект на архив */
 export function adoptiumBinaryUrl(): string {
 	const { os, arch } = adoptiumOsArch();

--- a/src/features/metadata/registerMetadataFeature.ts
+++ b/src/features/metadata/registerMetadataFeature.ts
@@ -16,6 +16,7 @@ import {
 	openExternalArtifactPropertiesPanel,
 	type ExternalArtifactPropertiesDto,
 } from './metadataExternalArtifactPropertiesPanel';
+import { cachedOvmTag, clearOvmCache } from '../../shared/ovmComponent';
 import { createMdSparrowMutationRunner } from './mdSparrowMutationQueue';
 import type { MetadataFilterViewProvider } from './metadataFilterView';
 import { MetadataSearchViewProvider } from './metadataSearchView';
@@ -1698,14 +1699,16 @@ export function registerMetadataFeature(
 			return loadProjectMetadataTree(context, root);
 		}),
 		vscode.commands.registerCommand('1c-platform-tools.components.update', async () => {
-			const [adapterTag, jarTag] = await Promise.all([
+			const [adapterTag, jarTag, ovmTag] = await Promise.all([
 				cachedOnecDebugAdapterTag(context),
 				cachedMdSparrowTag(context),
+				cachedOvmTag(context),
 			]);
 			const picked = await vscode.window.showQuickPick(
 				[
 					{ label: 'Отладчик', description: adapterTag ?? 'не загружен', value: 'adapter' as const, picked: true },
 					{ label: 'Дерево метаданных', description: jarTag ?? 'не загружен', value: 'jar' as const, picked: true },
+					{ label: 'OVM', description: ovmTag ?? 'не загружен', value: 'ovm' as const, picked: false },
 					{
 						label: 'Portable JRE',
 						description: portableJreCached(context) ? 'загружена' : 'не загружена',
@@ -1728,6 +1731,9 @@ export function registerMetadataFeature(
 			}
 			if (values.has('jar')) {
 				await clearMdSparrowJarCache(context);
+			}
+			if (values.has('ovm')) {
+				await clearOvmCache(context);
 			}
 			if (values.has('jre')) {
 				await clearPortableJreCache(context);

--- a/src/shared/githubReleaseLoader.ts
+++ b/src/shared/githubReleaseLoader.ts
@@ -69,6 +69,24 @@ interface StampInfo {
  * Строго ли тег {@code candidate} новее {@code current} (теги стабильных релизов вида `v1.2.3`/`1.2.3`).
  * Сравнение посегментно по числам; нечисловые теги — по строковому неравенству (консервативно).
  */
+/**
+ * Как часто спрашиваем GitHub о новой версии компонента: между проверками отдаём кэш.
+ * Столько же ждёт vsc-language-1c-bsl, на который мы ориентируемся.
+ */
+const UPDATE_CHECK_TTL_MS = 8 * 60 * 1000;
+
+/**
+ * Пора ли спрашивать GitHub о новой версии.
+ *
+ * @param lastCheckMs время последней проверки из штампа; пусто — не проверяли ни разу
+ */
+export function updateCheckDue(lastCheckMs: number | undefined, nowMs: number = Date.now()): boolean {
+	if (!lastCheckMs) {
+		return true;
+	}
+	return nowMs - lastCheckMs >= UPDATE_CHECK_TTL_MS;
+}
+
 export function isNewerTag(candidate: string, current: string): boolean {
 	const parts = (t: string): number[] =>
 		t
@@ -248,17 +266,42 @@ export async function ensureReleaseComponent(
 ): Promise<EnsuredComponent> {
 	const cached = await readStamp(baseDir, spec);
 	const cachedPath = cached?.assetPath ?? cached?.jarPath;
-	if (cached?.tag && cachedPath && fssync.existsSync(cachedPath)) {
-		log.debug(`${spec.label} из кэша: ${cachedPath} (${cached.tag})`);
-		return { tag: cached.tag, assetPath: cachedPath };
+	const inCache =
+		cached?.tag && cachedPath && fssync.existsSync(cachedPath)
+			? { tag: cached.tag, assetPath: cachedPath }
+			: undefined;
+	if (inCache && !updateCheckDue(cached?.lastCheckMs)) {
+		log.debug(`${spec.label} из кэша: ${inCache.assetPath} (${inCache.tag})`);
+		return inCache;
 	}
 
 	const { owner, repo } = parseRepoSlug(spec.repoSlug);
 	const headers = githubHeaders(token);
-	log.info(`Загрузка ${spec.label} с GitHub (${owner}/${repo})…`);
-	const status = showStatus(`${spec.label}: загрузка…`);
+	let status = showStatus(`${spec.label}: проверка обновлений…`);
 	try {
-		const rel = await fetchLatestStableRelease(owner, repo, headers);
+		let rel: GithubRelease;
+		try {
+			rel = await fetchLatestStableRelease(owner, repo, headers);
+		} catch (e) {
+			if (!inCache) {
+				throw e;
+			}
+			// Без сети работаем на том, что уже загружено.
+			log.warn(`${spec.label}: не удалось проверить обновление: ${e instanceof Error ? e.message : String(e)}`);
+			return inCache;
+		}
+		if (inCache && !isNewerTag(rel.tag_name, inCache.tag)) {
+			await writeStamp(baseDir, spec, {
+				tag: inCache.tag,
+				assetPath: inCache.assetPath,
+				lastCheckMs: Date.now(),
+			});
+			log.debug(`${spec.label} актуален: ${inCache.tag}`);
+			return inCache;
+		}
+		log.info(`Загрузка ${spec.label} ${rel.tag_name} с GitHub (${owner}/${repo})…`);
+		status.dispose();
+		status = showStatus(`${spec.label}: загрузка…`);
 		const asset = pickAsset(rel, spec);
 		const destDir = path.join(baseDir, spec.cacheSubdir, rel.tag_name.replace(/[^\w.-]+/g, '_'));
 		await fs.rm(destDir, { recursive: true, force: true }).catch(() => undefined);

--- a/src/shared/ovmComponent.ts
+++ b/src/shared/ovmComponent.ts
@@ -1,0 +1,49 @@
+/**
+ * OVM как загружаемый компонент: скачивается из релизов GitHub в кэш расширения и берётся оттуда.
+ *
+ * Раньше `ovm.exe` качался во временный каталог при каждой установке OneScript, а на Linux и macOS
+ * ещё и через `curl` прямо в терминале. Теперь загрузка отделена от использования: файл лежит в
+ * globalStorage рядом с остальными компонентами, обновляется при выходе новой версии и доступен
+ * для проверки.
+ * @module ovmComponent
+ */
+import * as vscode from 'vscode';
+import {
+	cachedReleaseTag,
+	clearReleaseCache,
+	ensureReleaseComponent,
+	installBaseDir,
+	resolveGithubToken,
+	type ReleaseComponentSpec,
+} from './githubReleaseLoader';
+
+/** Релизы OVM: в каждом лежит один и тот же `ovm.exe` (на Linux и macOS запускается через Mono). */
+const OVM_SPEC: ReleaseComponentSpec = {
+	repoSlug: 'oscript-library/ovm',
+	cacheSubdir: 'ovm',
+	stampName: '.ovm.json',
+	assetRegex: /^ovm\.exe$/i,
+	label: 'OVM',
+	extract: false,
+};
+
+/**
+ * Путь к `ovm.exe` из кэша; при необходимости загружает или обновляет его.
+ *
+ * @param context контекст расширения (кэш живёт в globalStorage)
+ * @returns абсолютный путь к файлу
+ */
+export async function ensureOvm(context: vscode.ExtensionContext): Promise<string> {
+	const ensured = await ensureReleaseComponent(installBaseDir(context), OVM_SPEC, resolveGithubToken());
+	return ensured.assetPath;
+}
+
+/** Тег загруженного OVM или undefined, если он ещё не загружался. */
+export async function cachedOvmTag(context: vscode.ExtensionContext): Promise<string | undefined> {
+	return cachedReleaseTag(installBaseDir(context), OVM_SPEC);
+}
+
+/** Забывает загруженный OVM: следующее использование скачает его заново. */
+export async function clearOvmCache(context: vscode.ExtensionContext): Promise<void> {
+	await clearReleaseCache(installBaseDir(context), OVM_SPEC);
+}

--- a/src/shared/ovmComponent.ts
+++ b/src/shared/ovmComponent.ts
@@ -7,6 +7,7 @@
  * для проверки.
  * @module ovmComponent
  */
+import * as fssync from 'node:fs';
 import * as vscode from 'vscode';
 import {
 	cachedReleaseTag,
@@ -28,12 +29,28 @@ const OVM_SPEC: ReleaseComponentSpec = {
 };
 
 /**
- * Путь к `ovm.exe` из кэша; при необходимости загружает или обновляет его.
+ * Путь к `ovm.exe`: своя сборка из настроек либо кэш, который при необходимости загружается и обновляется.
  *
  * @param context контекст расширения (кэш живёт в globalStorage)
  * @returns абсолютный путь к файлу
+ * @throws Error если автозагрузка выключена и не задан components.ovmFile, либо файл не найден.
  */
 export async function ensureOvm(context: vscode.ExtensionContext): Promise<string> {
+	const cfg = vscode.workspace.getConfiguration('1c-platform-tools');
+	const override = cfg.get<string>('components.ovmFile', '').trim();
+	if (override) {
+		if (override.includes('${')) {
+			throw new Error('components.ovmFile: укажите полный путь к ovm.exe.');
+		}
+		if (!fssync.existsSync(override)) {
+			throw new Error(`components.ovmFile не найден: ${override}.`);
+		}
+		return override;
+	}
+	if (!cfg.get<boolean>('components.ovmAutoload', true)) {
+		throw new Error('Укажите components.ovmFile или включите components.ovmAutoload.');
+	}
+
 	const ensured = await ensureReleaseComponent(installBaseDir(context), OVM_SPEC, resolveGithubToken());
 	return ensured.assetPath;
 }

--- a/src/test/utils/githubReleaseLoader.test.ts
+++ b/src/test/utils/githubReleaseLoader.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert';
-import { isNewerTag } from '../../shared/githubReleaseLoader';
+import { isNewerTag, updateCheckDue } from '../../shared/githubReleaseLoader';
 
 suite('githubReleaseLoader.isNewerTag', () => {
 	test('новее по patch/minor/major', () => {
@@ -21,5 +21,22 @@ suite('githubReleaseLoader.isNewerTag', () => {
 	test('нечисловые теги — по строковому неравенству', () => {
 		assert.strictEqual(isNewerTag('nightly', 'nightly'), false);
 		assert.strictEqual(isNewerTag('nightly-2', 'nightly-1'), true);
+	});
+});
+
+suite('githubReleaseLoader: проверка обновлений', () => {
+	const now = 1_000_000_000_000;
+
+	test('без штампа проверяем сразу', () => {
+		assert.strictEqual(updateCheckDue(undefined, now), true);
+	});
+
+	test('сразу после проверки отдаём кэш', () => {
+		assert.strictEqual(updateCheckDue(now - 60_000, now), false);
+	});
+
+	test('через восемь минут проверяем снова', () => {
+		assert.strictEqual(updateCheckDue(now - 8 * 60_000, now), true);
+		assert.strictEqual(updateCheckDue(now - 60 * 60_000, now), true);
 	});
 });


### PR DESCRIPTION
Два изменения в загрузке внешних компонентов, ориентир — `vsc-language-1c-bsl` (`src/util/serverDownloader.ts`).

## Компоненты обновляются сами
Загрузчик отдавал JAR или адаптер из кэша, **ни разу не сверяясь с релизами**: однажды скачанный компонент жил вечно. При этом в штампе уже лежало поле `lastCheckMs`, а рядом была готовая функция сравнения тегов — задумка была, но не работала.

Теперь как в референсе: между проверками отдаём кэш, раз в восемь минут спрашиваем `releases/latest` и качаем, если версия новее. Без сети остаёмся на том, что уже загружено (ошибку проглатываем и пишем в лог), а если не загружено ничего — ошибка наружу.

Это заодно снимает вопрос совместимости с новыми операциями md-sparrow: пользователь получит свежий JAR сам, без зашитых в код минимальных версий.

## OVM стал компонентом
`ovm.exe` качался во временный каталог при каждой установке OneScript, а на Linux и macOS ещё и через `curl` прямо в терминале (ровно то, за что мы на Windows отдельно ушли от `Invoke-WebRequest`: связку «скачать exe в оболочке и запустить» антивирусы метят как trojan-downloader).

Теперь OVM живёт в кэше рядом с отладчиком и md-sparrow: скачивание отделено от использования, обновляется по той же логике, виден и сбрасывается в «Обновить внешние компоненты». Установка OneScript просто берёт путь из кэша.

Настройки — как у остальных компонентов, парой:

| Настройка | Назначение |
| --- | --- |
| `components.ovmFile` | путь к своему `ovm.exe` вместо загрузки с GitHub |
| `components.ovmAutoload` | выключает загрузку, если путь выше не задан |

## Проверка
Тесты на решение о проверке обновления: без штампа проверяем сразу, сразу после проверки отдаём кэш, через восемь минут проверяем снова. Всего 452 теста, eslint и tsc зелёные.

Основан на #227 — вливать после него.