### PR TITLE
feat(properties): подписи вариантов свойств конфигурации

### DIFF
--- a/src/features/metadata/mdSparrowParams.ts
+++ b/src/features/metadata/mdSparrowParams.ts
@@ -74,6 +74,7 @@ export type MdSparrowOp =
 	| 'add-md-object'
 	// чтение (read-json)
 	| 'cf-md-object-get'
+	| 'cf-enum-labels'
 	| 'cf-md-object-enums'
 	| 'cf-md-object-structure-get'
 	| 'cf-form-content-get'

--- a/src/features/metadata/metadataObjectEditSpec.ts
+++ b/src/features/metadata/metadataObjectEditSpec.ts
@@ -4327,9 +4327,24 @@ export type MetadataEnumDictionary = Readonly<Record<string, readonly string[]>>
  * константой - лучше непривычная подпись, чем недоступное свойство.
  * Свойства вне словаря (ссылки на формы, хранилища и прочее) остаются как в спеке.
  */
+/**
+ * Подписи значений перечислимых свойств от md-sparrow: общие и у свойств, где значение называется
+ * иначе. Своего словаря расширение не держит: он бы разошёлся с форматом.
+ */
+export interface EnumValueLabels {
+	readonly values?: Readonly<Record<string, string>>;
+	readonly byProperty?: Readonly<Record<string, Readonly<Record<string, string>>>>;
+}
+
+/** Подпись значения; без подписи остаётся само значение. */
+export function labelOf(labels: EnumValueLabels, property: string, value: string): string {
+	return labels.byProperty?.[property]?.[value] ?? labels.values?.[value] ?? value;
+}
+
 export function applyEnumDictionary(
 	tabs: readonly MetadataEditTabSpec[],
-	dictionary: MetadataEnumDictionary
+	dictionary: MetadataEnumDictionary,
+	labels: EnumValueLabels = {}
 ): MetadataEditTabSpec[] {
 	return tabs.map((tab) => ({
 		...tab,
@@ -4344,7 +4359,9 @@ export function applyEnumDictionary(
 					(option) => option.value === '' || known.includes(option.value)
 				);
 				const labelled = new Set(fromSpec.map((option) => option.value));
-				const rest = known.filter((value) => !labelled.has(value)).map((value) => ({ value, label: value }));
+				const rest = known
+					.filter((value) => !labelled.has(value))
+					.map((value) => ({ value, label: labelOf(labels, field.path, value) }));
 				return { ...field, options: [...fromSpec, ...rest] };
 			}),
 		})),

