### PR TITLE
ci: убрали бампы зависимостей из changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -42,6 +42,8 @@ commit_parsers = [
     { message = "^test", group = "<!-- 6 -->Тестирование" },
     { message = "^chore\\(release\\)", skip = true },
     { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^build\\(deps.*\\)", skip = true },
+    { message = "^ci\\(deps.*\\)", skip = true },
     { message = "^chore\\(pr\\)", skip = true },
     { message = "^chore\\(pull\\)", skip = true },
     { message = "^chore|^ci", group = "<!-- 7 -->Обслуживание" },

--- a/src/commands/baseCommand.ts
+++ b/src/commands/baseCommand.ts
@@ -318,7 +318,7 @@ export abstract class BaseCommand {
 		if (gate) {
 			return gate === 'blocked' ? undefined : gate;
 		}
-		const steps = await this.vrunner.planIntent(intent);
+		const steps = await this.vrunner.planIntent(intent, opts?.settingsFile);
 		if (steps.length === 1) {
 			return this.runVRunner(steps[0], opts, terminalName, artifact, commandId, true);
 		}
@@ -338,7 +338,7 @@ export abstract class BaseCommand {
 		if (gate) {
 			return gate === 'blocked' ? undefined : gate;
 		}
-		const steps = await this.vrunner.planIntents(intents);
+		const steps = await this.vrunner.planIntents(intents, opts?.settingsFile);
 		return this.runVRunnerSequential(steps, opts, terminalName, commandId, true);
 	}
 

--- a/src/commands/extensionsCommands.ts
+++ b/src/commands/extensionsCommands.ts
@@ -96,7 +96,7 @@ export class ExtensionsCommands extends BaseCommand {
 		const intents = await Promise.all(selectedFolders.map(async (folder) =>
 			buildIntent(folder, await resolveExtensionNameFromSrc(path.join(cfeRoot, folder)))
 		));
-		const steps = await this.vrunner.planIntents(intents);
+		const steps = await this.vrunner.planIntents(intents, opts?.settingsFile);
 
 		if (opts?.wait === true) {
 			return this.runVRunnerSequential(steps, opts, commandName, commandId, true);
@@ -319,7 +319,7 @@ export class ExtensionsCommands extends BaseCommand {
 			intents.push({ kind: 'infobase.updateExtension', extensionName, common: ibConnectionParam });
 		}
 
-		const steps = await this.vrunner.planIntents(intents);
+		const steps = await this.vrunner.planIntents(intents, opts?.settingsFile);
 		await this.vrunner.executeVRunnerCommandsInSequence(steps, {
 			cwd: workspaceRoot,
 			name: commandName.title,
@@ -457,7 +457,7 @@ export class ExtensionsCommands extends BaseCommand {
 			const cfeFilePath = path.join(buildPath, 'cfe', cfeFile);
 			const commandParam = EPF_COMMANDS.LOAD_EXTENSION(cfeFilePath);
 			return { kind: 'run.enterprise' as const, command: commandParam, execute: epfPath, common: ibConnectionParam };
-		}));
+		}), opts?.settingsFile);
 
 		if (opts?.wait === true) {
 			return this.runVRunnerSequential(steps, opts, commandName.title, commandName.id, true);
@@ -692,7 +692,7 @@ export class ExtensionsCommands extends BaseCommand {
 				out: path.join(cfePath, folderName),
 				common: ibConnectionParam,
 			};
-		})));
+		})), opts?.settingsFile);
 
 		if (opts?.wait === true) {
 			return this.runVRunnerSequential(steps, opts, commandName.title, commandName.id, true);

--- a/src/shared/vrunnerManager.ts
+++ b/src/shared/vrunnerManager.ts
@@ -728,16 +728,18 @@ export class VRunnerManager {
 	 * с `appendOverrides: false`, чтобы не дописывать параметры повторно.
 	 *
 	 * @param intents - Намерения (каждое может развернуться в несколько команд)
+	 * @param settingsFile - Явный файл настроек; без него берётся активный профиль
 	 * @returns Список команд vrunner (каждая — массив аргументов)
 	 */
-	public async planIntents(intents: VRunnerIntent[]): Promise<string[][]> {
+	public async planIntents(intents: VRunnerIntent[], settingsFile?: string): Promise<string[][]> {
 		const version = await this.getVRunnerVersion();
 		const adapter = selectCliAdapter(version);
 		const cli3 = version !== undefined && isAtLeast(version, VRUNNER_FEATURES.cli3);
 		const overrides = this.getActiveEnvOverrideArgs();
 		// Именованный профиль подставляется во ВСЕ команды через --settings; для
 		// базового профиля параметр пустой (vrunner читает env.json сам).
-		const settingsParam = this.getActiveSettingsParamIfExists();
+		// Явно переданный файл настроек имеет приоритет над активным профилем.
+		const settingsParam = this.getSettingsParam(settingsFile);
 
 		const steps: string[][] = [];
 		for (const intent of intents) {
@@ -760,8 +762,8 @@ export class VRunnerManager {
 	/**
 	 * План одного намерения (см. {@link planIntents}).
 	 */
-	public async planIntent(intent: VRunnerIntent): Promise<string[][]> {
-		return this.planIntents([intent]);
+	public async planIntent(intent: VRunnerIntent, settingsFile?: string): Promise<string[][]> {
+		return this.planIntents([intent], settingsFile);
 	}
 
 	/**


### PR DESCRIPTION
В `cliff.toml` бампы Dependabot скрывались только по префиксу `chore(deps)`, а обновления GitHub Actions он коммитит как `ci(deps)`. Правило `^chore|^ci` затягивало их в «Обслуживание»: в changelog ближайшего релиза 0.8.0 набиралось восемь строк вида `ci(deps): bump actions/checkout from 4 to 7`.

Намерение в конфиге было, правило просто не покрывало все префиксы. Скрыли `chore(deps*)`, `build(deps*)` и `ci(deps*)`.

## Проверка
`git-cliff --unreleased` на клоне репозитория: все восемь строк с бампами ушли из «Обслуживания». В разделе остались два настоящих коммита («Добавили конфигурацию Dependabot», «Исключили мажорные обновления typescript в Dependabot») — это реальная работа, а не шум. Остальные разделы не изменились.

Парный PR для md-sparrow: yellow-hammer/md-sparrow#9.