### PR TITLE
fix(pipelines): в отчёте видно, из-за чего упал шаг

### DIFF
--- a/src/commands/pipelineCommands.ts
+++ b/src/commands/pipelineCommands.ts
@@ -24,6 +24,7 @@ import {
 } from '../shared/pipelines/pipelineTypes';
 import {
 	formatRunSummary,
+	stepErrorLine,
 	stepOutputTail,
 	runPipeline,
 	validatePipeline,
@@ -369,7 +370,7 @@ ${result.stderr ?? ''}`
 					resolve({
 						success: false,
 						exitCode,
-						message: this.lastLine(tail) ?? `код возврата ${exitCode}`,
+						message: stepErrorLine(tail) ?? `код возврата ${exitCode}`,
 					});
 				}
 			);

--- a/src/shared/pipelines/pipelineRunner.ts
+++ b/src/shared/pipelines/pipelineRunner.ts
@@ -310,6 +310,38 @@ export function stepOutputTail(output: string, limit: number): string | undefine
 ${text.slice(-limit)}` : text;
 }
 
+/** Метки, которыми vanessa-runner, oscript и платформа помечают ошибки в выводе. */
+const ERROR_MARKERS = [/^КРИТИЧНАЯОШИБКА/i, /^ОШИБКА/i, /^ERROR/i, /^FATAL/i];
+
+/**
+ * Строка вывода, по которой видно, из-за чего упал шаг.
+ *
+ * Последняя строка вывода для этого не годится: у vanessa-runner там оказывается «Закрытие
+ * TestClient», а у конфигуратора - закрывающая скобка сообщения. Берём первую строку с меткой
+ * ошибки, самую тяжёлую метку вперёд; без меток - первую непустую строку.
+ *
+ * @param output Вывод шага (stderr и stdout).
+ * @param limit Сколько символов оставить.
+ * @returns Строка ошибки или undefined для пустого вывода.
+ */
+export function stepErrorLine(output: string, limit = 300): string | undefined {
+	const lines = output
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) => line !== '');
+	if (lines.length === 0) {
+		return undefined;
+	}
+	for (const marker of ERROR_MARKERS) {
+		const found = lines.find((line) => marker.test(line));
+		if (found) {
+			return found.length > limit ? `${found.slice(0, limit)}…` : found;
+		}
+	}
+	const first = lines[0];
+	return first.length > limit ? `${first.slice(0, limit)}…` : first;
+}
+
 /**
  * Собирает текстовую сводку прогона: по строке на выполненный узел.
  *

--- a/src/test/shared/pipelineStepError.test.ts
+++ b/src/test/shared/pipelineStepError.test.ts
@@ -1,0 +1,42 @@
+import * as assert from 'node:assert';
+import { stepErrorLine } from '../../shared/pipelines/pipelineRunner';
+
+suite('pipelineRunner: строка ошибки шага', () => {
+	test('берётся строка с меткой ошибки, а не последняя строка вывода', () => {
+		const output = [
+			'ИНФОРМАЦИЯ - Выполняю команду в режиме 1С:Предприятие',
+			'ОШИБКА - Получен неожиданный результат работы - Не найден файл статуса build/buildstatus.log',
+			'Выполнение сценариев закончено. БЫЛИ ОШИБКИ.',
+			'Закрытие TestClient <Этот клиент>',
+		].join('\n');
+
+		assert.strictEqual(
+			stepErrorLine(output),
+			'ОШИБКА - Получен неожиданный результат работы - Не найден файл статуса build/buildstatus.log'
+		);
+	});
+
+	test('критичная ошибка важнее обычной', () => {
+		const output = [
+			'ОШИБКА - Получен ненулевой код возврата 1',
+			'КРИТИЧНАЯОШИБКА - Ошибка XDTO в файле - _ДемоОсновной.xml, при чтении свойства: Synonym',
+			'}',
+		].join('\r\n');
+
+		assert.strictEqual(
+			stepErrorLine(output),
+			'КРИТИЧНАЯОШИБКА - Ошибка XDTO в файле - _ДемоОсновной.xml, при чтении свойства: Synonym'
+		);
+	});
+
+	test('без меток берётся первая содержательная строка', () => {
+		assert.strictEqual(stepErrorLine('\n\nне удалось запустить oscript\nподробности ниже'), 'не удалось запустить oscript');
+	});
+
+	test('длинная строка обрезается, пустой вывод даёт undefined', () => {
+		const long = `ОШИБКА - ${'а'.repeat(400)}`;
+
+		assert.strictEqual(stepErrorLine(long, 50)?.length, 51);
+		assert.strictEqual(stepErrorLine('   \n  '), undefined);
+	});
+});


### PR DESCRIPTION
Текстом ошибки шага бралась последняя строка вывода. У vanessa-runner там оказывается «Закрытие TestClient <Этот клиент>», у конфигуратора - закрывающая скобка сообщения об ошибке XDTO. В отчёте о прогоне и в журнале от этого не было толку.

Теперь берётся первая строка с меткой ошибки (`ОШИБКА`, `КРИТИЧНАЯОШИБКА`, `ERROR`, `FATAL`), причём критичная важнее обычной; без меток - первая содержательная строка. Длинная строка обрезается.

Было:

```
Шаг 4. Инициализировать данные: ошибка - Закрытие TestClient <Этот клиент>
Шаг 2. Загрузить конфигурацию из src/cf: ошибка - }
```

Стало:

```
Шаг 4. Инициализировать данные: ошибка - ОШИБКА - Получен неожиданный результат работы - Не найден файл статуса build/buildstatus.log
Шаг 2. Загрузить конфигурацию из src/cf: ошибка - КРИТИЧНАЯОШИБКА - Ошибка XDTO в файле - _ДемоОсновной.xml, при чтении свойства: Synonym
```

## Проверка

Тесты на выбор строки: метка вместо последней строки, приоритет критичной ошибки, вывод без меток, обрезка и пустой вывод. 671 тест зелёный, tsc и eslint чисто.