### PR TITLE
fix(deps): вернули @types/vscode к минимальной поддерживаемой версии VS Code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/cytoscape": "^3.31.0",
         "@types/minimatch": "^6.0.0",
         "@types/node": "26.x",
-        "@types/vscode": "^1.134.0",
+        "@types/vscode": "^1.125.0",
         "@types/yauzl": "^3.4.0",
         "@types/yazl": "^3.3.1",
         "@vscode/test-cli": "^0.0.15",
@@ -2339,9 +2339,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.134.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.134.0.tgz",
-      "integrity": "sha512-NDEu0hg4sF7+vvFsADsktqUJ6f80LHSZvVK2Ovo1XiQ0/VHck1O3zst+ZZyVA/uvz6vo6LcuoqU2q48YMqOwWw==",
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -4318,7 +4318,7 @@
     "@types/cytoscape": "^3.31.0",
     "@types/minimatch": "^6.0.0",
     "@types/node": "26.x",
-    "@types/vscode": "^1.134.0",
+    "@types/vscode": "^1.125.0",
     "@types/yauzl": "^3.4.0",
     "@types/yazl": "^3.3.1",
     "@vscode/test-cli": "^0.0.15",


### PR DESCRIPTION
Сборка VSIX падала: `@types/vscode ^1.134.0 greater than engines.vscode ^1.125.0`.

Понизили типы до минимальной поддерживаемой версии VS Code, а не подняли `engines`: иначе расширение перестало бы ставиться в редакторы со старой базой VS Code.

Проверено: typecheck, lint, `vsce package` собирается.