--- a/src/features/metadata/metadataObjectEditSpec.ts
+++ b/src/features/metadata/metadataObjectEditSpec.ts
@@ -4351,9 +4351,14 @@ export function applyEnumDictionary(
 		groups: tab.groups.map((group) => ({
 			...group,
 			fields: group.fields.map((field) => {
-				const known = dictionary[field.path];
-				if (field.control !== 'select' || !known) {
+				if (field.control !== 'select') {
 					return field;
+				}
+				const known = dictionary[field.path];
+				if (!known) {
+					// Варианты приходят от md-sparrow: пока их нет, показываем значение полем ввода,
+					// иначе список был бы пустым и свойство не посмотреть.
+					return (field.options ?? []).length > 0 ? field : { ...field, control: 'text' as const };
 				}
 				const fromSpec = (field.options ?? []).filter(
 					(option) => option.value === '' || known.includes(option.value)

--- a/src/features/properties/metadataPaletteSource.ts
+++ b/src/features/properties/metadataPaletteSource.ts
@@ -25,6 +25,7 @@ import { mdSparrowSchemaFlagFromConfigurationXml } from '../metadata/mdSparrowSc
 import { logger } from '../../shared/logger';
 import { applyPaletteEdits, paletteGroupsFromSpec } from './propertyPaletteSpec';
 import { EXTERNAL_ARTIFACT_TABS, SOURCE_PROPERTIES_TABS } from './sourcePropertiesSpec';
+import { applyEnumDictionary } from '../metadata/metadataObjectEditSpec';
 import {
 	applyChildNodeEdits,
 	childNodeDtoList,
@@ -236,7 +237,18 @@ async function readProperties(context: vscode.ExtensionContext, target: PaletteT
 	const runtime = await ensureMdSparrowRuntime(context);
 	const dto = await readJson(runtime, target.readOp, target, schema);
 	if (target.readOp === 'cf-configuration-properties-get') {
-		return { dto, tabs: SOURCE_PROPERTIES_TABS, schema };
+		// Ключи словаря перечислений идут с видом объекта, а пути полей конфигурации - без него.
+		const [enums, labels] = await Promise.all([
+			readJson(runtime, 'cf-md-object-enums', target, schema).catch(() => ({})),
+			readJson(runtime, 'cf-enum-labels', target, schema).catch(() => ({})),
+		]);
+		const forConfiguration: Record<string, string[]> = {};
+		for (const [key, values] of Object.entries(enums)) {
+			if (key.startsWith('configuration.') && Array.isArray(values)) {
+				forConfiguration[key.slice('configuration.'.length)] = values as string[];
+			}
+		}
+		return { dto, tabs: applyEnumDictionary(SOURCE_PROPERTIES_TABS, forConfiguration, labels), schema };
 	}
 	if (target.readOp === 'external-artifact-properties-get') {
 		return { dto, tabs: EXTERNAL_ARTIFACT_TABS, schema };

--- a/src/features/properties/sourcePropertiesSpec.ts
+++ b/src/features/properties/sourcePropertiesSpec.ts
@@ -67,6 +67,11 @@ export const SOURCE_PROPERTIES_TABS: readonly MetadataEditTabSpec[] = [
 					},
 					{ path: 'interfaceCompatibilityMode', label: 'Режим совместимости интерфейса', control: 'select' },
 					{ path: 'compatibilityMode', label: 'Режим совместимости', control: 'select' },
+					{
+						path: 'configurationExtensionCompatibilityMode',
+						label: 'Режим совместимости расширения',
+						control: 'select',
+					},
 				],
 			},
 			{

--- a/src/features/properties/sourcePropertiesSpec.ts
+++ b/src/features/properties/sourcePropertiesSpec.ts
@@ -5,24 +5,13 @@
  * панель-вкладка нарисована разметкой. Палитре нужна та же форма описания, поэтому набор полей
  * вынесен сюда - подписи те же, что в панели.
  *
+ * Варианты выпадающих списков спека не перечисляет: их вместе с подписями отдаёт md-sparrow, а свой
+ * список разошёлся бы с форматом.
+ *
  * @module sourcePropertiesSpec
  */
 
-import type { MetadataEditOption, MetadataEditTabSpec } from '../metadata/metadataObjectEditSpec';
-
-function opts(...values: readonly string[]): MetadataEditOption[] {
-	return values.map((value) => ({ value, label: value }));
-}
-
-/** Режимы совместимости платформы; порядок как в конфигураторе - от новых к старым. */
-const COMPATIBILITY_MODES = [
-	'DONT_USE', 'VERSION_8_3_27', 'VERSION_8_3_26', 'VERSION_8_3_25', 'VERSION_8_3_24',
-	'VERSION_8_3_23', 'VERSION_8_3_22', 'VERSION_8_3_21', 'VERSION_8_3_20', 'VERSION_8_3_19',
-	'VERSION_8_3_18', 'VERSION_8_3_17', 'VERSION_8_3_16', 'VERSION_8_3_15', 'VERSION_8_3_14',
-	'VERSION_8_3_13', 'VERSION_8_3_12', 'VERSION_8_3_11', 'VERSION_8_3_10', 'VERSION_8_3_9',
-	'VERSION_8_3_8', 'VERSION_8_3_7', 'VERSION_8_3_6', 'VERSION_8_3_5', 'VERSION_8_3_4',
-	'VERSION_8_3_3', 'VERSION_8_3_2', 'VERSION_8_3_1', 'VERSION_8_2_16', 'VERSION_8_2_13', 'VERSION_8_1',
-];
+import type { MetadataEditTabSpec } from '../metadata/metadataObjectEditSpec';
 
 /**
  * Свойства конфигурации и расширения.
@@ -41,8 +30,8 @@ export const SOURCE_PROPERTIES_TABS: readonly MetadataEditTabSpec[] = [
 					{ path: 'name', label: 'Имя', control: 'text' },
 					{ path: 'synonymRu', label: 'Синоним', control: 'text' },
 					{ path: 'comment', label: 'Комментарий', control: 'text' },
-					{ path: 'defaultRunMode', label: 'Основной режим запуска', control: 'select', options: opts('MANAGED_APPLICATION', 'ORDINARY_APPLICATION') },
-					{ path: 'scriptVariant', label: 'Вариант встроенного языка', control: 'select', options: opts('RUSSIAN', 'ENGLISH') },
+					{ path: 'defaultRunMode', label: 'Основной режим запуска', control: 'select' },
+					{ path: 'scriptVariant', label: 'Вариант встроенного языка', control: 'select' },
 					{ path: 'usePurposes', label: 'Назначение использования', control: 'staticList' },
 					{ path: 'defaultRoles', label: 'Основные роли', control: 'staticList' },
 				],
@@ -68,17 +57,16 @@ export const SOURCE_PROPERTIES_TABS: readonly MetadataEditTabSpec[] = [
 			{
 				title: 'Совместимость',
 				fields: [
-					{ path: 'dataLockControlMode', label: 'Режим управления блокировкой данных', control: 'select', options: opts('AUTOMATIC', 'MANAGED', 'AUTOMATIC_AND_MANAGED') },
-					{ path: 'objectAutonumerationMode', label: 'Режим автонумерации объектов', control: 'select', options: opts('AUTO_FREE', 'NOT_AUTO_FREE') },
-					{ path: 'modalityUseMode', label: 'Режим использования модальности', control: 'select', options: opts('USE', 'USE_WITH_WARNINGS', 'DONT_USE') },
+					{ path: 'dataLockControlMode', label: 'Режим управления блокировкой данных', control: 'select' },
+					{ path: 'objectAutonumerationMode', label: 'Режим автонумерации объектов', control: 'select' },
+					{ path: 'modalityUseMode', label: 'Режим использования модальности', control: 'select' },
 					{
 						path: 'synchronousPlatformExtensionAndAddInCallUseMode',
 						label: 'Режим использования синхронных вызовов расширений',
 						control: 'select',
-						options: opts('USE', 'USE_WITH_WARNINGS', 'DONT_USE'),
 					},
-					{ path: 'interfaceCompatibilityMode', label: 'Режим совместимости интерфейса', control: 'select', options: opts('TAXI', 'TAXI_ENABLE_VERSION_8_2', 'VERSION_8_2_ENABLE_TAXI', 'VERSION_8_2') },
-					{ path: 'compatibilityMode', label: 'Режим совместимости', control: 'select', options: opts(...COMPATIBILITY_MODES) },
+					{ path: 'interfaceCompatibilityMode', label: 'Режим совместимости интерфейса', control: 'select' },
+					{ path: 'compatibilityMode', label: 'Режим совместимости', control: 'select' },
 				],
 			},
 			{


### PR DESCRIPTION
Свойства конфигурации и расширения показывали варианты техническими именами: `MANAGED_APPLICATION`, `AUTOMATIC_AND_MANAGED`, `TAXI_ENABLE_VERSION_8_2`. Списки при этом были зашиты в расширении снимком формата и уже разошлись с ним: режимы совместимости обрывались на `VERSION_8_3_27`, режима 8.5.1 в списке не было, хотя платформа его пишет.

Теперь варианты берутся из `cf-md-object-enums` (он отдаёт и свойства самой конфигурации), а подписи из `cf-enum-labels`. Свой список расширение больше не держит.

Заодно `applyEnumDictionary` подписывает значения, которых нет в спеке: раньше они оставались техническими и в панели объекта.

Требует md-sparrow с https://github.com/yellow-hammer/md-sparrow/pull/32: без него подписи не придут и варианты останутся как есть.