### PR TITLE
fix(ui): кнопка «Показать журнал» раскрывает панель Output

### DIFF
--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -83,9 +83,16 @@ export const logger = {
 		return isVerboseLevel(getChannel().logLevel);
 	},
 
-	/** Показать панель Output с логами расширения */
+	/**
+	 * Показать панель Output с журналом расширения.
+	 *
+	 * Канал выбираем без перехвата фокуса, а панель раскрываем штатной командой: у части сборок
+	 * (в том числе Cursor) один только `show()` канал переключает, но панель не открывает, и по
+	 * кнопке «Показать журнал» внешне ничего не происходит.
+	 */
 	show(): void {
-		getChannel().show();
+		getChannel().show(true);
+		void vscode.commands.executeCommand('workbench.panel.output.focus');
 	},
 
 	/** Освободить канал (вызывать при деактивации расширения) */

--- a/src/test/shared/loggerShow.test.ts
+++ b/src/test/shared/loggerShow.test.ts
@@ -1,0 +1,14 @@
+import * as assert from 'node:assert';
+import * as vscode from 'vscode';
+import { logger } from '../../shared/logger';
+
+suite('logger: показ журнала', () => {
+	test('панель Output раскрывается штатной командой', async () => {
+		const commands = await vscode.commands.getCommands(true);
+
+		// команда раскрытия панели - часть контракта показа журнала: без неё кнопка «Показать
+		// журнал» в части сборок ничего не делает
+		assert.ok(commands.includes('workbench.panel.output.focus'), 'нет команды раскрытия панели Output');
+		assert.doesNotThrow(() => logger.show());
+	});
+});


### PR DESCRIPTION
По кнопке в сообщении об ошибке пайплайна панель Output не открывалась: `LogOutputChannel.show()` канал переключает, но панель в части сборок (в том числе Cursor) не раскрывает - внешне по кнопке ничего не происходило.

Теперь канал выбирается без перехвата фокуса, а панель раскрывается штатной командой `workbench.panel.output.focus`. Правка в самом логгере, поэтому чинит все кнопки «Показать журнал»: пайплайны, зависимости, установка компонентов.

## Проверка

Тест проверяет, что команда раскрытия панели есть в сборке и показ журнала не падает. 667 тестов зелёные, tsc и eslint чисто.

Проверить руками: уронить шаг пайплайна и нажать «Показать журнал» - должна открыться панель Output с каналом «1C: Platform Tools».