### PR TITLE
fix(security): закрыли уязвимости зависимостей

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,24 +13,27 @@
         "cytoscape": "^3.34.0",
         "cytoscape-elk": "^2.3.0",
         "elkjs": "^0.12.0",
-        "extract-zip": "^2.0.1",
         "fast-xml-parser": "^5.10.1",
         "glob": "^13.0.6",
         "jsonc-parser": "^3.3.1",
-        "minimatch": "^10.2.6"
+        "minimatch": "^10.2.6",
+        "yauzl": "^3.4.0"
       },
       "devDependencies": {
         "@types/cytoscape": "^3.31.0",
         "@types/minimatch": "^6.0.0",
         "@types/node": "26.x",
         "@types/vscode": "^1.125.0",
+        "@types/yauzl": "^3.4.0",
+        "@types/yazl": "^3.3.1",
         "@vscode/test-cli": "^0.0.15",
         "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "^3.9.2",
         "esbuild": "^0.28.1",
         "eslint": "^10.8.1",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.66.0"
+        "typescript-eslint": "^8.66.0",
+        "yazl": "^3.3.1"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -1377,7 +1380,7 @@
       "version": "26.2.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
       "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -1405,11 +1408,21 @@
       "license": "MIT"
     },
     "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yazl": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-DIWfCKpsTp6hE5BDBHV3+fIL/bLUF9Bv13iDrWnMlmhQpH67buNvI291ZauQ1xcccxK3FqQ9honnXpq4R8NMuQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1910,6 +1923,26 @@
         "win32"
       ]
     },
+    "node_modules/@vscode/vsce/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -2143,9 +2176,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2201,12 +2234,13 @@
       }
     },
     "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -2695,6 +2729,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2969,7 +3004,9 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -3318,36 +3355,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3463,15 +3470,6 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -3675,21 +3673,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/github-from-package": {
@@ -4274,9 +4257,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -5009,6 +4992,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -5134,7 +5118,9 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5606,7 +5592,9 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -6801,7 +6789,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -7049,7 +7037,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "dev": true,
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",
@@ -7198,7 +7188,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
       "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -7208,13 +7197,13 @@
       }
     },
     "node_modules/yazl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3"
+        "buffer-crc32": "^1.0.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -3605,31 +3605,34 @@
     "diff": "^8.0.3",
     "serialize-javascript": "^7.0.5",
     "uuid": "^14.0.0",
-    "js-yaml": "^4.3.0",
-    "brace-expansion": "^5.0.8"
+    "js-yaml": "^4.3.1",
+    "brace-expansion": "^5.0.9"
   },
   "dependencies": {
     "@vscode/debugadapter": "^1.68.0",
     "cytoscape": "^3.34.0",
     "cytoscape-elk": "^2.3.0",
     "elkjs": "^0.12.0",
-    "extract-zip": "^2.0.1",
     "fast-xml-parser": "^5.10.1",
     "glob": "^13.0.6",
     "jsonc-parser": "^3.3.1",
-    "minimatch": "^10.2.6"
+    "minimatch": "^10.2.6",
+    "yauzl": "^3.4.0"
   },
   "devDependencies": {
     "@types/cytoscape": "^3.31.0",
     "@types/minimatch": "^6.0.0",
     "@types/node": "26.x",
     "@types/vscode": "^1.125.0",
+    "@types/yauzl": "^3.4.0",
+    "@types/yazl": "^3.3.1",
     "@vscode/test-cli": "^0.0.15",
     "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "^3.9.2",
     "esbuild": "^0.28.1",
     "eslint": "^10.8.1",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.66.0"
+    "typescript-eslint": "^8.66.0",
+    "yazl": "^3.3.1"
   }
 }

--- a/src/shared/githubReleaseLoader.ts
+++ b/src/shared/githubReleaseLoader.ts
@@ -13,7 +13,7 @@ import { createWriteStream } from 'node:fs';
 import { pipeline } from 'node:stream/promises';
 import { Readable } from 'node:stream';
 import * as vscode from 'vscode';
-import extract from 'extract-zip';
+import { extractZip } from './zipExtract';
 import { logger } from './logger';
 
 const log = logger.scope('releases');
