### PR TITLE
fix(commands): агентные вызовы не открывают окна выбора

### DIFF
--- a/src/commands/commandRegistry.ts
+++ b/src/commands/commandRegistry.ts
@@ -91,16 +91,32 @@ export function registerCommands(
 	];
 	disposables.push(...skillsCommands);
 
+	// Агентный вызов (MCP/IPC всегда передаёт объект опций) не должен открывать
+	// окно выбора: пользователь может быть не за экраном (web-сессия, телефон)
+	const rejectAgentInteractive = (arg: unknown, hint: string): StructuredCommandResult | undefined => {
+		if (typeof arg === 'object' && arg !== null) {
+			return {
+				success: false,
+				exitCode: 1,
+				stdout: '',
+				stderr: `Команда открывает окно выбора и недоступна агенту. ${hint}`,
+			};
+		}
+		return undefined;
+	};
+
 	// Команды служебных файлов
 	const serviceFilesCommands = [
-		vscode.commands.registerCommand('1c-platform-tools.serviceFiles.create', () =>
-			commands.serviceFiles.pickAndCreate()
+		vscode.commands.registerCommand('1c-platform-tools.serviceFiles.create', (arg?: unknown) =>
+			rejectAgentInteractive(arg, 'Используйте serviceFiles.createRecommendedSet, createGitignore, createGitattributes, createEnvJson или serviceFiles.ensure с id файла.')
+				?? commands.serviceFiles.pickAndCreate()
 		),
-		vscode.commands.registerCommand('1c-platform-tools.serviceFiles.ensure', (specId?: string) => {
+		vscode.commands.registerCommand('1c-platform-tools.serviceFiles.ensure', (specId?: unknown) => {
 			if (typeof specId === 'string') {
 				return commands.serviceFiles.ensure(specId);
 			}
-			return commands.serviceFiles.pickAndCreate();
+			return rejectAgentInteractive(specId, 'Передайте id служебного файла строкой (например, launchProfile).')
+				?? commands.serviceFiles.pickAndCreate();
 		}),
 		vscode.commands.registerCommand('1c-platform-tools.serviceFiles.createGitignore', () =>
 			commands.serviceFiles.createGitignore()

--- a/src/features/testing/configureTestingCommand.ts
+++ b/src/features/testing/configureTestingCommand.ts
@@ -105,9 +105,20 @@ export function registerConfigureTestingCommand(vrunner: VRunnerManager): vscode
 			}
 		];
 
-		// список фреймворков в опциях — неинтерактивный вызов (агент, MCP)
+		// объект опций — агентный вызов (MCP/IPC передаёт его всегда); визард в
+		// этом контексте открывать нельзя: пользователь может быть не за экраном
 		let selectedKeys: Set<string>;
 		const nonInteractive = Array.isArray(opts?.frameworks);
+		if (opts !== undefined && !nonInteractive) {
+			const message =
+				'Настройка тестов без параметра frameworks требует выбора в UI; ' +
+				'передайте frameworks (vanessa, xunit, yaxunit, onescript, onebdd)';
+			if (wait) {
+				return configureResult(false, message);
+			}
+			vscode.window.showErrorMessage(message);
+			return;
+		}
 		if (nonInteractive) {
 			const knownKeys = new Set<string>(frameworks.map((framework) => framework.key));
 			const requested = (opts?.frameworks ?? []).map((key) => String(key).trim().toLowerCase());
@@ -122,12 +133,6 @@ export function registerConfigureTestingCommand(vrunner: VRunnerManager): vscode
 			}
 			selectedKeys = new Set(requested);
 		} else {
-			if (wait) {
-				return configureResult(
-					false,
-					'Настройка тестов без параметра frameworks требует выбора в UI; передайте frameworks (vanessa, xunit, yaxunit, onescript, onebdd)'
-				);
-			}
 			const picks = frameworks.map((framework) => ({
 				...framework,
 				picked: config.get<boolean>(`testing.frameworks.${framework.key}`, framework.defaultEnabled)


### PR DESCRIPTION
На живом прогоне ssl_3_1 агент вызвал `testing_configure` без `frameworks` — на экране пользователя открылся визард фреймворков и вызов повис (скриншот в обсуждении); в первом прогоне так же висел `serviceFiles.create` до таймаута IPC 300 с.

Признак агентного вызова: MCP/IPC всегда передаёт объект опций первым аргументом, а палитра и command-ссылки — ничего. Интерактивные команды (`testing.configure` без `frameworks`, `serviceFiles.create`, `serviceFiles.ensure` без строкового id) при объекте-аргументе теперь сразу возвращают структурированную ошибку с подсказкой по неинтерактивным параметрам, не трогая UI.

Закрывает третий пункт #236 для самых горячих команд; остальные интерактивные команды — по мере надобности в рамках #236.

Проверка: tsc, eslint, 452 теста зелёные.