### PR TITLE
fix(git): флаг области после подкоманды

### DIFF
--- a/src/commands/dependenciesCommands.ts
+++ b/src/commands/dependenciesCommands.ts
@@ -206,6 +206,18 @@ async function showGitAdminCommands(): Promise<void> {
 /**
  * Команды для управления зависимостями проекта
  */
+/**
+ * Аргументы вызова `git config`.
+ *
+ * Флаг области идёт после подкоманды: перед ней git считает его своей опцией и падает с
+ * «unknown option».
+ *
+ * @param scopeArgs Флаги области: `--global` либо пусто для настроек текущего репозитория.
+ */
+export function gitConfigArgs(scopeArgs: readonly string[], key: string, value: string): string[] {
+	return ['config', ...scopeArgs, key, value];
+}
+
 export class DependenciesCommands extends BaseCommand {
 	/** Контекст нужен для кэша компонентов: OVM берём оттуда. */
 	constructor(private readonly context: vscode.ExtensionContext) {
@@ -363,10 +375,13 @@ export class DependenciesCommands extends BaseCommand {
 			};
 		};
 
-		/** Применяет список настроек git config с заданными флагами области видимости. При ошибке показывает сообщение и возвращает false. */
+		/**
+		 * Применяет список настроек git config с заданными флагами области видимости.
+		 * При ошибке показывает сообщение и возвращает false.
+		 */
 		const applyGitConfigs = (configs: [string, string][], args: string[]): boolean => {
 			for (const [key, value] of configs) {
-				const { ok, stderr } = runGitConfig([...args, 'config', key, value]);
+				const { ok, stderr } = runGitConfig(gitConfigArgs(args, key, value));
 				if (!ok) {
 					log.error(`Git config ${args.join(' ') || '(local)'} ${key}=${value}: ${stderr}`);
 					vscode.window.showErrorMessage(`Ошибка настройки Git (${key}): ${stderr || 'неизвестная ошибка'}`);

--- a/src/test/commands/gitConfigArgs.test.ts
+++ b/src/test/commands/gitConfigArgs.test.ts
@@ -1,0 +1,23 @@
+import * as assert from 'node:assert';
+import { gitConfigArgs } from '../../commands/dependenciesCommands';
+
+suite('Аргументы git config', () => {
+	test('флаг области идёт после подкоманды', () => {
+		assert.deepStrictEqual(
+			gitConfigArgs(['--global'], 'user.name', 'Иван'),
+			['config', '--global', 'user.name', 'Иван'],
+			'git config --global …; перед подкомандой git считает флаг своей опцией и падает'
+		);
+	});
+
+	test('без области настройка пишется в текущий репозиторий', () => {
+		assert.deepStrictEqual(gitConfigArgs([], 'core.autocrlf', 'true'), ['config', 'core.autocrlf', 'true']);
+	});
+
+	test('значение с пробелами остаётся одним аргументом', () => {
+		assert.deepStrictEqual(
+			gitConfigArgs(['--global'], 'mergetool.vscode.cmd', 'code --wait $MERGED'),
+			['config', '--global', 'mergetool.vscode.cmd', 'code --wait $MERGED']
+		);
+	});
+});


### PR DESCRIPTION
Команда «1C: Зависимости: Настроить Git» собирала `git --global config user.name …`. Перед подкомандой git считает `--global` своей опцией и падает с «unknown option», поэтому настройка обрывалась на первом же ключе.

При выборе «Текущий проект» первый набор проходил (там область пустая), но команда всё равно падала на merge/diff tool — там `--global` передаётся всегда.

Правильный порядок: `git config --global user.name …`. Сборка аргументов вынесена в отдельную функцию и покрыта тестом — порядок флагов в командной строке проверить иначе нечем.

Закрывает #282.