### PR TITLE
fix(configuration): выгрузка изменений в src/cf на 8.3.27

### DIFF
--- a/src/commands/configurationCommands.ts
+++ b/src/commands/configurationCommands.ts
@@ -105,11 +105,13 @@ export class ConfigurationCommands extends BaseCommand {
 
 		const ibConnectionParam = await this.vrunner.getIbConnectionParam();
 		const dumpIncrCmd = getDumpConfigurationIncrementToSrcCommandName();
+		// Файл версий не передаём: он лежит внутри каталога выгрузки, и платформа берёт его
+		// оттуда сама. Явный -configDumpInfoForChanges на файл внутри каталога ломает связку
+		// с -update: конфигуратор отвечает «Каталог не пуст» и инкремент не выполняется.
 		return this.runIntent(
 			{
 				kind: 'cf.dumpIbToSrc',
 				out: srcPath,
-				versionsFile: versionFileExists ? path.join(srcPath, 'ConfigDumpInfo.xml') : undefined,
 				common: ibConnectionParam,
 			},
 			opts,

--- a/src/shared/vrunnerCli/intents.ts
+++ b/src/shared/vrunnerCli/intents.ts
@@ -47,10 +47,12 @@ export type VRunnerIntent =
 	/**
 	 * Выгрузить конфигурацию ИБ в исходники.
 	 *
-	 * `versionsFile` (ConfigDumpInfo.xml) включает инкрементальную выгрузку в
-	 * 2.x (`--versions`); в 3.x такой опции нет — выполняется полная выгрузка.
+	 * Выгрузка в непустой каталог идёт инкрементально: vanessa-runner сам просит
+	 * у конфигуратора `-update`, а файл версий тот берёт из каталога выгрузки.
+	 * Отдельной опции для файла версий здесь нет: `--versions` на файл внутри
+	 * каталога выгрузки ломает инкремент - конфигуратор отвечает «Каталог не пуст».
 	 */
-	| { kind: 'cf.dumpIbToSrc'; out: string; versionsFile?: string; common?: CommonArgs }
+	| { kind: 'cf.dumpIbToSrc'; out: string; common?: CommonArgs }
 	/** Выгрузить конфигурацию ИБ в .cf. */
 	| { kind: 'cf.unloadIbToCf'; out: string; common?: CommonArgs }
 	/** Создать файл поставки (в 3.x команда пока не реализована — vrunner сообщит об этом сам). */

--- a/src/shared/vrunnerCli/v2Adapter.ts
+++ b/src/shared/vrunnerCli/v2Adapter.ts
@@ -54,13 +54,8 @@ export class V2CliAdapter implements VRunnerCliAdapter {
 				return [['compile', '--src', intent.src, '--out', intent.out, ...common(intent)]];
 			case 'cf.decompileFile':
 				return [['decompile', '--in', intent.file, '--out', intent.out, ...common(intent)]];
-			case 'cf.dumpIbToSrc': {
-				const args = ['decompile', '--current', '--out', intent.out, ...common(intent)];
-				if (intent.versionsFile !== undefined) {
-					args.push('--versions', intent.versionsFile);
-				}
-				return [args];
-			}
+			case 'cf.dumpIbToSrc':
+				return [['decompile', '--current', '--out', intent.out, ...common(intent)]];
 			case 'cf.unloadIbToCf':
 				return [['unload', intent.out, ...common(intent)]];
 			case 'cf.makeDist':

--- a/src/shared/vrunnerCli/v3Adapter.ts
+++ b/src/shared/vrunnerCli/v3Adapter.ts
@@ -127,8 +127,6 @@ export class V3CliAdapter implements VRunnerCliAdapter {
 				return [cmd(['cf', 'decompile'], ['--cf-file', intent.file, ...common(intent)], [intent.out])];
 			case 'cf.dumpIbToSrc':
 				// Без --cf-file исходники выгружаются из ИБ, указанной в --ibconnection.
-				// Опции --versions (инкрементальная выгрузка 2.x) в 3.x нет —
-				// versionsFile игнорируется, выполняется полная выгрузка.
 				return [cmd(['cf', 'decompile'], common(intent), [intent.out])];
 			case 'cf.unloadIbToCf':
 				return [cmd(['cf', 'unload'], common(intent), [intent.out])];

--- a/src/test/shared/vrunnerCliAdapters.test.ts
+++ b/src/test/shared/vrunnerCliAdapters.test.ts
@@ -97,7 +97,11 @@ suite('vrunnerCli: адаптеры v2/v3', () => {
 		);
 	});
 
-	test('cf.dumpIbToSrc', () => {
+	test('cf.dumpIbToSrc: файл версий не передаётся, его берут из каталога выгрузки', () => {
+		// --versions на файл внутри каталога выгрузки ломает инкремент: конфигуратор
+		// отвечает «Каталог не пуст», хотя тот же -update без него отрабатывает
+		const planned = v2.plan({ kind: 'cf.dumpIbToSrc', out: 'src/cf', common: conn }).flat();
+		assert.ok(!planned.includes('--versions'), 'файл версий ушёл в команду');
 		check(
 			{ kind: 'cf.dumpIbToSrc', out: 'src/cf', common: conn },
 			[['decompile', '--current', '--out', 'src/cf', ...conn]],


### PR DESCRIPTION
Закрывает #263.

## Причина

Команда передавала `--versions src/cf/ConfigDumpInfo.xml` - файл, который лежит внутри каталога выгрузки. vanessa-runner превращает это в `-configDumpInfoForChanges` на тот же файл, и в связке с `-update` конфигуратор отвечает «Каталог не пуст». Инкремент не выполнялся никогда, ошибка была всегда.

## Почему просто убрать опцию

По исходникам vanessa-runner 2.6.1 инкремент включает не `--versions`, а сама команда: `decompile --current` всегда идёт с `ТолькоИзмененные = Истина`, что даёт `-update -force`. `--versions` добавляет только `-configDumpInfoForChanges`. Файл версий конфигуратор берёт из каталога выгрузки сам - это и написано в описании его параметра.

## Проверено на платформе

8.3.27.2214, файловая база, каталог выгрузки с `ConfigDumpInfo.xml`, в базу загружено изменение (новый справочник):

- `decompile --current --out <кат> --versions <кат>/ConfigDumpInfo.xml` - **«Каталог не пуст»**, ровно как в задаче;
- `decompile --current --out <кат>` - выгрузка проходит, новый объект появляется в каталоге.

Без изменений в базе первый вариант отрабатывает: поэтому ошибка и выглядела плавающей - она вылезает только когда выгружать реально есть что.

## Заодно

Опция `versionsFile` убрана из модели команд: других вызовов у неё не было, а единственный способ, которым мы её применяли, ломал команду. Понадобится сравнение с копией файла версий вне каталога - вернётся с правильной семантикой.

Тест адаптеров проверяет, что `--versions` в команду не уходит. Прогон - 615 тестов, зелёный.