### PR TITLE
feat(metadata): создание пустого расширения из дерева метаданных

### DIFF
--- a/package.json
+++ b/package.json
@@ -564,6 +564,13 @@
         "category": "1C: Метаданные"
       },
       {
+        "command": "1c-platform-tools.metadata.initEmptyCfe",
+        "title": "Создать новое расширение",
+        "shortTitle": "Создать расширение",
+        "icon": "$(extensions)",
+        "category": "1C: Метаданные"
+      },
+      {
         "command": "1c-platform-tools.metadata.openObjectProperties",
         "title": "Свойства объекта",
         "category": "1C: Метаданные"
@@ -2190,7 +2197,7 @@
           "group": "navigation@30"
         },
         {
-          "command": "1c-platform-tools.metadata.initEmptyCf",
+          "submenu": "1c-platform-tools.metadata.createMenu",
           "when": "view == 1c-platform-tools-metadata-tree",
           "group": "navigation@0"
         },
@@ -2719,6 +2726,16 @@
           "group": "1_view@2"
         }
       ],
+      "1c-platform-tools.metadata.createMenu": [
+        {
+          "command": "1c-platform-tools.metadata.initEmptyCf",
+          "group": "navigation@0"
+        },
+        {
+          "command": "1c-platform-tools.metadata.initEmptyCfe",
+          "group": "navigation@1"
+        }
+      ],
       "1c-platform-tools.metadata.overflowMenu": [
         {
           "command": "1c-platform-tools.components.update",
@@ -2741,6 +2758,11 @@
         "id": "1c-platform-tools.metadata.overflowMenu",
         "label": "Ещё",
         "icon": "$(ellipsis)"
+      },
+      {
+        "id": "1c-platform-tools.metadata.createMenu",
+        "label": "Создать",
+        "icon": "$(add)"
       }
     ],
     "keybindings": [

--- a/src/features/metadata/mdSparrowParams.ts
+++ b/src/features/metadata/mdSparrowParams.ts
@@ -65,6 +65,7 @@ export type MdSparrowOp =
 	| 'cf-md-object-set'
 	| 'cf-configuration-properties-set'
 	| 'init-empty-cf'
+	| 'init-empty-cfe'
 	| 'add-md-object'
 	// чтение (read-json)
 	| 'cf-md-object-get'
@@ -84,6 +85,14 @@ export interface MdSparrowParams {
 	objectXml?: string;
 	artifactsRoot?: string;
 	targetCfRoot?: string;
+	/** Каталог создаваемого расширения (init-empty-cfe). */
+	targetCfeRoot?: string;
+	/** Configuration.xml расширяемой конфигурации: источник режимов совместимости. */
+	mainConfigurationXml?: string;
+	/** Префикс имён объектов расширения. */
+	namePrefix?: string;
+	/** Назначение расширения: patch, customization или add-on. */
+	purpose?: string;
 	projectRoot?: string;
 	/** Каталоги исходников относительно projectRoot; пусто — стандартные src/cf, src/cfe, src/epf, src/erf. */
 	cfDir?: string;

--- a/src/features/metadata/registerMetadataFeature.ts
+++ b/src/features/metadata/registerMetadataFeature.ts
@@ -1595,6 +1595,95 @@ export function registerMetadataFeature(
 				void vscode.window.showInformationMessage('XML для выбранного узла не найден.');
 			}
 		),
+		vscode.commands.registerCommand('1c-platform-tools.metadata.initEmptyCfe', async () => {
+			await runMdSparrowMutation(async () => {
+				const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+				if (!root) {
+					void vscode.window.showInformationMessage('Нет открытой папки проекта.');
+					return;
+				}
+				const configurationXml = metadataTreeProvider.configurationXml;
+				if (!configurationXml || !fs.existsSync(configurationXml)) {
+					void vscode.window.showInformationMessage(
+						'Не найдена выгрузка конфигурации: режимы совместимости расширения берутся из неё.'
+					);
+					return;
+				}
+
+				const name = await vscode.window.showInputBox({
+					title: 'Новое расширение',
+					prompt: 'Имя расширения',
+					validateInput: (value) =>
+						value.trim() === '' ? 'Имя обязательно' : undefined,
+				});
+				if (!name) {
+					return;
+				}
+				const namePrefix = await vscode.window.showInputBox({
+					title: 'Новое расширение',
+					prompt: 'Префикс имён объектов; можно оставить пустым',
+					value: '',
+				});
+				if (namePrefix === undefined) {
+					return;
+				}
+				const purposeItem = await vscode.window.showQuickPick(
+					[
+						{ label: 'Дополнение', description: 'add-on', value: 'add-on' },
+						{ label: 'Адаптация', description: 'customization', value: 'customization' },
+						{ label: 'Исправление', description: 'patch', value: 'patch' },
+					],
+					{ title: 'Назначение расширения' }
+				);
+				if (!purposeItem) {
+					return;
+				}
+
+				const cfeRoot = path.join(
+					root,
+					VRunnerManager.getInstance(context).getCfePath(),
+					name.trim()
+				);
+				if (fs.existsSync(cfeRoot)) {
+					void vscode.window.showErrorMessage(`Каталог расширения уже есть: ${cfeRoot}`);
+					return;
+				}
+
+				try {
+					const runtime = await ensureMdSparrowRuntime(context);
+					const version = await mdSparrowSchemaFlagFromConfigurationXml(configurationXml);
+					if (!version) {
+						return;
+					}
+					const res = await runMdSparrowParamsMutation(
+						runtime,
+						{
+							op: 'init-empty-cfe',
+							targetCfeRoot: cfeRoot,
+							schemaVersion: version,
+							name: name.trim(),
+							namePrefix: namePrefix.trim() === '' ? undefined : namePrefix.trim(),
+							purpose: purposeItem.value,
+							mainConfigurationXml: configurationXml,
+						},
+						{ cwd: root }
+					);
+					if (res.exitCode !== 0) {
+						const errText = (res.stderr.trim() || res.stdout.trim() || `код ${res.exitCode}`).slice(
+							0,
+							MD_SPARROW_CLI_ERR_PREVIEW
+						);
+						void vscode.window.showErrorMessage(errText);
+						return;
+					}
+					await metadataTreeProvider.refresh();
+					notifyQuiet(`Расширение ${name.trim()} создано.`);
+				} catch (e) {
+					const msg = e instanceof Error ? e.message : String(e);
+					void vscode.window.showErrorMessage(msg.slice(0, MD_SPARROW_CLI_ERR_PREVIEW));
+				}
+			});
+		}),
 		vscode.commands.registerCommand('1c-platform-tools.metadata.initEmptyCf', async () => {
 			await runMdSparrowMutation(async () => {
 				const cfRoot = metadataTreeProvider.resolveCfRoot();


### PR DESCRIPTION
Команда «Создать новое расширение» рядом с «Создать новую конфигурацию» в дереве метаданных.

Спрашивает имя, префикс имён (можно оставить пустым - платформа так и делает) и назначение: дополнение, адаптация или исправление. Каталог берётся из настроек проекта, версия формата и режимы совместимости - из выгрузки конфигурации, поэтому расширение подходит к ней сразу.

Режим совместимости расширений конфигурация объявляет отдельным свойством. На демонстрационной конфигурации БСП это видно: `ConfigurationExtensionCompatibilityMode` там `Version8_3_27`, а общий `CompatibilityMode` - `Version8_3_24`. Берётся первое.

Каркас пишет md-sparrow операцией `init-empty-cfe` (yellow-hammer/md-sparrow#19), прямой записи XML в расширении нет.

Требует md-sparrow с этой операцией: до её выхода в релиз путь к локальной сборке задаётся настройкой «Дерево метаданных: путь к файлу».