@@ -205,7 +205,7 @@ export async function extractArchive(archivePath: string, outDir: string): Promi
 	await fs.mkdir(outDir, { recursive: true });
 	const lower = archivePath.toLowerCase();
 	if (lower.endsWith('.zip')) {
-		await extract(archivePath, { dir: outDir });
+		await extractZip(archivePath, outDir);
 		return;
 	}
 	if (lower.endsWith('.tar.gz') || lower.endsWith('.tgz')) {

--- a/src/shared/zipExtract.ts
+++ b/src/shared/zipExtract.ts
@@ -1,0 +1,122 @@
+/**
+ * Распаковка zip-архивов загружаемых компонентов.
+ *
+ * Своя распаковка поверх yauzl, а не готовая библиотека: запись за пределы каталога назначения
+ * недопустима, а ссылки внутри архива нам не нужны ни в одной поставке, поэтому они пропускаются.
+ * @module zipExtract
+ */
+
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import yauzl, { type Entry, type ZipFile } from 'yauzl';
+import { logger } from './logger';
+
+const log = logger.scope('releases');
+
+/** Биты типа файла и тип «символьная ссылка» из режима записи архива. */
+const FILE_TYPE_MASK = 0o170000;
+const SYMLINK_TYPE = 0o120000;
+/** Права на выполнение: сохраняем их, иначе бинарь из архива не запустится. */
+const EXECUTE_BITS = 0o111;
+
+/** Права записи из внешних атрибутов zip; 0 - архив собран системой без прав (например Windows). */
+function entryMode(entry: Entry): number {
+	return (entry.externalFileAttributes >>> 16) & 0xffff;
+}
+
+function isSymlink(entry: Entry): boolean {
+	return (entryMode(entry) & FILE_TYPE_MASK) === SYMLINK_TYPE;
+}
+
+function isDirectory(entry: Entry): boolean {
+	return entry.fileName.endsWith('/');
+}
+
+/**
+ * Путь записи внутри каталога назначения; undefined - запись уводит наружу.
+ *
+ * @param outDir каталог назначения (абсолютный)
+ * @param fileName имя записи из архива
+ */
+export function safeEntryPath(outDir: string, fileName: string): string | undefined {
+	if (fileName.includes('\0')) {
+		return undefined;
+	}
+	const root = path.resolve(outDir);
+	const target = path.resolve(root, fileName.replace(/\\/g, '/'));
+	const relative = path.relative(root, target);
+	if (relative === '') {
+		return undefined;
+	}
+	if (relative.startsWith('..') || path.isAbsolute(relative)) {
+		return undefined;
+	}
+	return target;
+}
+
+async function writeEntry(zip: ZipFile, entry: Entry, target: string): Promise<void> {
+	await fsp.mkdir(path.dirname(target), { recursive: true });
+	const source = await new Promise<NodeJS.ReadableStream>((resolve, reject) => {
+		zip.openReadStream(entry, (err, stream) => (err ? reject(err) : resolve(stream)));
+	});
+	await pipeline(source, fs.createWriteStream(target));
+
+	const mode = entryMode(entry) & EXECUTE_BITS;
+	if (process.platform !== 'win32' && mode !== 0) {
+		await fsp.chmod(target, 0o644 | mode);
+	}
+}
+
+/**
+ * Распаковывает zip в каталог: записи с путём наружу считаются ошибкой, ссылки пропускаются.
+ *
+ * @param archivePath путь к архиву
+ * @param outDir каталог назначения (создаётся при необходимости)
+ * @throws Error если архив повреждён или запись уводит за пределы каталога
+ */
+export async function extractZip(archivePath: string, outDir: string): Promise<void> {
+	await fsp.mkdir(outDir, { recursive: true });
+	const zip = await new Promise<ZipFile>((resolve, reject) => {
+		yauzl.open(archivePath, { lazyEntries: true, autoClose: true }, (err, opened) =>
+			err ? reject(err) : resolve(opened)
+		);
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		let skippedLinks = 0;
+
+		const fail = (error: unknown): void => {
+			zip.close();
+			reject(error instanceof Error ? error : new Error(String(error)));
+		};
+
+		zip.on('error', fail);
+		zip.on('end', () => {
+			if (skippedLinks > 0) {
+				log.warn(`в архиве ${path.basename(archivePath)} пропущено ссылок: ${skippedLinks}`);
+			}
+			resolve();
+		});
+		zip.on('entry', (entry: Entry) => {
+			const target = safeEntryPath(outDir, entry.fileName);
+			if (!target) {
+				fail(new Error(`Архив ${path.basename(archivePath)}: запись «${entry.fileName}» ведёт за пределы каталога`));
+				return;
+			}
+			if (isSymlink(entry)) {
+				skippedLinks += 1;
+				zip.readEntry();
+				return;
+			}
+			if (isDirectory(entry)) {
+				fsp.mkdir(target, { recursive: true }).then(() => zip.readEntry(), fail);
+				return;
+			}
+			writeEntry(zip, entry, target).then(() => zip.readEntry(), fail);
+		});
+
+		zip.readEntry();
+	});
+}

--- a/src/test/shared/zipExtract.test.ts
+++ b/src/test/shared/zipExtract.test.ts
@@ -1,0 +1,96 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { ZipFile } from 'yazl';
+import { extractZip, safeEntryPath } from '../../shared/zipExtract';
+
+interface ArchiveEntry {
+	name: string;
+	content?: string;
+	/** Режим записи для внешних атрибутов: права и тип (ссылка). */
+	mode?: number;
+}
+
+function tempDir(prefix: string): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/** Собирает архив с произвольными записями, включая такие, каких обычный упаковщик не делает. */
+async function writeArchive(file: string, entries: ArchiveEntry[]): Promise<void> {
+	const zip = new ZipFile();
+	for (const entry of entries) {
+		zip.addBuffer(Buffer.from(entry.content ?? ''), entry.name, { mode: entry.mode });
+	}
+	zip.end();
+	await new Promise<void>((resolve, reject) => {
+		const out = fs.createWriteStream(file);
+		zip.outputStream.pipe(out).on('close', resolve).on('error', reject);
+	});
+}
+
+suite('распаковка zip', () => {
+	test('путь наружу каталога не проходит проверку', () => {
+		const root = path.join(os.tmpdir(), '1cpt-zip-root');
+		assert.strictEqual(safeEntryPath(root, '../evil.txt'), undefined);
+		assert.strictEqual(safeEntryPath(root, 'a/../../evil.txt'), undefined);
+		assert.strictEqual(safeEntryPath(root, '/etc/passwd'), undefined);
+		assert.strictEqual(safeEntryPath(root, 'a/../b.txt'), path.join(root, 'b.txt'));
+		assert.strictEqual(safeEntryPath(root, 'sub/file.txt'), path.join(root, 'sub', 'file.txt'));
+	});
+
+	test('обычный архив распаковывается', async () => {
+		const work = tempDir('1cpt-zip-ok-');
+		const archive = path.join(work, 'component.zip');
+		await writeArchive(archive, [
+			{ name: 'component/readme.txt', content: 'привет' },
+			{ name: 'component/bin/tool', content: '#!/bin/sh', mode: 0o100755 },
+		]);
+
+		const out = path.join(work, 'out');
+		await extractZip(archive, out);
+
+		assert.strictEqual(fs.readFileSync(path.join(out, 'component/readme.txt'), 'utf8'), 'привет');
+		const tool = path.join(out, 'component/bin/tool');
+		assert.ok(fs.existsSync(tool));
+		if (process.platform !== 'win32') {
+			assert.ok((fs.statSync(tool).mode & 0o111) !== 0, 'право на выполнение должно сохраниться');
+		}
+	});
+
+	test('запись за пределы каталога прерывает распаковку', async () => {
+		const work = tempDir('1cpt-zip-traversal-');
+		const archive = path.join(work, 'evil.zip');
+		// Упаковщик не даёт записать путь с «..», поэтому имя подменяется в готовом архиве:
+		// длина совпадает, поэтому смещения записей остаются верными.
+		const placeholder = 'zz/zz/evil.txt';
+		const traversal = '../../evil.txt';
+		await writeArchive(archive, [
+			{ name: 'component/readme.txt', content: 'ок' },
+			{ name: placeholder, content: 'чужой файл' },
+		]);
+		const patched = fs.readFileSync(archive).toString('binary').split(placeholder).join(traversal);
+		fs.writeFileSync(archive, Buffer.from(patched, 'binary'));
+
+		const out = path.join(work, 'out');
+		// Такое имя отсекает уже разбор архива, до нашей проверки пути.
+		await assert.rejects(() => extractZip(archive, out), /ведёт за пределы каталога|invalid relative path/);
+		assert.ok(!fs.existsSync(path.join(work, 'evil.txt')), 'файл не должен появиться рядом с каталогом');
+	});
+
+	test('символьные ссылки пропускаются', async () => {
+		const work = tempDir('1cpt-zip-symlink-');
+		const archive = path.join(work, 'link.zip');
+		await writeArchive(archive, [
+			{ name: 'component/readme.txt', content: 'ок' },
+			// Ссылка наружу: содержимое записи - путь, куда она указывает.
+			{ name: 'component/passwd', content: '../../../../etc/passwd', mode: 0o120777 },
+		]);
+
+		const out = path.join(work, 'out');
+		await extractZip(archive, out);
+
+		assert.ok(fs.existsSync(path.join(out, 'component/readme.txt')));
+		assert.ok(!fs.existsSync(path.join(out, 'component/passwd')), 'ссылка не должна создаваться');
+	});
+});


### PR DESCRIPTION
Три открытых алерта Dependabot.

**extract-zip (high, direct)**: патча нет, пакет не публиковался с 2023 года. Заменён своей распаковкой поверх `yauzl` (`src/shared/zipExtract.ts`): ссылки из архива пропускаются, запись за пределы каталога назначения прерывает распаковку, права на выполнение сохраняются. Уязвимость была именно в ссылках: имена с `..` отсекает сам yauzl.

**js-yaml (high, dev)** до 4.3.1 и **brace-expansion (high)** до 5.0.9 через overrides.

Проверено: `npm audit` без находок; распакованный новым кодом настоящий релизный архив побайтно совпадает с распаковкой средствами Windows (218 файлов), адаптер из него запускается и отвечает по DAP; в контейнере Linux бит выполнения у нативного хоста сохраняется (755), у обычных файлов 644. Тесты на обход каталога и ссылку в архиве собирают zip прямо в тесте, всего 868 зелёных.