### PR TITLE
fix(vrunner): передаём явный settingsFile в план команд

### DIFF
--- a/src/commands/baseCommand.ts
+++ b/src/commands/baseCommand.ts
@@ -318,7 +318,7 @@ export abstract class BaseCommand {
 		if (gate) {
 			return gate === 'blocked' ? undefined : gate;
 		}
-		const steps = await this.vrunner.planIntent(intent);
+		const steps = await this.vrunner.planIntent(intent, opts?.settingsFile);
 		if (steps.length === 1) {
 			return this.runVRunner(steps[0], opts, terminalName, artifact, commandId, true);
 		}
@@ -338,7 +338,7 @@ export abstract class BaseCommand {
 		if (gate) {
 			return gate === 'blocked' ? undefined : gate;
 		}
-		const steps = await this.vrunner.planIntents(intents);
+		const steps = await this.vrunner.planIntents(intents, opts?.settingsFile);
 		return this.runVRunnerSequential(steps, opts, terminalName, commandId, true);
 	}
 

--- a/src/commands/extensionsCommands.ts
+++ b/src/commands/extensionsCommands.ts
@@ -96,7 +96,7 @@ export class ExtensionsCommands extends BaseCommand {
 		const intents = await Promise.all(selectedFolders.map(async (folder) =>
 			buildIntent(folder, await resolveExtensionNameFromSrc(path.join(cfeRoot, folder)))
 		));
-		const steps = await this.vrunner.planIntents(intents);
+		const steps = await this.vrunner.planIntents(intents, opts?.settingsFile);
 
 		if (opts?.wait === true) {
 			return this.runVRunnerSequential(steps, opts, commandName, commandId, true);
@@ -319,7 +319,7 @@ export class ExtensionsCommands extends BaseCommand {
 			intents.push({ kind: 'infobase.updateExtension', extensionName, common: ibConnectionParam });
 		}
 
-		const steps = await this.vrunner.planIntents(intents);
+		const steps = await this.vrunner.planIntents(intents, opts?.settingsFile);
 		await this.vrunner.executeVRunnerCommandsInSequence(steps, {
 			cwd: workspaceRoot,
 			name: commandName.title,
@@ -457,7 +457,7 @@ export class ExtensionsCommands extends BaseCommand {
 			const cfeFilePath = path.join(buildPath, 'cfe', cfeFile);
 			const commandParam = EPF_COMMANDS.LOAD_EXTENSION(cfeFilePath);
 			return { kind: 'run.enterprise' as const, command: commandParam, execute: epfPath, common: ibConnectionParam };
-		}));
+		}), opts?.settingsFile);
 
 		if (opts?.wait === true) {
 			return this.runVRunnerSequential(steps, opts, commandName.title, commandName.id, true);
@@ -692,7 +692,7 @@ export class ExtensionsCommands extends BaseCommand {
 				out: path.join(cfePath, folderName),
 				common: ibConnectionParam,
 			};
-		})));
+		})), opts?.settingsFile);
 
 		if (opts?.wait === true) {
 			return this.runVRunnerSequential(steps, opts, commandName.title, commandName.id, true);

--- a/src/shared/vrunnerManager.ts
+++ b/src/shared/vrunnerManager.ts
@@ -728,16 +728,18 @@ export class VRunnerManager {
 	 * с `appendOverrides: false`, чтобы не дописывать параметры повторно.
 	 *
 	 * @param intents - Намерения (каждое может развернуться в несколько команд)
+	 * @param settingsFile - Явный файл настроек; без него берётся активный профиль
 	 * @returns Список команд vrunner (каждая — массив аргументов)
 	 */
-	public async planIntents(intents: VRunnerIntent[]): Promise<string[][]> {
+	public async planIntents(intents: VRunnerIntent[], settingsFile?: string): Promise<string[][]> {
 		const version = await this.getVRunnerVersion();
 		const adapter = selectCliAdapter(version);
 		const cli3 = version !== undefined && isAtLeast(version, VRUNNER_FEATURES.cli3);
 		const overrides = this.getActiveEnvOverrideArgs();
 		// Именованный профиль подставляется во ВСЕ команды через --settings; для
 		// базового профиля параметр пустой (vrunner читает env.json сам).
-		const settingsParam = this.getActiveSettingsParamIfExists();
+		// Явно переданный файл настроек имеет приоритет над активным профилем.
+		const settingsParam = this.getSettingsParam(settingsFile);
 
 		const steps: string[][] = [];
 		for (const intent of intents) {
@@ -760,8 +762,8 @@ export class VRunnerManager {
 	/**
 	 * План одного намерения (см. {@link planIntents}).
 	 */
-	public async planIntent(intent: VRunnerIntent): Promise<string[][]> {
-		return this.planIntents([intent]);
+	public async planIntent(intent: VRunnerIntent, settingsFile?: string): Promise<string[][]> {
+		return this.planIntents([intent], settingsFile);
 	}
 
 	/**


### PR DESCRIPTION
## Проблема

При вызове инструмента `test_vanessa` с параметром `settingsFile` прогон всё равно шёл по активному профилю: в ERP отбирались smoke-сценарии вместо init-сценариев с тегом `@FirstStart`.

Причина не в MCP-сервере, а в последнем шаге на стороне расширения. Цепочка целая почти до конца: MCP кладёт `settingsFile` в аргументы, IPC-приёмник раскладывает его в `optsForCommand`. Дальше всё сходится в `planIntents` — единственную точку, где намерение превращается в аргументы CLI, — и там жёстко вызывался `getActiveSettingsParamIfExists()`, то есть всегда активный профиль.

При этом рядом уже лежал `getSettingsParam(settingsFile?)` с нужной логикой (`settingsFile ? ['--settings', file] : активный`). У метода не было ни одного вызывающего: написали, подключить забыли.

## Решение

Протянули `settingsFile` из `CommandExecutionOptions` в `planIntents`/`planIntent` и задействовали `getSettingsParam`.

Правка охватывает не только `test_vanessa`: через `runIntent`/`runIntentsSequential` в `baseCommand.ts` идёт основная масса команд, плюс четыре прямых вызова `planIntents` в `extensionsCommands.ts`.

Теперь `test_vanessa` с `settingsFile: tools/vrunner.init.json` даёт `vrunner vanessa --settings tools/vrunner.init.json`.

## Совместимость

Без явного `settingsFile` поведение не меняется: `getSettingsParam(undefined)` возвращает ровно то же, что возвращал прежний вызов.

## Проверка

- `tsc --noEmit` — чисто
- `eslint` по изменённым файлам — чисто
- `npm test` — 452 passing, exit 0

На живом проекте с vrunner не проверялось: тестов на `planIntents` в репозитории нет, класс завязан на vscode.

## Связанные задачи

Исправляет yellow-hammer/mcp-1c-platform-tools#25 (issue в другом репозитории, автоматически не закроется — закрыть вручную после мержа).

Задел под #208: `planIntents` больше не игнорирует переданные аргументы.
