### PR TITLE
feat: Дерево метаданных помнит раскрытие верхнего уровня

### DIFF
--- a/src/features/metadata/metadataTreeView.ts
+++ b/src/features/metadata/metadataTreeView.ts
@@ -178,11 +178,12 @@ export class MetadataSourceTreeItem extends vscode.TreeItem {
 		label: string,
 		public readonly sourceKind: string,
 		public readonly configurationXmlAbs: string | undefined,
-		public readonly metadataRootAbs: string | undefined
+		public readonly metadataRootAbs: string | undefined,
+		expanded?: boolean
 	) {
 		super(
 			label,
-			sourceKind === 'main'
+			(expanded ?? sourceKind === 'main')
 				? vscode.TreeItemCollapsibleState.Expanded
 				: vscode.TreeItemCollapsibleState.Collapsed
 		);
@@ -1096,6 +1097,9 @@ function themeIconFromGroupHint(hint: string): vscode.ThemeIcon {
 	return new vscode.ThemeIcon(id);
 }
 
+/** Ключ состояния рабочей области: какие источники дерева раскрыты. */
+const EXPANDED_SOURCES_KEY = '1c-platform-tools.metadata.expandedSources';
+
 export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
 	private readonly _onDidChange = new vscode.EventEmitter<vscode.TreeItem | undefined | null | void>();
 	readonly onDidChangeTreeData = this._onDidChange.event;
@@ -1116,6 +1120,11 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 
 	/** Кэш последнего успешного дерева (для API). */
 	private _sourceItems: MetadataSourceTreeItem[] = [];
+	/**
+	 * Раскрытые источники: дерево перестраивается целиком, и без этого каждое обновление
+	 * возвращало бы раскрытой основную конфигурацию, а свёрнутыми - расширения.
+	 */
+	private _expandedSources: Set<string> | undefined;
 	private readonly _groupsBySource = new Map<string, MetadataMdGroupTreeItem[]>();
 	private readonly _subgroupsByGroup = new Map<string, MetadataMdSubgroupTreeItem[]>();
 	private readonly _leavesByGroup = new Map<string, MetadataLeafTreeItem[]>();
@@ -1129,6 +1138,34 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 	private readonly _subsystemsBySource = new Map<string, Map<string, MetadataLeafTreeItem>>();
 
 	constructor(private readonly _context: vscode.ExtensionContext) {}
+
+	/** Раскрытые источники из состояния рабочей области; пусто - состояние ещё не сохраняли. */
+	private expandedSources(): Set<string> | undefined {
+		if (this._expandedSources === undefined) {
+			const saved = this._context.workspaceState.get<string[]>(EXPANDED_SOURCES_KEY);
+			this._expandedSources = saved === undefined ? undefined : new Set(saved);
+		}
+		return this._expandedSources;
+	}
+
+	/**
+	 * Запоминает, раскрыт ли источник. Хранится только верхний уровень: глубже узлы создаются
+	 * по мере раскрытия, и восстанавливать их всё равно нечем.
+	 *
+	 * @param sourceId Идентификатор источника: основная конфигурация, расширение, внешние файлы.
+	 */
+	rememberSourceExpanded(sourceId: string, expanded: boolean): void {
+		const current = this.expandedSources() ?? new Set(
+			this._sourceItems.filter((s) => s.sourceKind === 'main').map((s) => s.sourceId)
+		);
+		if (expanded) {
+			current.add(sourceId);
+		} else {
+			current.delete(sourceId);
+		}
+		this._expandedSources = current;
+		void this._context.workspaceState.update(EXPANDED_SOURCES_KEY, [...current]);
+	}
 
 	/**
 	 * Последнее дерево после успешного refresh; иначе `undefined`.
@@ -1262,7 +1299,9 @@ export class MetadataTreeDataProvider implements vscode.TreeDataProvider<vscode.
 			const cfgRel = src.configurationXmlRelativePath;
 			const cfgAbs = cfgRel.length > 0 ? path.join(workspaceRoot, cfgRel) : undefined;
 			const metaAbs = path.join(workspaceRoot, src.metadataRootRelativePath);
-			const sItem = new MetadataSourceTreeItem(src.id, src.label, src.kind, cfgAbs, metaAbs);
+			const expanded = this.expandedSources();
+			const sItem = new MetadataSourceTreeItem(
+				src.id, src.label, src.kind, cfgAbs, metaAbs, expanded?.has(src.id));
 			sItem.iconPath = metadataSourceIcon(src.kind, this._context.extensionUri);
 			this._sourceItems.push(sItem);
 

--- a/src/features/metadata/registerMetadataView.ts
+++ b/src/features/metadata/registerMetadataView.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import {
 	MetadataLeafTreeItem,
+	MetadataSourceTreeItem,
 	MetadataTreeDataProvider,
 } from './metadataTreeView';
 import { METADATA_SEARCH_VIEW_ID, MetadataSearchViewProvider } from './metadataSearchView';
@@ -42,6 +43,19 @@ export function registerMetadataView(
 		showCollapseAll: true,
 	});
 	context.subscriptions.push(metadataTreeView);
+	// Раскрытие верхнего уровня переживает обновление дерева: оно перестраивается целиком.
+	context.subscriptions.push(
+		metadataTreeView.onDidExpandElement((e) => {
+			if (e.element instanceof MetadataSourceTreeItem) {
+				metadataTreeProvider.rememberSourceExpanded(e.element.sourceId, true);
+			}
+		}),
+		metadataTreeView.onDidCollapseElement((e) => {
+			if (e.element instanceof MetadataSourceTreeItem) {
+				metadataTreeProvider.rememberSourceExpanded(e.element.sourceId, false);
+			}
+		})
+	);
 
 	const metadataSearchProvider = new MetadataSearchViewProvider(context.extensionUri, (query) => {
 		metadataTreeProvider.setTextFilter(query);

--- a/src/test/metadata/treeExpansionMemory.test.ts
+++ b/src/test/metadata/treeExpansionMemory.test.ts
@@ -1,0 +1,76 @@
+import * as assert from 'node:assert';
+import * as vscode from 'vscode';
+import { MetadataSourceTreeItem, MetadataTreeDataProvider } from '../../features/metadata/metadataTreeView';
+import { createMockExtensionContext } from '../fixtures/mocks/vscodeMocks';
+
+const KEY = '1c-platform-tools.metadata.expandedSources';
+
+/** Контекст с работающим хранилищем: общий мок ничего не запоминает. */
+function contextWithState(saved?: string[]): vscode.ExtensionContext {
+	const state = new Map<string, unknown>();
+	if (saved) {
+		state.set(KEY, saved);
+	}
+	const context = createMockExtensionContext();
+	return {
+		...context,
+		workspaceState: {
+			get: (key: string) => state.get(key),
+			update: (key: string, value: unknown) => {
+				state.set(key, value);
+				return Promise.resolve();
+			},
+			keys: () => [...state.keys()],
+		} as unknown as vscode.Memento,
+	} as vscode.ExtensionContext;
+}
+
+function saved(context: vscode.ExtensionContext): string[] | undefined {
+	return context.workspaceState.get<string[]>(KEY);
+}
+
+suite('Память раскрытия дерева метаданных', () => {
+	test('без сохранённого состояния раскрыта основная конфигурация', () => {
+		const main = new MetadataSourceTreeItem('cf', 'Основная конфигурация', 'main', undefined, undefined);
+		const extension = new MetadataSourceTreeItem('cfe1', 'Расширение', 'extension', undefined, undefined);
+
+		assert.strictEqual(main.collapsibleState, vscode.TreeItemCollapsibleState.Expanded);
+		assert.strictEqual(extension.collapsibleState, vscode.TreeItemCollapsibleState.Collapsed);
+	});
+
+	test('сохранённое состояние сильнее умолчания', () => {
+		const main = new MetadataSourceTreeItem('cf', 'Основная', 'main', undefined, undefined, false);
+		const extension = new MetadataSourceTreeItem('cfe1', 'Расширение', 'extension', undefined, undefined, true);
+
+		assert.strictEqual(main.collapsibleState, vscode.TreeItemCollapsibleState.Collapsed);
+		assert.strictEqual(extension.collapsibleState, vscode.TreeItemCollapsibleState.Expanded);
+	});
+
+	test('раскрытие источника запоминается', () => {
+		const context = contextWithState();
+		const provider = new MetadataTreeDataProvider(context);
+
+		provider.rememberSourceExpanded('cfe1', true);
+
+		assert.deepStrictEqual(saved(context), ['cfe1']);
+	});
+
+	test('сворачивание убирает источник из запомненных', () => {
+		const context = contextWithState(['cf', 'cfe1']);
+		const provider = new MetadataTreeDataProvider(context);
+
+		provider.rememberSourceExpanded('cf', false);
+
+		assert.deepStrictEqual(saved(context), ['cfe1'], 'основную свернули, расширение осталось раскрытым');
+	});
+
+	test('повторное раскрытие не плодит записей', () => {
+		const context = contextWithState(['cfe1']);
+		const provider = new MetadataTreeDataProvider(context);
+
+		provider.rememberSourceExpanded('cfe1', true);
+		provider.rememberSourceExpanded('cfe1', true);
+
+		assert.deepStrictEqual(saved(context), ['cfe1']);
+	});
+});


### PR DESCRIPTION
Дерево перестраивается целиком при каждом обновлении, поэтому основная конфигурация снова раскрывалась, а расширения сворачивались — сколько ни переключай.

Теперь состояние источников запоминается в рабочей области: свернули основную конфигурацию и раскрыли расширение, обновили дерево — так и осталось. Пока состояние не сохраняли, работает прежнее умолчание: основная конфигурация раскрыта, остальное свёрнуто.

Запоминается только верхний уровень: вложенные узлы дерево читает по мере раскрытия, и восстанавливать их всё равно нечем. Поиск и фильтр по подсистемам раскрывают узлы по-своему и сохранённое состояние не трогают.

Закрывает #292.