### PR TITLE
feat(profile): добавили секцию yaxunit в профиль запуска

### DIFF
--- a/docs/launch-profiles.md
+++ b/docs/launch-profiles.md
@@ -94,6 +94,7 @@ vanessa-runner 3 — это отдельный инструмент со сво�
 
 - **vanessa** — сценарные тесты Vanessa Automation (BDD/feature);
 - **xunit** — дымовые тесты xUnit;
+- **yaxunit** — модульные тесты YAxUnit;
 - **syntax-check** — синтаксический контроль конфигурации.
 
 Секции добавляют в файл готовые блоки настроек в формате установленного vrunner (плоские секции в `env.json`, каскад `vrunner.test.*` / `vrunner.validate.*` в `autumn-properties.json`), которые ссылаются на файлы из каталога `tools/`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,7 +14,7 @@
 |-------------------------|-----------------------------------------------------------|------------------------------------------------------------|
 | **Vanessa Automation**  | `.feature` → сценарии                                     | настройки VA проекта; отчёт jUnit или Cucumber JSON        |
 | **xUnit / Vanessa-ADD** | исходники тестовых обработок → методы (обработка собирается перед прогоном) | активный профиль запуска, секция `xunit`                   |
-| **YAxUnit**             | модули тестового расширения → тесты                       | `tools/yaxunit.json`                                        |
+| **YAxUnit**             | модули тестового расширения → тесты                       | активный профиль запуска, секция `yaxunit`; `tools/yaxunit.json` |
 | **OneScript (1testrunner)** | `.os`-тесты с `ИсполняемыеСценарии` или аннотациями `&Тест` | отчёт в `build/out/onescript`                              |
 | **OneScript (OneUnit)** | `.os`-тесты, в том числе `&ПараметризованныйТест`         | отчёт в `build/out/onescript`                              |
 | **1bdd**                | `.feature` в OneScript-проектах                           | отчёт в `build/out/1bdd`                                    |
@@ -70,7 +70,7 @@ project/
 
 Расширение использует служебные файлы проекта и не генерирует свои. Все прогоны идут под [активным профилем запуска](launch-profiles.md): его `--settings` подставляется централизованно, а пути отчётов и параметров читаются из файла профиля с учётом схемы (плоские секции в `env.json`, каскад `vrunner.test.*` в `autumn-properties.json`).
 
-- профиль — секции `vanessa` (`vanessasettings`) и `xunit` (`reportsxunit` — отсюда берётся путь jUnit-отчёта);
+- профиль — секции `vanessa` (`vanessasettings`), `xunit` (`reportsxunit` — отсюда берётся путь jUnit-отчёта) и `yaxunit` (см. [ниже](#yaxunit-и-профиль-запуска));
 - `tools/VAParams.json` — какие отчёты пишет Vanessa Automation (jUnit или Cucumber JSON) и куда;
 - `tools/yaxunit.json` — базовый конфиг RunUnitTests; панель накладывает на него фильтр по выбранному модулю/тесту.
 
@@ -88,7 +88,7 @@ project/
 | `test.exclude`                                   | `["oscript_modules", "build"]` | Сегменты пути, исключаемые при поиске тестов      |
 | `test.onescriptRunner`                           | `auto`                         | Раннер OneScript: auto / 1testrunner / oneunit    |
 | `test.onescriptRunnerPath`, `test.onebddPath` | —                              | Пути к раннерам (поддерживают относительные)      |
-| `test.yaxunitConfigPath`                         | `tools/yaxunit.json`           | Базовый конфиг YAxUnit                            |
+| `test.path.yaxunitConfig`                        | `tools/yaxunit.json`           | Базовый конфиг YAxUnit, если профиль не задаёт свой |
 | `test.reportsPath`                               | `build/out/testapi`            | Временные файлы прогонов                          |
 
 ## Тестовые расширения
@@ -135,6 +135,12 @@ project/
 Панель тестирования ищет тесты YAxUnit в обоих корнях - и в `path.cfe`, и в `tests/cfe`:
 расширение с тестами встречается и внутри решения, и рядом с тестами. Отладчику каталоги
 тестовых расширений тоже передаются, иначе в тест нельзя было бы зайти точкой останова.
+
+## YAxUnit и профиль запуска
+
+Секция `yaxunit` профиля задаёт запуск тестов YAxUnit из панели и командой «YAxUnit тесты»: конфиг в `--command` (`RunUnitTests=<конфиг>`) вместо настройки `test.path.yaxunitConfig`, режим клиента `--ordinaryapp`, файл кода возврата `--exitCodePath`, а также `--additional` и `--no-wait`. Так разные профили запускают разные конфиги, например дымовой и полный. Секция добавляется в редакторе профиля и при создании файла настроек.
+
+В `autumn-properties.json` это секция `vrunner.test.yaxunit` с опциями команды `vrunner test yaxunit`: готовый конфиг `yaxunit-config`, отчёт `report`, файл кода возврата `exitcode`, фильтры `ext`, `modules`, `tests`, `tags` и `suites`. Готовый конфиг используется как есть, поэтому отчёт, код возврата и фильтры из секции действуют, когда конфиг не задан.
 
 ## Особенности
 

--- a/package.json
+++ b/package.json
@@ -4101,7 +4101,7 @@
           "1c-platform-tools.test.path.yaxunitConfig": {
             "type": "string",
             "default": "tools/yaxunit.json",
-            "description": "Базовый конфиг YAxUnit (RunUnitTests). Панель тестирования накладывает на него фильтр по выбранному модулю/тесту и берёт из него reportPath."
+            "description": "Базовый конфиг YAxUnit (RunUnitTests), если секция yaxunit активного профиля не задаёт свой. Панель тестирования накладывает на него фильтр по выбранному модулю или тесту и берёт из него reportPath."
           },
           "1c-platform-tools.test.frameworks.vanessa": {
             "type": "boolean",

--- a/resources/schemas/vrunner-options.overrides.json
+++ b/resources/schemas/vrunner-options.overrides.json
@@ -190,10 +190,25 @@
 			}
 		}
 	},
