### PR TITLE
fix(pipelines): вывод шагов уходит в панель «Вывод»

### DIFF
--- a/src/commands/pipelineCommands.ts
+++ b/src/commands/pipelineCommands.ts
@@ -24,6 +24,7 @@ import {
 } from '../shared/pipelines/pipelineTypes';
 import {
 	formatRunSummary,
+	stepOutputTail,
 	runPipeline,
 	validatePipeline,
 	NodeExecutionResult,
@@ -38,6 +39,14 @@ const log = logger.scope('pipelines');
 
 /** Сколько символов вывода команды оболочки оставлять в отчёте */
 const SHELL_OUTPUT_LIMIT = 2_000;
+
+/**
+ * Сколько вывода шага уходит в панель «Вывод».
+ *
+ * Прогон конфигуратора выдаёт мегабайты, и целиком они панель забивают, поэтому
+ * хвост: интересное у vanessa-runner и платформы в конце.
+ */
+const STEP_OUTPUT_LIMIT = 20_000;
 
 /**
  * Префикс кодировки для команд оболочки: exec на Windows запускает cmd, где без
@@ -270,6 +279,25 @@ export class PipelineCommands extends BaseCommand {
 	 * @param opts - Опции выполнения, общие для узлов
 	 * @returns Исход узла
 	 */
+	/**
+	 * Пишет вывод шага в панель «Вывод».
+	 *
+	 * Шаги пайплайна идут захваченными, без терминала, поэтому без этого вывод
+	 * vanessa-runner и команд оболочки не виден нигде: остаются только отметки
+	 * «шаг выполнен» и отчёт по прогону.
+	 *
+	 * @param label - Название шага
+	 * @param output - Собранный вывод команды
+	 */
+	private logStepOutput(label: string, output: string): void {
+		const tail = stepOutputTail(output, STEP_OUTPUT_LIMIT);
+		if (tail === undefined) {
+			return;
+		}
+		log.info(`Вывод шага «${label}»:
+${tail}`);
+	}
+
 	private async runExtensionCommand(
 		node: PipelineNode,
 		opts?: CommandExecutionOptions
@@ -292,6 +320,11 @@ export class PipelineCommands extends BaseCommand {
 		if (!result) {
 			return { success: true };
 		}
+		this.logStepOutput(
+			nodeLabel(node, commandTitle),
+			`${result.stdout ?? ''}
+${result.stderr ?? ''}`
+		);
 		return {
 			success: result.success,
 			exitCode: result.exitCode,
@@ -324,6 +357,7 @@ export class PipelineCommands extends BaseCommand {
 				},
 				(error, stdout, stderr) => {
 					const output = `${stdout}${stderr}`.trim();
+					this.logStepOutput(nodeLabel(node, commandTitle), output);
 					if (!error) {
 						log.info(`Команда оболочки завершилась: ${script}`);
 						resolve({ success: true, exitCode: 0 });

--- a/src/shared/pipelines/pipelineRunner.ts
+++ b/src/shared/pipelines/pipelineRunner.ts
@@ -292,6 +292,25 @@ export function validatePipeline(pipeline: Pipeline): string[] {
 }
 
 /**
+ * Готовит вывод шага для панели «Вывод»: пустой отбрасывается, длинный обрезается с начала.
+ *
+ * Прогон конфигуратора выдаёт мегабайты, и целиком они панель забивают. Интересное у
+ * vanessa-runner и платформы в конце, поэтому остаётся хвост.
+ *
+ * @param output - Собранный вывод команды шага
+ * @param limit - Сколько символов оставить
+ * @returns Текст для панели или undefined, если выводить нечего
+ */
+export function stepOutputTail(output: string, limit: number): string | undefined {
+	const text = output.trim();
+	if (text === '') {
+		return undefined;
+	}
+	return text.length > limit ? `…
+${text.slice(-limit)}` : text;
+}
+
+/**
  * Собирает текстовую сводку прогона: по строке на выполненный узел.
  *
  * @param result - Результат прогона

--- a/src/test/shared/pipelineRunner.test.ts
+++ b/src/test/shared/pipelineRunner.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'node:assert';
 import {
 	runPipeline,
 	formatRunSummary,
+	stepOutputTail,
 	validatePipeline,
 	NodeExecutionResult,
 } from '../../shared/pipelines/pipelineRunner';
@@ -27,6 +28,26 @@ function executor(
 		return outcomes[item.id] ?? { success: true };
 	};
 }
+
+suite('Пайплайны: вывод шага', () => {
+	test('пустой вывод в панель не идёт', () => {
+		assert.strictEqual(stepOutputTail('', 100), undefined);
+		assert.strictEqual(stepOutputTail('   \n  ', 100), undefined);
+	});
+
+	test('короткий вывод идёт целиком', () => {
+		assert.strictEqual(stepOutputTail('загрузка завершена', 100), 'загрузка завершена');
+	});
+
+	test('длинный вывод обрезается с начала: интересное в конце', () => {
+		const long = 'начало'.repeat(100) + 'КОНЕЦ';
+		const tail = stepOutputTail(long, 20);
+
+		assert.ok(tail !== undefined);
+		assert.ok(tail.startsWith('…'), 'не видно, что вывод обрезан');
+		assert.ok(tail.endsWith('КОНЕЦ'), 'потерян конец вывода');
+	});
+});
 
 suite('прогон пайплайна: линейная цепочка', () => {
 	test('узлы идут по связям, а не по порядку объявления', async () => {


### PR DESCRIPTION
По жалобе из чата: запустил пайплайн - вывода vanessa-runner нигде нет.

## Причина

Обычная команда идёт задачей в терминал, и вывод виден там. Шаг пайплайна выполняется захваченным - `wait: true`, вывод собирается в результат и используется только чтобы понять, упал шаг или нет. В панель уходили лишь отметки «Шаг N: выполнен за X мс» и итоговый отчёт.

У команд оболочки было хуже: при успехе вывод отбрасывался целиком, при ошибке оставался хвост в 2000 символов.

Хуки при этом свой вывод пишут построчно - то есть в пайплайне это было упущение, а не решение.

## Что изменилось

Вывод каждого шага - и команды расширения, и команды оболочки - пишется в панель «Вывод» под заголовком с названием шага. Длинный обрезается с начала до 20 000 символов: прогон конфигуратора выдаёт мегабайты, а интересное у vanessa-runner и платформы в конце.

## Проверки

Три теста на обрезку: пустой вывод в панель не идёт, короткий идёт целиком, длинный обрезается с начала и сохраняет конец. Прогон - 618 тестов, зелёный.