### PR TITLE
fix(debug): отбросили кэш адаптера чужой системы

### DIFF
--- a/src/features/debug/onecDebugAdapterBootstrap.ts
+++ b/src/features/debug/onecDebugAdapterBootstrap.ts
@@ -82,6 +82,7 @@ function onecDebugAdapterSpec(): ReleaseComponentSpec {
 		assetRegex: adapterAssetRegexes(adapterRid()),
 		label: 'onec-debug-adapter',
 		extract: true,
+		isCacheValid: (assetPath) => adapterCacheMatchesPlatform(assetPath),
 	};
 }
 
@@ -129,6 +130,34 @@ export function ensureExecutable(file: string, platform: NodeJS.Platform = proce
  * собран под систему сборщика и требует установленного .NET, поэтому смотрим на состав:
  * includedFrameworks в runtimeconfig.json бывает только у самостоятельной сборки.
  */
+/**
+ * Распакованный релиз собран под эту ОС: чужие native-библиотеки рантайма .NET
+ * (linux zip на Windows и наоборот) означают, что кэш нужно скачать заново.
+ */
+export function adapterCacheMatchesPlatform(
+	root: string,
+	platform: NodeJS.Platform = process.platform
+): boolean {
+	const dll = findUnder(root, ONEC_DEBUG_ADAPTER_DLL);
+	if (!dll) {
+		return false;
+	}
+	const dir = path.dirname(dll);
+	const hasSo = fssync.existsSync(path.join(dir, 'libhostpolicy.so'));
+	const hasDylib = fssync.existsSync(path.join(dir, 'libhostpolicy.dylib'));
+	const hasDll = fssync.existsSync(path.join(dir, 'hostpolicy.dll'));
+	if (platform === 'win32') {
+		return !hasSo && !hasDylib;
+	}
+	if (platform === 'linux') {
+		return !hasDll && !hasDylib;
+	}
+	if (platform === 'darwin') {
+		return !hasDll && !hasSo;
+	}
+	return true;
+}
+
 function isSelfContained(dir: string): boolean {
 	try {
 		const raw = fssync.readFileSync(path.join(dir, 'OnecDebugAdapter.runtimeconfig.json'), 'utf8');
@@ -188,7 +217,9 @@ export async function ensureOnecDebugAdapter(context: vscode.ExtensionContext): 
 		if (!fssync.existsSync(override)) {
 			throw new Error(`components.adapterFile не найден: ${override}.`);
 		}
-		return runtimeFromFile(override);
+		const runtime = runtimeFromFile(override);
+		log.info(`адаптер готов: ${describeRuntime(runtime)} (локальный файл)`);
+		return runtime;
 	}
 	if (!cfg.get<boolean>('components.adapterAutoload', true)) {
 		throw new Error('Укажите components.adapterFile или включите components.adapterAutoload.');

--- a/src/features/debug/registerDebugFeature.ts
+++ b/src/features/debug/registerDebugFeature.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import * as onecDebugTargets from './debugTargets';
 import {
@@ -25,7 +26,10 @@ class OnecDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptor
 
 	async createDebugAdapterDescriptor(): Promise<vscode.DebugAdapterDescriptor> {
 		const runtime = await ensureOnecDebugAdapter(this.context);
-		return new vscode.DebugAdapterExecutable(runtime.command, runtime.args);
+		const cwd = runtime.args[0]
+			? path.dirname(runtime.args[0])
+			: path.dirname(runtime.command);
+		return new vscode.DebugAdapterExecutable(runtime.command, runtime.args, { cwd });
 	}
 }
 
@@ -33,30 +37,59 @@ class OnecDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptor
 const ADAPTER_FAILURE_HINT = 'Подробности в панели Output, канал 1C: Platform Tools.';
 
 /**
- * Текст об аварийном завершении процесса адаптера; undefined, если адаптер завершился штатно.
+ * Текст об аварийном завершении процесса адаптера; undefined, если адаптер завершился штатно
+ * или сессию остановили кнопкой (канал stdio закрывается, процесс часто выходит с кодом 1).
  */
-export function adapterExitMessage(code?: number, signal?: string): string | undefined {
+export function adapterExitMessage(
+	code?: number,
+	signal?: string,
+	sessionStopping = false
+): string | undefined {
 	if (code === 0) {
+		return undefined;
+	}
+	if (sessionStopping && (code === 1 || code === undefined)) {
 		return undefined;
 	}
 	const reason = code === undefined ? `сигнал ${signal ?? 'неизвестен'}` : `код возврата ${code}`;
 	return `процесс адаптера отладки завершился аварийно: ${reason}`;
 }
 
+/** Ошибки канала stdio, которые VS Code даёт при штатной остановке сессии. */
+export function isAdapterShutdownNoise(error: Error): boolean {
+	const message = error.message.toLowerCase();
+	return (
+		message === 'read error' ||
+		message.includes('epipe') ||
+		message.includes('eof') ||
+		message.includes('broken pipe')
+	);
+}
+
 /**
  * Отслеживает жизненный цикл процесса адаптера. Без этого аварийное завершение адаптера выглядит как
  * молчаливое закрытие сессии: панель отладки исчезает, консоль отладки пуста, в Output ничего нет.
+ * Остановку кнопкой не показываем как аварию: клиент закрывает pipe раньше ответа disconnect.
  */
 class OnecDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactory {
 	createDebugAdapterTracker(): vscode.DebugAdapterTracker {
+		let sessionStopping = false;
 		return {
+			onWillStopSession() {
+				sessionStopping = true;
+			},
 			onError(error: Error) {
+				if (isAdapterShutdownNoise(error)) {
+					// VS Code шлёт это при любом закрытии stdout адаптера, часто раньше onWillStopSession.
+					log.debug(`канал адаптера закрыт: ${error.message}`);
+					return;
+				}
 				const message = `ошибка процесса адаптера отладки: ${error.message}`;
 				log.error(message);
 				void vscode.window.showErrorMessage(`${capitalize(message)}. ${ADAPTER_FAILURE_HINT}`);
 			},
 			onExit(code: number | undefined, signal: string | undefined) {
-				const message = adapterExitMessage(code, signal);
+				const message = adapterExitMessage(code, signal, sessionStopping);
 				if (!message) {
 					return;
 				}

--- a/src/shared/githubReleaseLoader.ts
+++ b/src/shared/githubReleaseLoader.ts
@@ -48,6 +48,11 @@ export interface ReleaseComponentSpec {
 	label: string;
 	/** Распаковать архив (true) или сохранить файл как есть (false). */
 	extract: boolean;
+	/**
+	 * Дополнительная проверка распакованного кэша. Нужна, когда в штампе ещё нет имени asset'а
+	 * (старый кэш): например, в каталоге лежат нативные библиотеки чужой ОС.
+	 */
+	isCacheValid?: (assetPath: string) => boolean;
 }
 
 /** Результат загрузки: путь к файлу (extract=false) или к каталогу распаковки (extract=true). */
@@ -59,6 +64,8 @@ export interface EnsuredComponent {
 interface StampInfo {
 	tag?: string;
 	assetPath?: string;
+	/** Имя скачанного asset'а релиза — чтобы не оставлять в кэше сборку чужой платформы. */
+	assetName?: string;
 	/** Время последней проверки обновления (ms) — троттлинг фоновых опросов GitHub. */
 	lastCheckMs?: number;
 	/** Легаси-поле прежнего загрузчика md-sparrow. */
@@ -235,6 +242,17 @@ export function findAsset(assets: GithubAsset[] | undefined, assetRegex: RegExp 
 	return undefined;
 }
 
+/**
+ * Имя asset'а из штампа подходит под текущие регэксп спецификации.
+ * Пустое имя — штамп старого формата, пригодность кэша проверяет {@link ReleaseComponentSpec.isCacheValid}.
+ */
+export function stampAssetMatchesSpec(assetName: string | undefined, assetRegex: RegExp | RegExp[]): boolean {
+	if (!assetName) {
+		return true;
+	}
+	return findAsset([{ name: assetName, browser_download_url: '' }], assetRegex) !== undefined;
+}
+
 function pickAsset(rel: GithubRelease, spec: ReleaseComponentSpec): GithubAsset {
 	const asset = findAsset(rel.assets, spec.assetRegex);
 	if (!asset) {
@@ -271,17 +289,34 @@ async function writeStamp(baseDir: string, spec: ReleaseComponentSpec, info: Sta
  * @param spec описание компонента
  * @param token GitHub-токен (может быть пустым)
  */
+function usableCachedComponent(
+	cached: StampInfo | undefined,
+	spec: ReleaseComponentSpec
+): EnsuredComponent | undefined {
+	const cachedPath = cached?.assetPath ?? cached?.jarPath;
+	if (!cached?.tag || !cachedPath || !fssync.existsSync(cachedPath)) {
+		return undefined;
+	}
+	if (!stampAssetMatchesSpec(cached.assetName, spec.assetRegex)) {
+		log.info(
+			`${spec.label}: кэш отброшен (артефакт ${cached.assetName} не подходит для этой системы)`
+		);
+		return undefined;
+	}
+	if (spec.isCacheValid && !spec.isCacheValid(cachedPath)) {
+		log.info(`${spec.label}: кэш отброшен (содержимое не подходит для этой системы)`);
+		return undefined;
+	}
+	return { tag: cached.tag, assetPath: cachedPath };
+}
+
 export async function ensureReleaseComponent(
 	baseDir: string,
 	spec: ReleaseComponentSpec,
 	token: string
 ): Promise<EnsuredComponent> {
 	const cached = await readStamp(baseDir, spec);
-	const cachedPath = cached?.assetPath ?? cached?.jarPath;
-	const inCache =
-		cached?.tag && cachedPath && fssync.existsSync(cachedPath)
-			? { tag: cached.tag, assetPath: cachedPath }
-			: undefined;
+	const inCache = usableCachedComponent(cached, spec);
 	if (inCache && !updateCheckDue(cached?.lastCheckMs)) {
 		log.debug(`${spec.label} из кэша: ${inCache.assetPath} (${inCache.tag})`);
 		return inCache;
@@ -306,6 +341,7 @@ export async function ensureReleaseComponent(
 			await writeStamp(baseDir, spec, {
 				tag: inCache.tag,
 				assetPath: inCache.assetPath,
+				assetName: cached?.assetName,
 				lastCheckMs: Date.now(),
 			});
 			log.debug(`${spec.label} актуален: ${inCache.tag}`);
@@ -337,7 +373,12 @@ export async function ensureReleaseComponent(
 			});
 		}
 
-		await writeStamp(baseDir, spec, { tag: rel.tag_name, assetPath, lastCheckMs: Date.now() });
+		await writeStamp(baseDir, spec, {
+			tag: rel.tag_name,
+			assetPath,
+			assetName: asset.name,
+			lastCheckMs: Date.now(),
+		});
 		log.info(`${spec.label}: ${assetPath} (${rel.tag_name})`);
 		return { tag: rel.tag_name, assetPath };
 	} finally {

--- a/src/test/features/debugAdapterExit.test.ts
+++ b/src/test/features/debugAdapterExit.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'node:assert';
-import { adapterExitMessage } from '../../features/debug/registerDebugFeature';
+import { adapterExitMessage, isAdapterShutdownNoise } from '../../features/debug/registerDebugFeature';
 
 suite('debugAdapterExit', () => {
 	test('штатное завершение адаптера не сообщается', () => {
@@ -11,6 +11,18 @@ suite('debugAdapterExit', () => {
 			adapterExitMessage(134, undefined),
 			'процесс адаптера отладки завершился аварийно: код возврата 134'
 		);
+	});
+
+	test('остановка сессии не показывает код 1; обрыв канала — штатный шум', () => {
+		assert.strictEqual(adapterExitMessage(1, undefined, true), undefined);
+		assert.strictEqual(adapterExitMessage(undefined, undefined, true), undefined);
+		assert.strictEqual(
+			adapterExitMessage(134, undefined, true),
+			'процесс адаптера отладки завершился аварийно: код возврата 134'
+		);
+		assert.ok(isAdapterShutdownNoise(new Error('read error')));
+		assert.ok(isAdapterShutdownNoise(new Error('write EPIPE')));
+		assert.ok(!isAdapterShutdownNoise(new Error('hostpolicy.dll not found')));
 	});
 
 	test('завершение по сигналу описывается сигналом', () => {

--- a/src/test/features/onecDebugAdapterBootstrap.test.ts
+++ b/src/test/features/onecDebugAdapterBootstrap.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import {
 	adapterAssetRegexes,
+	adapterCacheMatchesPlatform,
 	adapterHostName,
 	adapterRid,
 	resolveAdapterRuntime,
@@ -110,6 +111,19 @@ suite('onecDebugAdapterBootstrap', () => {
 
 	test('пустой каталог релиза не даёт команды запуска', () => {
 		assert.strictEqual(resolveAdapterRuntime(tempDir('1cpt-dap-empty-')), undefined);
+	});
+
+	test('кэш с native-библиотеками чужой ОС отбрасывается', () => {
+		const { root, dir } = releaseLayout('1cpt-dap-wrongos-', true);
+		fs.writeFileSync(path.join(dir, 'libhostpolicy.so'), '');
+
+		assert.strictEqual(adapterCacheMatchesPlatform(root, 'win32'), false);
+		assert.strictEqual(adapterCacheMatchesPlatform(root, 'linux'), true);
+	});
+
+	test('кэш без чужих native-библиотек подходит', () => {
+		const { root } = releaseLayout('1cpt-dap-nativeos-', true);
+		assert.strictEqual(adapterCacheMatchesPlatform(root, 'win32'), true);
 	});
 
 	test('свой путь к адаптеру: dll через dotnet, остальное напрямую', () => {

--- a/src/test/utils/githubReleaseLoader.test.ts
+++ b/src/test/utils/githubReleaseLoader.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'node:assert';
-import { isNewerTag, updateCheckDue } from '../../shared/githubReleaseLoader';
+import { isNewerTag, stampAssetMatchesSpec, updateCheckDue } from '../../shared/githubReleaseLoader';
+import { adapterAssetRegexes } from '../../features/debug/onecDebugAdapterBootstrap';
 
 suite('githubReleaseLoader.isNewerTag', () => {
 	test('новее по patch/minor/major', () => {
@@ -38,5 +39,22 @@ suite('githubReleaseLoader: проверка обновлений', () => {
 	test('через восемь минут проверяем снова', () => {
 		assert.strictEqual(updateCheckDue(now - 8 * 60_000, now), true);
 		assert.strictEqual(updateCheckDue(now - 60 * 60_000, now), true);
+	});
+});
+
+suite('githubReleaseLoader.stampAssetMatchesSpec', () => {
+	const winRegexes = adapterAssetRegexes('win-x64');
+
+	test('штамп без имени asset’а не отбрасываем — пригодность смотрит isCacheValid', () => {
+		assert.strictEqual(stampAssetMatchesSpec(undefined, winRegexes), true);
+	});
+
+	test('сборка этой системы и универсальный архив подходят', () => {
+		assert.strictEqual(stampAssetMatchesSpec('onec-debug-adapter-win-x64-v0.3.0.zip', winRegexes), true);
+		assert.strictEqual(stampAssetMatchesSpec('onec-debug-adapter-v0.3.0.zip', winRegexes), true);
+	});
+
+	test('сборка чужой системы не подходит', () => {
+		assert.strictEqual(stampAssetMatchesSpec('onec-debug-adapter-linux-x64-v0.3.0.zip', winRegexes), false);
 	});
 });


### PR DESCRIPTION
## Описание

Перестали оставлять в кэше сборку адаптера отладки под чужую ОС. После обновления расширения старый linux-zip больше не запускается на Windows.

Закрывает #330

## Что сделано

- Запомнили имя скачанного asset'а в штампе кэша и сверяем его с текущей системой
- Отбросили распакованный кэш, если в нём лежат native-библиотеки другой ОС
- Покрыли отбор кэша тестами

## Чек-лист

- [x] Заголовок PR соответствует Conventional Commits
- [x] Код проверен линтером
- [x] Проект успешно собирается
- [x] Изменения покрыты тестами
- [x] Документация не требовала правок