+	"v2CustomSections": [
+		{
+			"id": "yaxunit",
+			"label": "YAxUnit: запуск тестов",
+			"hint": "Опции vrunner run для запуска тестов YAxUnit; сам vanessa-runner эту секцию не читает",
+			"keys": [
+				"--command",
+				"--ordinaryapp",
+				"--exitCodePath",
+				"--additional",
+				"--no-wait"
+			]
+		}
+	],
 	"v2Sections": [
 		"default",
 		"vanessa",
 		"xunit",
+		"yaxunit",
 		"syntax-check",
 		"run",
 		"designer",

--- a/resources/templates/gitattributes.template
+++ b/resources/templates/gitattributes.template
@@ -36,4 +36,5 @@ Form.bin binary
 *.cfe binary
 *.epf binary
 *.erf binary
+*.mxl binary
 ParentConfigurations.bin binary

--- a/src/commands/testCommands.ts
+++ b/src/commands/testCommands.ts
@@ -19,7 +19,7 @@ import type { CommandExecutionOptions, StructuredCommandResult, SyntaxCheckError
 import { DEFAULT_TESTING, DEFAULT_PATHS, BUILD_SUBDIRS } from '../shared/pathDefaults';
 import { legacyTestsSrcHint } from '../features/testing/legacyTestsSrc';
 import * as fs from 'node:fs/promises';
-import { settingValue, resolveConfigPath, reportsXunitFromEnv, extractJUnitPathFromReportsXunit, extractAllurePathFromReportsXunit, vanessaReportTarget, vanessaSettingsPathFromEnv, syntaxCheckJUnitPathFromEnv, syntaxCheckAllurePathsFromEnv } from '../features/testing/projectTestConfig';
+import { settingValue, resolveConfigPath, reportsXunitFromEnv, extractJUnitPathFromReportsXunit, extractAllurePathFromReportsXunit, vanessaReportTarget, vanessaSettingsPathFromEnv, syntaxCheckJUnitPathFromEnv, syntaxCheckAllurePathsFromEnv, yaxunitSectionFromEnv, YaxunitProfileSection } from '../features/testing/projectTestConfig';
 import { parseSyntaxCheckFindings, toSyntaxCheckErrors, SyntaxCheckFinding } from '../features/diagnostics/syntaxCheckJUnit';
 import { readRunSummary, formatRunSummary, RunReportFormat } from '../features/testing/runReportSummary';
 import { ensureAllure } from '../shared/allureComponent';
@@ -78,11 +78,38 @@ export class TestCommands extends BaseCommand {
 	}
 
 	/**
+	 * Готовый конфиг YAxUnit: из секции активного профиля, иначе из настройки
+	 * test.path.yaxunitConfig. На vanessa-runner 3 файла из настройки может не
+	 * быть, тогда конфиг собирает раннер из секции vrunner.test.yaxunit.
+	 *
+	 * @param opts - Опции выполнения (нужны для выбора файла настроек)
+	 * @param workspaceRoot - Корень проекта
+	 * @returns Секция профиля и путь конфига, как он уйдёт в команду
+	 */
+	private async yaxunitRunConfig(
+		opts: CommandExecutionOptions | undefined,
+		workspaceRoot: string
+	): Promise<{ profile: YaxunitProfileSection; configPath?: string }> {
+		const { settings, schema } = await this.readRunSettings(opts);
+		const profile = yaxunitSectionFromEnv(settings, schema);
+		if (profile.configPath) {
+			return { profile, configPath: profile.configPath };
+		}
+		const config = vscode.workspace.getConfiguration('1c-platform-tools');
+		const configured = config.get<string>('test.path.yaxunitConfig', DEFAULT_TESTING.yaxunitConfigPath);
+		if (schema === 'v2') {
+			return { profile, configPath: configured };
+		}
+		const exists = await fs.access(resolveConfigPath(configured, workspaceRoot)).then(() => true, () => false);
+		return { profile, configPath: exists ? configured : undefined };
+	}
+
+	/**
 	 * Путь jUnit-отчёта прогона по конфигурации проекта.
 	 *
 	 * vanessa: файл VAParams (--vanessasettings) → КаталогОтчетаJUnit;
 	 * xunit: --reportsxunit → путь генератора jUnit;
-	 * yaxunit: конфиг test.path.yaxunitConfig → reportPath.
+	 * yaxunit: готовый конфиг → reportPath, без него report секции профиля 3.x.
 	 *
 	 * @returns Абсолютный путь к файлу/каталогу отчёта или undefined
 	 */
@@ -96,9 +123,13 @@ export class TestCommands extends BaseCommand {
 		}
 		try {
 			if (framework === 'yaxunit') {
-				const config = vscode.workspace.getConfiguration('1c-platform-tools');
-				const configPath = config.get<string>('test.path.yaxunitConfig', DEFAULT_TESTING.yaxunitConfigPath);
-				const raw = await fs.readFile(path.join(workspaceRoot, configPath), 'utf8');
+				const { profile, configPath } = await this.yaxunitRunConfig(opts, workspaceRoot);
+				if (!configPath) {
+					return profile.report
+						? { path: resolveConfigPath(profile.report, workspaceRoot), format: 'junit' }
+						: undefined;
+				}
+				const raw = await fs.readFile(resolveConfigPath(configPath, workspaceRoot), 'utf8');
 				const parsed = JSON.parse(stripBom(raw)) as Record<string, unknown>;
 				const reportPath = parsed['reportPath'];
 				return typeof reportPath === 'string' && reportPath.length > 0
@@ -388,9 +419,10 @@ export class TestCommands extends BaseCommand {
 	/**
 	 * Запускает тесты YAxUnit
 	 *
-	 * Выполняет vrunner run --command RunUnitTests=<конфиг>. Конфиг прогона —
-	 * test.path.yaxunitConfig (по умолчанию tools/yaxunit.json), отчёт
-	 * и фильтры берутся из него.
+	 * Готовый конфиг берётся из секции yaxunit активного профиля, иначе из
+	 * test.path.yaxunitConfig; отчёт и фильтры в нём. На vanessa-runner 2 это
+	 * run --command RunUnitTests=<конфиг> с опциями секции, на 3 - test yaxunit,
+	 * секцию профиля раннер читает сам.
 	 *
 	 * Предварительно в ИБ должны быть загружены расширение-движок YAXUNIT
 	 * и тестовое расширение (с отключённым безопасным режимом).
@@ -407,8 +439,7 @@ export class TestCommands extends BaseCommand {
 			return;
 		}
 
-		const config = vscode.workspace.getConfiguration('1c-platform-tools');
-		const configPath = config.get<string>('test.path.yaxunitConfig', DEFAULT_TESTING.yaxunitConfigPath);
+		const { profile, configPath } = await this.yaxunitRunConfig(opts, workspaceRoot);
 		// --settings активного профиля подставляет planIntent; здесь — только явный
 		// адрес ИБ из вызова MCP (перекрывает ИБ профиля), иначе пусто.
 		const connectionArgs = await this.vrunner.getIbConnectionParam(opts?.ibConnection);
@@ -417,7 +448,15 @@ export class TestCommands extends BaseCommand {
 		const reportTarget = await this.resolveRunReportTarget('yaxunit', opts);
 		await this.ensureReportDir('yaxunit', reportTarget);
 		const result = await this.runIntent(
-			{ kind: 'run.enterprise', command: `RunUnitTests=${configPath}`, common: connectionArgs },
+			{
+				kind: 'test.yaxunit',
+				configPath,
+				ordinaryApp: profile.ordinaryApp,
+				exitCodePath: profile.exitCodePath,
+				additional: profile.additional,
+				noWait: profile.noWait,
+				common: connectionArgs,
+			},
 			opts, yaxCmd.title, undefined, yaxCmd.id
 		);
 		return this.withRunReport(result, 'yaxunit', startedAtMs, opts, reportTarget);

--- a/src/features/profileEditor/optionsCatalog.ts
+++ b/src/features/profileEditor/optionsCatalog.ts
@@ -56,6 +56,8 @@ export interface EditorSection {
 	isMain: boolean;
 	/** Секцию стоит предлагать к добавлению (не экзотика) */
 	advertised: boolean;
+	/** Пояснение к секции при добавлении */
+	hint?: string;
 	/** Опции, применимые в секции */
 	options: CatalogOption[];
 }
@@ -76,13 +78,15 @@ interface Overrides {
 	options: Record<string, Partial<CatalogOption>>;
 	/** Секции 2.x, предлагаемые к добавлению в редакторе */
 	v2Sections?: string[];
+	/** Секции 2.x вне схемы vanessa-runner: их читает расширение */
+	v2CustomSections?: { id: string; label: string; hint?: string; keys: string[] }[];
 }
 
 /** Группа «всё остальное» (сворачивается в форме). */
 export const OTHER_GROUP: OptionGroup = { id: 'other', label: 'Прочее' };
 
 /** Приоритетные секции 2.x (показываются первыми, в этом порядке). */
-const V2_SECTION_ORDER = ['default', 'vanessa', 'xunit', 'syntax-check', 'run', 'designer', 'updatedb', 'init-dev', 'update-dev'];
+const V2_SECTION_ORDER = ['default', 'vanessa', 'xunit', 'yaxunit', 'syntax-check', 'run', 'designer', 'updatedb', 'init-dev', 'update-dev'];
 
 function readJson<T>(extensionPath: string, fileName: string): T {
 	const fullPath = path.join(extensionPath, 'resources', 'schemas', fileName);
@@ -132,8 +136,15 @@ function byImportance(a: CatalogOption, b: CatalogOption): number {
 	return a.order - b.order || a.key.localeCompare(b.key);
 }
 
-function buildV2Sections(catalog: V2Catalog, ctx: CatalogContext, advertisedSections: Set<string>): EditorSection[] {
-	const ordered = [...catalog.sections].sort((a, b) => {
+function buildV2Sections(
+	catalog: V2Catalog,
+	ctx: CatalogContext,
+	advertisedSections: Set<string>,
+	customSections: NonNullable<Overrides['v2CustomSections']>
+): EditorSection[] {
+	const labelById = new Map(customSections.map((section) => [section.id, section.label]));
+	const hintById = new Map(customSections.map((section) => [section.id, section.hint]));
+	const ordered = [...catalog.sections, ...customSections].sort((a, b) => {
 		const ai = V2_SECTION_ORDER.indexOf(a.id);
 		const bi = V2_SECTION_ORDER.indexOf(b.id);
 		if (ai !== -1 || bi !== -1) {
@@ -143,10 +154,11 @@ function buildV2Sections(catalog: V2Catalog, ctx: CatalogContext, advertisedSect
 	});
 	return ordered.map((section) => ({
 		id: section.id,
-		label: section.id === 'default' ? 'Общие параметры' : `Команда: ${section.id}`,
+		label: section.id === 'default' ? 'Общие параметры' : labelById.get(section.id) ?? `Команда: ${section.id}`,
 		jsonPath: [section.id],
 		isMain: section.id === 'default',
 		advertised: advertisedSections.has(section.id),
+		hint: hintById.get(section.id),
 		options: section.keys
 			.map((key) => ctx.finalize(key, catalog.options[key] ?? {}))
 			.sort(byImportance),
@@ -223,7 +235,8 @@ export function loadEditorSections(
 			: buildV2Sections(
 				readJson<V2Catalog>(extensionPath, 'vrunner-options.v2.json'),
 				ctx,
-				new Set(overrides.v2Sections ?? [])
+				new Set(overrides.v2Sections ?? []),
+				overrides.v2CustomSections ?? []
 			);
 	return { sections, groups: [...ctx.groups, OTHER_GROUP] };
 }

--- a/src/features/profileEditor/profileEditorProvider.ts
+++ b/src/features/profileEditor/profileEditorProvider.ts
@@ -192,6 +192,7 @@ export class ProfileEditorProvider implements vscode.CustomTextEditorProvider {
 			commandSections.map((section) => ({
 				label: section.label.replace(/^Команда: /, ''),
 				description: `${section.options.length} параметров`,
+				detail: section.hint,
 				section,
 			})),
 			{ title: 'Параметры для команды', placeHolder: 'Команда vanessa-runner…' }

--- a/src/features/serviceFiles/envSections.ts
+++ b/src/features/serviceFiles/envSections.ts
@@ -1,5 +1,5 @@
 /**
- * Опциональные секции env.json (vanessa / xunit / синтаксический контроль).
+ * Опциональные секции env.json (vanessa / xunit / yaxunit / синтаксический контроль).
  *
  * При создании env.json пользователь отмечает нужные секции; базовая секция
  * `default` присутствует всегда. Слияние (mergeEnvSections) — чистая функция.
@@ -58,6 +58,16 @@ export const ENV_OPTIONAL_SECTIONS: EnvSectionOption[] = [
 				'-ExternalConnection',
 				'-ThickClientOrdinaryApplication',
 			],
+		},
+	},
+	{
+		id: 'yaxunit',
+		label: 'yaxunit',
+		description: 'Модульные тесты YAxUnit',
+		section: {
+			'--command': 'RunUnitTests=tools/yaxunit.json',
+			'--ordinaryapp': '-1',
+			'--exitCodePath': './build/out/yaxunit/result.txt',
 		},
 	},
 ];
@@ -137,6 +147,14 @@ export const AUTUMN_OPTIONAL_SECTIONS: AutumnSectionOption[] = [
 				'ExternalConnection',
 				'ThickClientOrdinaryApplication',
 			],
+		},
+	},
+	{
+		id: 'yaxunit',
+		description: 'Модульные тесты YAxUnit',
+		path: ['test', 'yaxunit'],
+		section: {
+			'yaxunit-config': 'tools/yaxunit.json',
 		},
 	},
 ];

--- a/src/features/testing/adapters/yaxunitAdapter.ts
+++ b/src/features/testing/adapters/yaxunitAdapter.ts
@@ -6,12 +6,19 @@ import { logger } from '../../../shared/logger';
 import { TestFrameworkAdapter, AdapterRunPlan, RunUnit } from '../frameworkAdapter';
 import { DiscoveredFile } from '../parsers/parserTypes';
 import { parseBslTestModule } from '../parsers/bslTestParser';
-import { resolveConfigPath } from '../projectTestConfig';
+import { resolveConfigPath, yaxunitSectionFromEnv, type YaxunitProfileSection } from '../projectTestConfig';
 import { normalizeGlobBase } from './adapterUtils';
 import { DEFAULT_TESTING } from '../../../shared/pathDefaults';
 import { resolveExtensionNameFromSrc } from '../../extensions/extensionNames';
+import type { SettingsSchema } from '../../../shared/envProfiles';
+import type { YaxunitFilter } from '../../../shared/vrunnerCli';
 
 const log = logger.scope('testing');
+
+const NO_REPORT_HINT =
+	'Для YAxUnit в информационной базе должны быть загружены: расширение-движок YAXUNIT ' +
+	'(yaxunit.cfe с https://github.com/bia-technologies/yaxunit/releases) и тестовое расширение ' +
+	'с вашими тестами. У обоих отключите «Безопасный режим» и «Защиту от опасных действий».';
 
 /**
  * Адаптер YAxUnit (модульные тесты в расширении конфигурации)
@@ -21,10 +28,12 @@ const log = logger.scope('testing');
  * тестовых (<path.tests>/cfe) - расширение с тестами держат отдельно от поставки,
  * но и внутри решения оно встречается.
  *
- * Запуск: vrunner run --command RunUnitTests=<конфиг>. За основу берётся
- * конфиг проекта (test.path.yaxunitConfig, по умолчанию tools/yaxunit.json) —
- * из него же берётся reportPath; поверх накладывается filter по выбранному
- * модулю или конкретным тестам (единственный фреймворк с точечным запуском).
+ * Запуск: готовый конфиг из секции yaxunit активного профиля, иначе из
+ * настройки test.path.yaxunitConfig; из него же reportPath, поверх ложится
+ * filter по выбранному модулю или тестам (единственный фреймворк с точечным
+ * запуском). На vanessa-runner 2 это run --command RunUnitTests=<копия> с
+ * опциями секции, на 3 - test yaxunit; без конфига фильтр и отчёт уходят
+ * опциями команды, остальное раннер берёт из профиля.
  */
 export class YaxunitAdapter implements TestFrameworkAdapter {
 	public readonly id = 'yaxunit' as const;
@@ -91,101 +100,100 @@ export class YaxunitAdapter implements TestFrameworkAdapter {
 	 * @returns План батч-прогона
 	 */
 	public async buildBatchRunPlan(units: RunUnit[], reportDir: string): Promise<AdapterRunPlan | undefined> {
-		const workspaceRoot = this.vrunner.getWorkspaceRoot();
-		const baseConfig = await this.readProjectConfig(workspaceRoot);
-		const baseFilter =
-			baseConfig['filter'] && typeof baseConfig['filter'] === 'object'
-				? (baseConfig['filter'] as Record<string, unknown>)
-				: {};
 		const modules = [...new Set(units.map((unit) => extractModuleName(unit.fileUri.fsPath)))];
 		const extensions = await this.extensionNames(units);
-
-		const reportPathRaw =
-			typeof baseConfig['reportPath'] === 'string' && baseConfig['reportPath'].length > 0
-				? baseConfig['reportPath']
-				: path.join(reportDir, 'report.xml');
-		const reportPathAbsolute = workspaceRoot
-			? resolveConfigPath(reportPathRaw, workspaceRoot)
-			: reportPathRaw;
-
-		const runConfig: Record<string, unknown> = {
-			...baseConfig,
-			filter: { ...baseFilter, extensions, modules, tests: null },
-			reportPath: reportPathRaw,
-			reportFormat: baseConfig['reportFormat'] ?? 'jUnit',
-			closeAfterTests: baseConfig['closeAfterTests'] ?? true
-		};
-
-		const configPath = path.join(reportDir, 'yaxunit-config.json');
-		await fs.writeFile(configPath, JSON.stringify(runConfig, null, 2), 'utf8');
-
 		const connectionArgs = await this.vrunner.getIbConnectionParam();
-		const [args] = await this.vrunner.planIntent({
-			kind: 'run.enterprise',
-			command: `RunUnitTests=${configPath}`,
-			common: connectionArgs
-		});
-
-		return {
-			tool: 'vrunner',
-			args,
-			reportTarget: { format: 'junit', path: reportPathAbsolute }
-		};
+		return this.plan({ extensions, modules }, reportDir, connectionArgs);
 	}
 
 	public async buildRunPlan(unit: RunUnit, reportDir: string): Promise<AdapterRunPlan> {
-		const workspaceRoot = this.vrunner.getWorkspaceRoot();
 		const moduleName = extractModuleName(unit.fileUri.fsPath);
-		const baseConfig = await this.readProjectConfig(workspaceRoot);
+		const extensions = await this.extensionNames([unit]);
+		// Модуль целиком либо выбранные тесты
+		const filter: YaxunitFilter =
+			unit.caseNames && unit.caseNames.length > 0
+				? { extensions, tests: unit.caseNames.map((name) => `${moduleName}.${name}`) }
+				: { extensions, modules: [moduleName] };
+		// --settings активного профиля подставляет planIntent централизованно.
+		return this.plan(filter, reportDir);
+	}
 
-		// Фильтр поверх конфига проекта: модуль целиком либо выбранные тесты
+	/**
+	 * План прогона по фильтру.
+	 *
+	 * С готовым конфигом фильтр накладывается на его копию в каталоге прогона:
+	 * раннер использует готовый конфиг как есть. Без конфига, что бывает только
+	 * на vanessa-runner 3, фильтр и путь отчёта уходят опциями test yaxunit, а
+	 * остальное раннер берёт из секции vrunner.test.yaxunit профиля.
+	 *
+	 * @param filter - Отбор тестов прогона
+	 * @param reportDir - Каталог отчёта прогона
+	 * @param common - Сквозные опции команды
+	 * @returns План прогона
+	 */
+	private async plan(filter: YaxunitFilter, reportDir: string, common?: string[]): Promise<AdapterRunPlan> {
+		const workspaceRoot = this.vrunner.getWorkspaceRoot();
+		const { settings, schema } = await this.vrunner.readActiveSettings();
+		const profile = yaxunitSectionFromEnv(settings, schema);
+		const baseConfig = await this.readBaseConfig(profile, schema, workspaceRoot);
+		const runOptions = {
+			ordinaryApp: profile.ordinaryApp,
+			exitCodePath: profile.exitCodePath,
+			additional: profile.additional,
+			noWait: profile.noWait,
+		};
+		const ownReport = path.join(reportDir, 'report.xml');
+
+		if (baseConfig === undefined) {
+			const sectionReport =
+				profile.report && workspaceRoot ? resolveConfigPath(profile.report, workspaceRoot) : undefined;
+			const [args] = await this.vrunner.planIntent({
+				kind: 'test.yaxunit',
+				filter,
+				report: sectionReport ? undefined : ownReport,
+				...runOptions,
+				common,
+			});
+			return {
+				tool: 'vrunner',
+				args,
+				reportTarget: { format: 'junit', path: sectionReport ?? ownReport },
+				noReportHint: NO_REPORT_HINT,
+			};
+		}
+
 		const baseFilter =
 			baseConfig['filter'] && typeof baseConfig['filter'] === 'object'
 				? (baseConfig['filter'] as Record<string, unknown>)
 				: {};
-		const extensions = await this.extensionNames([unit]);
-		const filter = unit.caseNames && unit.caseNames.length > 0
-			? {
-				...baseFilter,
-				extensions,
-				modules: null,
-				tests: unit.caseNames.map((name) => `${moduleName}.${name}`)
-			}
-			: { ...baseFilter, extensions, modules: [moduleName], tests: null };
-
 		const reportPathRaw =
 			typeof baseConfig['reportPath'] === 'string' && baseConfig['reportPath'].length > 0
 				? baseConfig['reportPath']
-				: path.join(reportDir, 'report.xml');
-		const reportPathAbsolute = workspaceRoot
-			? resolveConfigPath(reportPathRaw, workspaceRoot)
-			: reportPathRaw;
-
+				: ownReport;
 		const runConfig: Record<string, unknown> = {
 			...baseConfig,
-			filter,
+			filter: {
+				...baseFilter,
+				extensions: filter.extensions ?? null,
+				modules: filter.modules ?? null,
+				tests: filter.tests ?? null,
+			},
 			reportPath: reportPathRaw,
 			reportFormat: baseConfig['reportFormat'] ?? 'jUnit',
-			closeAfterTests: baseConfig['closeAfterTests'] ?? true
+			closeAfterTests: baseConfig['closeAfterTests'] ?? true,
 		};
-
 		const configPath = path.join(reportDir, 'yaxunit-config.json');
 		await fs.writeFile(configPath, JSON.stringify(runConfig, null, 2), 'utf8');
 
-		const noReportHint =
-			'Для YAxUnit в информационной базе должны быть загружены: расширение-движок YAXUNIT ' +
-			'(yaxunit.cfe с https://github.com/bia-technologies/yaxunit/releases) и тестовое расширение ' +
-			'с вашими тестами. У обоих отключите «Безопасный режим» и «Защиту от опасных действий».';
-
-		// --settings активного профиля подставляет planIntent централизованно.
-		const [args] = await this.vrunner.planIntent(
-			{ kind: 'run.enterprise', command: `RunUnitTests=${configPath}` }
-		);
+		const [args] = await this.vrunner.planIntent({ kind: 'test.yaxunit', configPath, ...runOptions, common });
 		return {
 			tool: 'vrunner',
 			args,
-			reportTarget: { format: 'junit', path: reportPathAbsolute },
-			noReportHint
+			reportTarget: {
+				format: 'junit',
+				path: workspaceRoot ? resolveConfigPath(reportPathRaw, workspaceRoot) : reportPathRaw,
+			},
+			noReportHint: NO_REPORT_HINT,
 		};
 	}
 
@@ -212,24 +220,34 @@ export class YaxunitAdapter implements TestFrameworkAdapter {
 	}
 
 	/**
-	 * Читает базовый конфиг YAxUnit проекта (tools/yaxunit.json)
+	 * Готовый конфиг прогона: из секции профиля, иначе из настройки test.path.yaxunitConfig.
 	 *
-	 * @returns Содержимое конфига или пустой объект, если файла нет
+	 * На vanessa-runner 2 конфиг есть всегда: без файла база пустая, фильтр и
+	 * отчёт панель задаёт сама. На 3 файла из настройки может не быть, тогда
+	 * конфиг собирает раннер из секции профиля. Конфиг из профиля обязан читаться.
+	 *
+	 * @returns Содержимое конфига или undefined, когда готового конфига нет
 	 */
-	private async readProjectConfig(workspaceRoot: string | undefined): Promise<Record<string, unknown>> {
+	private async readBaseConfig(
+		profile: YaxunitProfileSection,
+		schema: SettingsSchema,
+		workspaceRoot: string | undefined
+	): Promise<Record<string, unknown> | undefined> {
 		if (!workspaceRoot) {
-			return {};
+			return schema === 'v3' ? undefined : {};
 		}
-
-		const config = vscode.workspace.getConfiguration('1c-platform-tools');
-		const configured = config.get<string>('test.path.yaxunitConfig', DEFAULT_TESTING.yaxunitConfigPath);
-		const configPath = resolveConfigPath(configured, workspaceRoot);
-
+		const configured = vscode.workspace
+			.getConfiguration('1c-platform-tools')
+			.get<string>('test.path.yaxunitConfig', DEFAULT_TESTING.yaxunitConfigPath);
+		const configPath = resolveConfigPath(profile.configPath ?? configured, workspaceRoot);
 		try {
 			return JSON.parse(await fs.readFile(configPath, 'utf8')) as Record<string, unknown>;
 		} catch (error) {
+			if (profile.configPath) {
+				throw new Error(`Конфиг YAxUnit из профиля не прочитан: ${configPath}. ${(error as Error).message}`);
+			}
 			log.debug(`Конфиг YAxUnit ${configPath} не прочитан: ${(error as Error).message}`);
-			return {};
+			return schema === 'v3' ? undefined : {};
 		}
 	}
 }

--- a/src/features/testing/projectTestConfig.ts
+++ b/src/features/testing/projectTestConfig.ts
@@ -6,6 +6,7 @@ const V3_SECTION_PATH: Record<string, string[]> = {
 	default: [],
 	vanessa: ['test', 'vanessa'],
 	xunit: ['test', 'xunit'],
+	yaxunit: ['test', 'yaxunit'],
 	'syntax-check': ['validate', 'syntax-check'],
 };
 
@@ -44,6 +45,77 @@ export function settingValue(
 	return typeof sectionValue === 'object' && sectionValue !== null
 		? (sectionValue as Record<string, unknown>)[`--${option}`]
 		: undefined;
+}
+
+/**
+ * Секция YAxUnit активного профиля: что расширение переносит в запуск тестов.
+ *
+ * В 2.x секцию `yaxunit` vanessa-runner не читает, её ключи те же, что у
+ * команды `run`: `--command` с `RunUnitTests=<конфиг>` задаёт готовый конфиг,
+ * остальные уходят в командную строку. В 3.x секцию `vrunner.test.yaxunit`
+ * раннер читает сам, расширению нужны только готовый конфиг и путь отчёта.
+ */
+export interface YaxunitProfileSection {
+	/** Готовый конфиг YAxUnit как записан в профиле. */
+	configPath?: string;
+	/** Путь jUnit-отчёта из секции 3.x: без готового конфига раннер пишет отчёт туда. */
+	report?: string;
+	/** Режим клиента для `vrunner run` (2.x). */
+	ordinaryApp?: string;
+	/** Файл кода возврата для `vrunner run` (2.x). */
+	exitCodePath?: string;
+	/** Дополнительные параметры запуска 1С (2.x). */
+	additional?: string;
+	/** Не ждать завершения 1С (2.x). */
+	noWait?: boolean;
+}
+
+/**
+ * Путь конфига из строки запуска `RunUnitTests=<путь>`; параметры после `;` отбрасываются.
+ *
+ * @param command - Значение `--command` секции yaxunit
+ * @returns Путь как записан в профиле или undefined, если строка не про YAxUnit
+ */
+export function yaxunitConfigPathFromCommand(command: string): string | undefined {
+	const match = /^\s*RunUnitTests\s*=\s*([^;]*)/i.exec(command);
+	const value = match?.[1].trim();
+	return value ? value : undefined;
+}
+
+/**
+ * Читает секцию YAxUnit активного профиля с учётом схемы.
+ *
+ * @param settings - Разобранное содержимое файла настроек
+ * @param schema - Схема файла настроек (2.x или 3.x)
+ * @returns Значения секции; пустой объект, если секции нет
+ */
+export function yaxunitSectionFromEnv(
+	settings: Record<string, unknown>,
+	schema: SettingsSchema = 'v2'
+): YaxunitProfileSection {
+	const text = (option: string): string | undefined => {
+		const value = settingValue(settings, schema, 'yaxunit', option);
+		if (typeof value === 'number') {
+			return String(value);
+		}
+		return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+	};
+	if (schema === 'v3') {
+		const format = text('report-format');
+		return {
+			configPath: text('yaxunit-config'),
+			// Отчёт другого формата панель не прочитает: путь остаётся раннеру
+			report: format === undefined || format.toLowerCase() === 'junit' ? text('report') : undefined,
+		};
+	}
+	const command = text('command');
+	return {
+		configPath: command ? yaxunitConfigPathFromCommand(command) : undefined,
+		ordinaryApp: text('ordinaryapp'),
+		exitCodePath: text('exitCodePath'),
+		additional: text('additional'),
+		noWait: settingValue(settings, schema, 'yaxunit', 'no-wait') === true ? true : undefined,
+	};
 }
 
 /**

--- a/src/shared/vrunnerCli/intents.ts
+++ b/src/shared/vrunnerCli/intents.ts
@@ -23,6 +23,13 @@
 /** Сквозные опции команды (аргументы, валидные в обоих CLI). */
 export type CommonArgs = readonly string[];
 
+/** Отбор тестов YAxUnit: имена расширений, модулей и полные имена тестов `Модуль.Тест`. */
+export interface YaxunitFilter {
+	extensions?: readonly string[];
+	modules?: readonly string[];
+	tests?: readonly string[];
+}
+
 /** Намерение для vanessa-runner (замкнутый union). */
 export type VRunnerIntent =
 	// ---- Информационная база ----
@@ -124,6 +131,27 @@ export type VRunnerIntent =
 	 * файлу настроек Vanessa Automation (VAParams).
 	 */
 	| { kind: 'test.vanessa'; featurePath?: string; vanessaSettings?: string; common?: CommonArgs }
+	/**
+	 * Прогнать модульные тесты YAxUnit.
+	 *
+	 * `configPath` — готовый конфиг (`RunUnitTests=`); без него vanessa-runner 3
+	 * собирает конфиг сам из опций и файла настроек, а 2.x без конфига тесты не
+	 * запускает. `filter` и `report` выражаются только без готового конфига: с
+	 * ним раннер берёт фильтр и путь отчёта из самого файла. Опции запуска
+	 * приходят из секции `yaxunit` профиля 2.x.
+	 */
+	| {
+		kind: 'test.yaxunit';
+		configPath?: string;
+		filter?: YaxunitFilter;
+		/** Путь jUnit-отчёта; раннер пишет отчёт туда, когда готового конфига нет. */
+		report?: string;
+		ordinaryApp?: string;
+		exitCodePath?: string;
+		additional?: string;
+		noWait?: boolean;
+		common?: CommonArgs;
+	}
 	/** Синтаксический контроль конфигурации. */
 	| { kind: 'validate.syntaxCheck'; common?: CommonArgs }
 

--- a/src/shared/vrunnerCli/v2Adapter.ts
+++ b/src/shared/vrunnerCli/v2Adapter.ts
@@ -175,6 +175,30 @@ export class V2CliAdapter implements VRunnerCliAdapter {
 				}
 				return [[...args, ...common(intent)]];
 			}
+			case 'test.yaxunit': {
+				// В 2.x YAxUnit запускается предприятием с готовым конфигом:
+				// фильтр и отчёт задаются в нём
+				if (intent.configPath === undefined || intent.filter !== undefined || intent.report !== undefined) {
+					throw new Error(
+						'vanessa-runner 2.x запускает YAxUnit только с готовым конфигом: ' +
+						'фильтр и путь отчёта задаются в нём.'
+					);
+				}
+				const args = ['run', '--command', `RunUnitTests=${intent.configPath}`];
+				if (intent.ordinaryApp !== undefined) {
+					args.push('--ordinaryapp', intent.ordinaryApp);
+				}
+				if (intent.exitCodePath !== undefined) {
+					args.push('--exitCodePath', intent.exitCodePath);
+				}
+				if (intent.additional !== undefined) {
+					args.push('--additional', intent.additional);
+				}
+				if (intent.noWait) {
+					args.push('--no-wait');
+				}
+				return [[...args, ...common(intent)]];
+			}
 			case 'validate.syntaxCheck':
 				return [['syntax-check', ...common(intent)]];
 

--- a/src/shared/vrunnerCli/v3Adapter.ts
+++ b/src/shared/vrunnerCli/v3Adapter.ts
@@ -236,6 +236,40 @@ export class V3CliAdapter implements VRunnerCliAdapter {
 				}
 				return [cmd(['test', 'vanessa'], [...options, ...common(intent)], [])];
 			}
+			case 'test.yaxunit': {
+				// Штатная команда 3.x: секцию vrunner.test.yaxunit раннер читает сам.
+				// Готовый конфиг он использует как есть, поэтому фильтр и отчёт
+				// передаются только без него.
+				const options: string[] = [];
+				if (intent.configPath !== undefined) {
+					options.push('--yaxunit-config', intent.configPath);
+				}
+				if (intent.filter?.extensions?.length) {
+					options.push('--ext', intent.filter.extensions.join(','));
+				}
+				if (intent.filter?.modules?.length) {
+					options.push('--modules', intent.filter.modules.join(','));
+				}
+				if (intent.filter?.tests?.length) {
+					options.push('--tests', intent.filter.tests.join(','));
+				}
+				if (intent.report !== undefined) {
+					options.push('--report', intent.report, '--report-format', 'jUnit');
+				}
+				if (intent.ordinaryApp !== undefined) {
+					options.push('--ordinaryapp', intent.ordinaryApp);
+				}
+				if (intent.exitCodePath !== undefined) {
+					options.push('--exitcode', intent.exitCodePath);
+				}
+				if (intent.additional !== undefined) {
+					options.push('--additional', intent.additional);
+				}
+				if (intent.noWait) {
+					options.push('--no-wait');
+				}
+				return [cmd(['test', 'yaxunit'], [...options, ...common(intent)], [])];
+			}
 			case 'validate.syntaxCheck':
 				return [cmd(['validate', 'syntax-check'], common(intent), [])];
 

--- a/src/test/profileEditor/optionsCatalog.test.ts
+++ b/src/test/profileEditor/optionsCatalog.test.ts
@@ -43,4 +43,30 @@ suite('profileEditor: каталог опций', () => {
 		// опции наборов доступны и на уровне команды (каскад)
 		assert.ok(cfeLoad.options.some((option) => option.key === 'ibconnection'));
 	});
+
+	test('v2: секция yaxunit с опциями run и пояснением', () => {
+		const { sections } = loadEditorSections(extensionPath, 'v2');
+		const yaxunit = sections.find((section) => section.id === 'yaxunit');
+		assert.ok(yaxunit, 'должна быть секция yaxunit');
+		assert.strictEqual(yaxunit.advertised, true);
+		assert.deepStrictEqual(yaxunit.jsonPath, ['yaxunit']);
+		assert.ok(yaxunit.hint && yaxunit.hint.length > 0, 'пояснение, кто читает секцию');
+		assert.deepStrictEqual(
+			yaxunit.options.map((option) => option.key).sort(),
+			['--additional', '--command', '--exitCodePath', '--no-wait', '--ordinaryapp']
+		);
+		const command = yaxunit.options.find((option) => option.key === '--command');
+		assert.ok(command && command.description.length > 5, 'описание из каталога 2.x');
+		assert.ok(
+			sections.findIndex((section) => section.id === 'yaxunit') < sections.findIndex((section) => section.id === 'run'),
+			'секция среди приоритетных'
+		);
+	});
+
+	test('v3: секция vrunner.test.yaxunit с опцией yaxunit-config', () => {
+		const { sections } = loadEditorSections(extensionPath, 'v3');
+		const yaxunit = sections.find((section) => section.id === 'vrunner.test.yaxunit');
+		assert.ok(yaxunit, 'должна быть секция vrunner.test.yaxunit');
+		assert.ok(yaxunit.options.some((option) => option.key === 'yaxunit-config'));
+	});
 });

--- a/src/test/serviceFiles/envSections.test.ts
+++ b/src/test/serviceFiles/envSections.test.ts
@@ -33,6 +33,16 @@ suite('serviceFiles/envSections', () => {
 		}
 	});
 
+	test('секция yaxunit есть в обоих форматах и указывает на tools/yaxunit.json', () => {
+		const env = ENV_OPTIONAL_SECTIONS.find((option) => option.id === 'yaxunit');
+		assert.ok(env, 'секция yaxunit для env.json');
+		assert.strictEqual(env.section['--command'], 'RunUnitTests=tools/yaxunit.json');
+		const result = mergeAutumnSections({ vrunner: {} }, ['yaxunit']) as {
+			vrunner: { test: { yaxunit: Record<string, unknown> } };
+		};
+		assert.strictEqual(result.vrunner.test.yaxunit['yaxunit-config'], 'tools/yaxunit.json');
+	});
+
 	suite('autumn (v3)', () => {
 		const autumnBase = { vrunner: { ibconnection: '/F./build/ib' } };
 

--- a/src/test/shared/vrunnerCliAdapters.test.ts
+++ b/src/test/shared/vrunnerCliAdapters.test.ts
@@ -275,6 +275,51 @@ suite('vrunnerCli: адаптеры v2/v3', () => {
 		);
 	});
 
+	test('test.yaxunit с готовым конфигом и опциями секции профиля', () => {
+		check(
+			{
+				kind: 'test.yaxunit',
+				configPath: 'build/out/testapi/yaxunit-config.json',
+				ordinaryApp: '-1',
+				exitCodePath: './build/out/yaxunit/result.txt',
+				additional: '/L ru',
+				noWait: true,
+				common: conn,
+			},
+			[[
+				'run', '--command', 'RunUnitTests=build/out/testapi/yaxunit-config.json',
+				'--ordinaryapp', '-1', '--exitCodePath', './build/out/yaxunit/result.txt',
+				'--additional', '/L ru', '--no-wait', ...conn,
+			]],
+			[[
+				'test', 'yaxunit', '--yaxunit-config', 'build/out/testapi/yaxunit-config.json',
+				'--ordinaryapp', '-1', '--exitcode', './build/out/yaxunit/result.txt',
+				'--additional', '/L ru', '--no-wait', ...conn,
+			]]
+		);
+	});
+
+	test('test.yaxunit без готового конфига: 3.x передаёт фильтр и отчёт опциями, 2.x отказывает', () => {
+		const intent: VRunnerIntent = {
+			kind: 'test.yaxunit',
+			filter: { extensions: ['Тесты'], modules: ['ОМ_Тест'] },
+			report: 'build/out/testapi/yaxunit/report.xml',
+			common: conn,
+		};
+		assert.deepStrictEqual(v3.plan(intent), [[
+			'test', 'yaxunit', '--ext', 'Тесты', '--modules', 'ОМ_Тест',
+			'--report', 'build/out/testapi/yaxunit/report.xml', '--report-format', 'jUnit', ...conn,
+		]]);
+		assert.throws(() => v2.plan(intent), /готовым конфигом/);
+	});
+
+	test('test.yaxunit: выбранные тесты уходят в --tests', () => {
+		assert.deepStrictEqual(
+			v3.plan({ kind: 'test.yaxunit', filter: { extensions: ['Тесты'], tests: ['ОМ_Тест.Первый', 'ОМ_Тест.Второй'] } }),
+			[['test', 'yaxunit', '--ext', 'Тесты', '--tests', 'ОМ_Тест.Первый,ОМ_Тест.Второй']]
+		);
+	});
+
 	test('run.designer с --additional', () => {
 		check(
 			{ kind: 'run.designer', additional: '/DumpConfigToFiles src/cf', common: conn },

--- a/src/test/testing/projectTestConfig.test.ts
+++ b/src/test/testing/projectTestConfig.test.ts
@@ -9,7 +9,9 @@ import {
 	vanessaSettingsPathFromEnv,
 	reportsXunitFromEnv,
 	syntaxCheckJUnitPathFromEnv,
-	syntaxCheckGroupByMetadataFromEnv
+	syntaxCheckGroupByMetadataFromEnv,
+	yaxunitSectionFromEnv,
+	yaxunitConfigPathFromCommand,
 } from '../../features/testing/projectTestConfig';
 
 // Абсолютный корень на любой ОС: path.join('C:','proj') не абсолютен под Linux,
@@ -158,6 +160,58 @@ suite('projectTestConfig', () => {
 		assert.strictEqual(syntaxCheckGroupByMetadataFromEnv(autumn, 'v3'), false);
 		// v2-читатель не находит значения в autumn-структуре
 		assert.strictEqual(reportsXunitFromEnv(autumn, 'v2'), undefined);
+	});
+
+	test('yaxunitSectionFromEnv: секция yaxunit env.json (2.x)', () => {
+		const envJson = {
+			yaxunit: {
+				'--command': 'RunUnitTests=tools/yaxunit.smoke.json',
+				'--ordinaryapp': -1,
+				'--exitCodePath': './build/out/yaxunit/result.txt',
+				'--no-wait': true
+			}
+		};
+		assert.deepStrictEqual(yaxunitSectionFromEnv(envJson), {
+			configPath: 'tools/yaxunit.smoke.json',
+			ordinaryApp: '-1',
+			exitCodePath: './build/out/yaxunit/result.txt',
+			additional: undefined,
+			noWait: true
+		});
+		assert.deepStrictEqual(yaxunitSectionFromEnv({}), {
+			configPath: undefined,
+			ordinaryApp: undefined,
+			exitCodePath: undefined,
+			additional: undefined,
+			noWait: undefined
+		});
+	});
+
+	test('yaxunitConfigPathFromCommand: путь до точки с запятой, другая команда даёт undefined', () => {
+		assert.strictEqual(yaxunitConfigPathFromCommand('RunUnitTests=tools/yaxunit.json'), 'tools/yaxunit.json');
+		assert.strictEqual(
+			yaxunitConfigPathFromCommand(' runUnitTests = ./tools/yaxunit.json ;ЗавершитьРаботуСистемы'),
+			'./tools/yaxunit.json'
+		);
+		assert.strictEqual(yaxunitConfigPathFromCommand('RunUnitTests='), undefined);
+		assert.strictEqual(yaxunitConfigPathFromCommand('Путь=МойКаталог'), undefined);
+	});
+
+	test('yaxunitSectionFromEnv: секция vrunner.test.yaxunit autumn-properties (3.x)', () => {
+		const autumn = {
+			vrunner: {
+				test: { yaxunit: { 'yaxunit-config': 'tools/yaxunit.json', report: 'build/out/yaxunit/junit.xml', ordinaryapp: '-1' } }
+			}
+		};
+		assert.deepStrictEqual(yaxunitSectionFromEnv(autumn, 'v3'), {
+			configPath: 'tools/yaxunit.json',
+			report: 'build/out/yaxunit/junit.xml'
+		});
+		// отчёт другого формата панель не прочитает: путь остаётся раннеру
+		const allure = { vrunner: { test: { yaxunit: { report: 'build/out/yaxunit/allure', 'report-format': 'allure' } } } };
+		assert.deepStrictEqual(yaxunitSectionFromEnv(allure, 'v3'), { configPath: undefined, report: undefined });
+		// v2-читатель не находит значения в autumn-структуре
+		assert.strictEqual(yaxunitSectionFromEnv(autumn, 'v2').configPath, undefined);
 	});
 
 	test('syntaxCheckJUnitPathFromEnv читает --junitpath секции syntax-check', () => {


### PR DESCRIPTION
Закрывает #407

Секция `yaxunit` в `env.json` задаёт запуск тестов YAxUnit из панели и командой «YAxUnit тесты»: `--command` с `RunUnitTests=<конфиг>` вместо настройки `test.path.yaxunitConfig`, `--ordinaryapp`, `--exitCodePath`, `--additional` и `--no-wait`. Так разные профили запускают разные конфиги. vanessa-runner 2 эту секцию не читает, в `vrunner run` её переносит расширение. Секция есть в редакторе профиля и предлагается при создании `env.json` и `autumn-properties.json`.

На vanessa-runner 3 тесты идут штатной `vrunner test yaxunit`, секцию `vrunner.test.yaxunit` раннер читает сам. Готовый конфиг берётся из `yaxunit-config` или из `test.path.yaxunitConfig`, если файл есть; раннер использует его как есть, поэтому фильтры, `report` и `exitcode` секции действуют без него. Тогда панель передаёт фильтр опциями `--ext`, `--modules`, `--tests`, а отчёт читает из `report` либо пишет в свой каталог прогона.

Вторым коммитом `*.mxl binary` в шаблоне `.gitattributes`.

По вопросам из issue:
1. `--command` секции перекрывает настройку.
2. Файл кода возврата расширение не читает, результат берётся из jUnit-отчёта; `--exitCodePath` уходит раннеру как есть.
3. В редакторе секция подписана «YAxUnit: запуск тестов», при добавлении есть пояснение, что vanessa-runner её не читает. Официальная схема `env.json` подчёркивает секцию как лишнее свойство, на работу это не влияет.
4. Пять ключей: `--command`, `--ordinaryapp`, `--exitCodePath`, `--additional`, `--no-wait`.
5. Переход на `test yaxunit` сделан здесь: по исходникам rc15 команда использует готовый конфиг как есть, остальное берёт из профиля сама.

Проверено на ssl_3_1: vanessa-runner 2.6.1 принимает `run --command RunUnitTests=tools/yaxunit.json --ordinaryapp -1 --exitCodePath ./build/out/yaxunit/result.txt` и выставляет код возврата по этому файлу; vanessa-runner 3.0.0_beta принимает `test yaxunit --yaxunit-config tools/yaxunit.json` и вариант без конфига с `--ext`, `--modules`, `--report`. До отчёта прогон локально не дошёл: в `build/ib` нет загруженной конфигурации, без изменений из PR результат тот же.

Тесты: адаптеры 2.x и 3.x, чтение секции в обеих схемах, секции при создании профиля, каталог редактора. Полный прогон зелёный.
