### PR TITLE
chore(agent): убрали pathsOverride, который ничего не делал

### DIFF
--- a/src/shared/agentGate.ts
+++ b/src/shared/agentGate.ts
@@ -16,7 +16,6 @@ const AGENT_OPTION_KEYS = [
 	'projectPath',
 	'settingsFile',
 	'ibConnection',
-	'pathsOverride',
 	'sha',
 	'extensions',
 	'frameworks',

--- a/src/shared/commandExecutionTypes.ts
+++ b/src/shared/commandExecutionTypes.ts
@@ -49,14 +49,6 @@ export interface CommandExecutionOptions {
 	sessionConnections?: boolean;
 	/** Идентификатор или название пайплайна для запуска (pipelines.run). */
 	pipeline?: string;
-	/** Переопределения стандартных путей. */
-	pathsOverride?: {
-		cf?: string;
-		out?: string;
-		cfe?: string;
-		epf?: string;
-		erf?: string;
-	};
 }
 
 /**

--- a/src/shared/ipcServer.ts
+++ b/src/shared/ipcServer.ts
@@ -102,7 +102,7 @@ async function handlePing(
  * @param request — исходный IPC-запрос
  * @param commandId — идентификатор команды
  * @param projectPath — путь к корню проекта
- * @param flags — флаги выполнения (wait, settingsFile, ibConnection, pathsOverride)
+ * @param flags — флаги выполнения (wait, settingsFile, ibConnection и прочие)
  * @returns IPC-ответ со структурированным commandResult
  */
 async function handleExecuteCommandSync(
@@ -121,7 +121,6 @@ async function handleExecuteCommandSync(
 			projectPath,
 			settingsFile: flags.settingsFile,
 			ibConnection: flags.ibConnection,
-			pathsOverride: flags.pathsOverride,
 			sha: flags.sha,
 			extensions: flags.extensions,
 			frameworks: flags.frameworks,


### PR DESCRIPTION
Закрывает #269.

Параметр `pathsOverride` объявлялся в опциях выполнения, проходил через IPC, разрешался шлюзом агента и был описан агенту в MCP:

> Переопределение каталогов src/cf, build/out, src/cfe, src/epf, src/erf относительно projectPath

При этом не читался нигде: пути всегда брались из настроек. Агент передавал каталог, получал успех и работу с другим каталогом - худший вид молчания.

Реализовывать не стали: переопределение глобального пути на один вызов даёт ошибки, которые не поймаешь - половина команды отработает с одним каталогом, половина с другим. Раскладка решается настройками проекта, а другой проект у агента задаётся через `projectPath`.

Убрано из опций выполнения, шлюза агента и IPC. Парная правка в MCP - там же снимается описание.

Прогон - 618 тестов, зелёный.